### PR TITLE
Support summary types in spec

### DIFF
--- a/src/Spark.Engine.Test/Extensions/HttpRequestFhirExtensionsTests.cs
+++ b/src/Spark.Engine.Test/Extensions/HttpRequestFhirExtensionsTests.cs
@@ -1,12 +1,8 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Spark.Engine.Extensions;
 using System;
-using System.Net;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net.Http;
-using System.Text;
-using System.Threading.Tasks;
+using Hl7.Fhir.Rest;
 
 namespace Spark.Engine.Test.Extensions
 {
@@ -20,6 +16,69 @@ namespace Spark.Engine.Test.Extensions
             var httpRequest = new HttpRequestMessage(HttpMethod.Get, new Uri("http://spark.furore.com/fhir/Encounter/_history?_since=2017-01-01T00%3A00%3A00%2B01%3A00", UriKind.Absolute));
             var expected = new DateTimeOffset(2017, 1, 1, 0, 0, 0, new TimeSpan(1, 0, 0));
             var actual = httpRequest.GetDateParameter("_since");
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void RequestSummary_SummaryTypeDefaultIsFalse()
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, "http://example.org/fhir/Patient");
+            var expected = SummaryType.False;
+            var actual = request.RequestSummary();
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void RequestSummary_SummaryTypeIsText()
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, "http://example.org/fhir/Patient?_summary=text");
+            var expected = SummaryType.Text;
+            var actual = request.RequestSummary();
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void RequestSummary_SummaryTypeIsData()
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, "http://example.org/fhir/Patient?_summary=data");
+            var expected = SummaryType.Data;
+            var actual = request.RequestSummary();
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void RequestSummary_SummaryTypeIsTrue()
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, "http://example.org/fhir/Patient?_summary=true");
+            var expected = SummaryType.True;
+            var actual = request.RequestSummary();
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void RequestSummary_SummaryTypeIsFalse()
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, "http://example.org/fhir/Patient?_summary=false");
+            var expected = SummaryType.False;
+            var actual = request.RequestSummary();
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void RequestSummary_SummaryTypeIsCount()
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, "http://example.org/fhir/Patient?_summary=count");
+            var expected = SummaryType.Count;
+            var actual = request.RequestSummary();
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void RequestSummary_SummaryTypeIsFalseWhen_summaryIsEmpty()
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, "http://example.org/fhir/Patient?_summary=");
+            var expected = SummaryType.False;
+            var actual = request.RequestSummary();
             Assert.AreEqual(expected, actual);
         }
     }

--- a/src/Spark.Engine/Extensions/HttpRequestFhirExtensions.cs
+++ b/src/Spark.Engine/Extensions/HttpRequestFhirExtensions.cs
@@ -15,6 +15,7 @@ using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
 using Spark.Engine.Core;
 using Hl7.Fhir.Rest;
+using Hl7.Fhir.Utility;
 
 namespace Spark.Engine.Extensions
 {
@@ -275,8 +276,14 @@ namespace Spark.Engine.Extensions
 
         public static SummaryType RequestSummary(this HttpRequestMessage request)
         {
+            SummaryType? summaryType = null;
+            string summary = request.GetParameter("_summary");
+            if (string.IsNullOrWhiteSpace(summary))
+                summaryType = SummaryType.False;
+            else
+                summaryType = EnumUtility.ParseLiteral<SummaryType>(summary, true);
 
-            return (request.GetParameter("_summary") == "true") ? SummaryType.True : SummaryType.False;
+            return summaryType.HasValue ? summaryType.Value : SummaryType.False;
         }
 
     }


### PR DESCRIPTION
* true - Return only those elements marked as "summary" in the base definition
  of the resource(s)
* text - Return only the "text" element, the 'id' element, the 'meta' element,
  and only top-level mandatory elements
* data - Remove the text element
* count - Search only: just return a count of the matching resources, without
  returning the actual matches
* false - Return all parts of the resource(s)
* Fixes #126, #127, #128