### PR TITLE
Add script to remove 'Id'-fields from mongodb spark.resources

### DIFF
--- a/scripts/RemoveDuplicateId.bat
+++ b/scripts/RemoveDuplicateId.bat
@@ -1,0 +1,1 @@
+mongo spark RemoveDuplicateId.js > RemoveDuplicateId.log

--- a/scripts/RemoveDuplicateId.js
+++ b/scripts/RemoveDuplicateId.js
@@ -1,0 +1,2 @@
+print("Removing duplicate Ids");
+printjson(db.resources.update({}, {$unset: {Id:1}}, {multi: true}));


### PR DESCRIPTION
This script should resolve the issue where a mongo resource contains both an "id" and an "Id" field, causing Spark to crash when trying to serve such resources.
