### PR TITLE
fix: Only parse search prefixes for ordered types

### DIFF
--- a/src/Spark.Engine.Test/Search/CriteriumTests.cs
+++ b/src/Spark.Engine.Test/Search/CriteriumTests.cs
@@ -62,70 +62,89 @@ namespace Spark.Search
 		[TestMethod]
 		public void ParseCriteriumDSTU2()
 		{
-			var crit = Criterium.Parse("paramX=18");
-			Assert.AreEqual("paramX", crit.ParamName);
+			var crit = Criterium.Parse("birthdate=2018-01-01");
+			Assert.AreEqual("birthdate", crit.ParamName);
 			Assert.IsNull(crit.Modifier);
-			Assert.AreEqual("18", crit.Operand.ToString());
+			Assert.AreEqual("2018-01-01", crit.Operand.ToString());
 			Assert.AreEqual(Operator.EQ, crit.Operator);
 
-			crit = Criterium.Parse("paramX=eq18");
-			Assert.AreEqual("paramX", crit.ParamName);
+			crit = Criterium.Parse("birthdate=eq2018-01-01");
+			Assert.AreEqual("birthdate", crit.ParamName);
 			Assert.IsNull(crit.Modifier);
-			Assert.AreEqual("18", crit.Operand.ToString());
+			Assert.AreEqual("2018-01-01", crit.Operand.ToString());
 			Assert.AreEqual(Operator.EQ, crit.Operator);
 
-			crit = Criterium.Parse("paramX=ne18");
-			Assert.AreEqual("paramX", crit.ParamName);
+			crit = Criterium.Parse("birthdate=ne2018-01-01");
+			Assert.AreEqual("birthdate", crit.ParamName);
 			Assert.IsNull(crit.Modifier);
-			Assert.AreEqual("18", crit.Operand.ToString());
+			Assert.AreEqual("2018-01-01", crit.Operand.ToString());
 			Assert.AreEqual(Operator.NOT_EQUAL, crit.Operator);
 
-			crit = Criterium.Parse("paramX=gt18");
-			Assert.AreEqual("paramX", crit.ParamName);
+			crit = Criterium.Parse("birthdate=gt2018-01-01");
+			Assert.AreEqual("birthdate", crit.ParamName);
 			Assert.IsNull(crit.Modifier);
-			Assert.AreEqual("18", crit.Operand.ToString());
+			Assert.AreEqual("2018-01-01", crit.Operand.ToString());
 			Assert.AreEqual(Operator.GT, crit.Operator);
 
-			crit = Criterium.Parse("paramX=ge18");
-			Assert.AreEqual("paramX", crit.ParamName);
+			crit = Criterium.Parse("birthdate=ge2018-01-01");
+			Assert.AreEqual("birthdate", crit.ParamName);
 			Assert.IsNull(crit.Modifier);
-			Assert.AreEqual("18", crit.Operand.ToString());
+			Assert.AreEqual("2018-01-01", crit.Operand.ToString());
 			Assert.AreEqual(Operator.GTE, crit.Operator);
 
-			crit = Criterium.Parse("paramX=lt18");
-			Assert.AreEqual("paramX", crit.ParamName);
+			crit = Criterium.Parse("birthdate=lt2018-01-01");
+			Assert.AreEqual("birthdate", crit.ParamName);
 			Assert.IsNull(crit.Modifier);
-			Assert.AreEqual("18", crit.Operand.ToString());
+			Assert.AreEqual("2018-01-01", crit.Operand.ToString());
 			Assert.AreEqual(Operator.LT, crit.Operator);
 
-			crit = Criterium.Parse("paramX=le18");
-			Assert.AreEqual("paramX", crit.ParamName);
+			crit = Criterium.Parse("birthdate=le2018-01-01");
+			Assert.AreEqual("birthdate", crit.ParamName);
 			Assert.IsNull(crit.Modifier);
-			Assert.AreEqual("18", crit.Operand.ToString());
+			Assert.AreEqual("2018-01-01", crit.Operand.ToString());
 			Assert.AreEqual(Operator.LTE, crit.Operator);
 
-			crit = Criterium.Parse("paramX:modif1=ap18");
-			Assert.AreEqual("paramX", crit.ParamName);
-			Assert.AreEqual("18", crit.Operand.ToString());
+			crit = Criterium.Parse("birthdate:modif1=ap2018-01-01");
+			Assert.AreEqual("birthdate", crit.ParamName);
+			Assert.AreEqual("2018-01-01", crit.Operand.ToString());
 			Assert.AreEqual("modif1", crit.Modifier);
 			Assert.AreEqual(Operator.APPROX, crit.Operator);
 
-			crit = Criterium.Parse("paramX:missing=true");
-			Assert.AreEqual("paramX", crit.ParamName);
+			crit = Criterium.Parse("birthdate:missing=true");
+			Assert.AreEqual("birthdate", crit.ParamName);
 			Assert.IsNull(crit.Operand);
 			Assert.IsNull(crit.Modifier);
 			Assert.AreEqual(Operator.ISNULL, crit.Operator);
 
-			crit = Criterium.Parse("paramX:missing=false");
-			Assert.AreEqual("paramX", crit.ParamName);
+			crit = Criterium.Parse("birthdate:missing=false");
+			Assert.AreEqual("birthdate", crit.ParamName);
 			Assert.IsNull(crit.Operand);
 			Assert.IsNull(crit.Modifier);
 			Assert.AreEqual(Operator.NOTNULL, crit.Operator);
 		}
+        
+        [TestMethod]
+        public void ParseComparatorOperatorForDate()
+        {
+            var criterium = Criterium.Parse("birthdate=lt2018-01-01");
+            Assert.AreEqual(Operator.LT, criterium.Operator);
+        }
 
+        [TestMethod]
+        public void ParseComparatorOperatorForQuantity()
+        {
+            var criterium = Criterium.Parse("value-quantity=le5.4|http://unitsofmeasure.org|mg");
+            Assert.AreEqual(Operator.LTE, criterium.Operator);
+        }
 
+        [TestMethod]
+        public void ParseComparatorOperatorForNumber()
+        {
+            var criterium = Criterium.Parse("length=gt20");
+            Assert.AreEqual(Operator.GT, criterium.Operator);
+        }
 
-		[TestMethod]
+        [TestMethod]
 		public void ParseChain()
 		{
 			var crit = Criterium.Parse("par1:type1.par2.par3:text=hoi");
@@ -412,35 +431,5 @@ namespace Spark.Search
 			Assert.AreEqual(14.8M, ((UntypedValue)comp1.Components[1]).AsNumberValue().Value);
 			Assert.AreEqual("http://somesuch.org|NOK", ((UntypedValue)crit1.Choices[1]).AsTokenValue().ToString());
 		}
-
-		//[TestMethod]
-		//public void HandleCombinedParam()
-		//{
-		//    var p1 = new CombinedParamValue(new TokenParamValue("NOK"), new IntegerParamValue(18));
-		//    Assert.AreEqual("NOK$18", p1.QueryValue);
-
-		//    var p2 = CombinedParamValue.FromQueryValue("!NOK$>=18");
-		//    Assert.AreEqual(2, p2.Values.Count());
-		//    Assert.AreEqual("NOK", ((UntypedParamValue)p2.Values.First()).AsTokenParam().Value);
-		//    Assert.AreEqual(18, ((UntypedParamValue)p2.Values.Skip(1).First()).AsIntegerParam().Value);
-		//}
-
-		//[TestMethod]
-		//public void ParseSearchParam()
-		//{
-		//    var p1 = new SearchParam("dummy", "exact", new IntegerParamValue(ComparisonOperator.LTE,18),
-		//            new CombinedParamValue( new StringParamValue("ewout"), new ReferenceParamValue("patient","1")));
-		//    Assert.AreEqual("dummy:exact=<=18,\"ewout\"$patient/1", p1.QueryPair);
-
-		//    var p2 = new SearchParam("name", isMissing:true);
-		//    Assert.AreEqual("name:missing=true", p2.QueryPair);
-
-		//    var p3 = SearchParam.FromQueryKeyAndValue("dummy:exact", "<=18,\"ewout\"$patient/1");
-		//    Assert.AreEqual("dummy", p3.Name);
-		//    Assert.AreEqual("exact", p3.Modifier);
-		//    Assert.AreEqual(2, p3.Values.Count());
-		//    Assert.AreEqual(18, ((UntypedParamValue)p3.Values.First()).AsIntegerParam().Value);
-		//    Assert.AreEqual("\"ewout\"$patient/1", ((UntypedParamValue)p3.Values.Skip(1).First()).AsCombinedParam().QueryValue);
-		//}
 	}
 }

--- a/src/Spark.Engine/Extensions/HttpConfigurationFhirExtensions.cs
+++ b/src/Spark.Engine/Extensions/HttpConfigurationFhirExtensions.cs
@@ -7,6 +7,8 @@ using Spark.Handlers;
 using Spark.Formatters;
 using Spark.Core;
 using Spark.Engine.ExceptionHandling;
+using Hl7.Fhir.Model;
+using static Hl7.Fhir.Model.ModelInfo;
 
 namespace Spark.Engine.Extensions
 {
@@ -42,14 +44,25 @@ namespace Spark.Engine.Extensions
             config.MessageHandlers.Add(new FhirMediaTypeHandler());
             config.MessageHandlers.Add(new FhirResponseHandler());
             config.MessageHandlers.Add(new FhirErrorMessageHandler());
+        }
 
+        public static void AddFhirHttpSearchParameters(this HttpConfiguration configuration)
+        {
+            SearchParameters.AddRange(new []
+            {
+                new SearchParamDefinition { Resource = "Resource", Name = "_id", Type = SearchParamType.String, Path = new string[] { "Resource.id" } }
+                , new SearchParamDefinition { Resource = "Resource", Name = "_lastUpdated", Type = SearchParamType.Date, Path = new string[] { "Resource.meta.lastUpdated" } }
+                , new SearchParamDefinition { Resource = "Resource", Name = "_tag", Type = SearchParamType.Token, Path = new string[] { "Resource.meta.tag" } }
+                , new SearchParamDefinition { Resource = "Resource", Name = "_profile", Type = SearchParamType.Uri, Path = new string[] { "Resource.meta.profile" } }
+                , new SearchParamDefinition { Resource = "Resource", Name = "_security", Type = SearchParamType.Token, Path = new string[] { "Resource.meta.security" } }
+            });
         }
 
         public static void AddFhir(this HttpConfiguration config, params string[] endpoints)
         {
-            
             config.AddFhirMessageHandlers();
             config.AddFhirExceptionHandling();
+            config.AddFhirHttpSearchParameters();
             
             // Hook custom formatters            
             config.AddFhirFormatters();

--- a/src/Spark.Engine/Extensions/SearchParamDefinitionExtensions.cs
+++ b/src/Spark.Engine/Extensions/SearchParamDefinitionExtensions.cs
@@ -1,0 +1,27 @@
+﻿using Hl7.Fhir.Model;
+using System.Collections.Generic;
+using static Hl7.Fhir.Model.ModelInfo;
+
+namespace Spark.Engine.Extensions
+{
+    internal static class SearchParamDefinitionExtensions
+    {
+        /// <summary>
+        /// Returns true if the search parameter is one of the following types: Number, Date or Quantity.
+        /// See https://www.hl7.org/fhir/stu3/search.html#prefix for more information.
+        /// </summary>
+        /// <param name="searchParamDefinitions">
+        /// A List of <see cref="SearchParamDefinition"/>, since this is an extension this is usually a reference 
+        /// to ModelInfo.SearcParameters.
+        /// </param>
+        /// <param name="name">A <see cref="string"/> representing the name of the search parameter.</param>
+        /// <returns>Returns true if the search parameter is of type Number, Date or Quanity, otherwise false.</returns>
+        internal static bool CanHaveOperatorPrefix(this List<SearchParamDefinition> searchParamDefinitions, string name)
+        {
+            SearchParamDefinition searchParamDefinition = searchParamDefinitions.Find(p => p.Name == name);
+            return searchParamDefinition != null && (searchParamDefinition.Type == SearchParamType.Number
+                || searchParamDefinition.Type == SearchParamType.Date
+                || searchParamDefinition.Type == SearchParamType.Quantity);
+        }
+    }
+}

--- a/src/Spark.Engine/Search/ValueExpressionTypes/Criterium.cs
+++ b/src/Spark.Engine/Search/ValueExpressionTypes/Criterium.cs
@@ -12,6 +12,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Hl7.Fhir.Rest;
 using Hl7.Fhir.Model;
+using Spark.Engine.Extensions;
 
 namespace Spark.Search
 {
@@ -141,13 +142,15 @@ namespace Spark.Search
             // else see if the value starts with a comparator
             else
             {
-                var compVal = findComparator(value);
-
-                type = compVal.Item1;
-                value = compVal.Item2;
+                // If this an ordered parameter type, then we accept a comparator prefix: https://www.hl7.org/fhir/stu3/search.html#prefix
+                if (ModelInfo.SearchParameters.CanHaveOperatorPrefix(name))
+                {
+                    var compVal = findComparator(value);
+                    type = compVal.Item1;
+                    value = compVal.Item2;
+                }
 
                 if (value == null) throw new FormatException("Value is empty");
-
                 // Parse the value. If there's > 1, we are using the IN operator, unless
                 // the input already specifies another comparison, which would be illegal
                 var values = ChoiceValue.Parse(value);

--- a/src/Spark.Engine/Spark.Engine.csproj
+++ b/src/Spark.Engine/Spark.Engine.csproj
@@ -121,6 +121,7 @@
     <Compile Include="Extensions\BundleExtensions.cs" />
     <Compile Include="Extensions\QuantityExtensions.cs" />
     <Compile Include="Extensions\RegexExtensions.cs" />
+    <Compile Include="Extensions\SearchParamDefinitionExtensions.cs" />
     <Compile Include="Extensions\StringExtensions.cs" />
     <Compile Include="FhirResponseFactory\FhirResponseFactory.cs" />
     <Compile Include="FhirResponseFactory\ConditionalHeaderFhirResponseInterceptor.cs" />


### PR DESCRIPTION
* Only parse search prefixes for ordered types of number, date and
  quantity
* fixes #146