### PR TITLE
Ignore os x files for file attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -220,3 +220,6 @@ _Pvt_Extensions
 #NDepend
 NDependOut/
 *.ndproj
+
+# OS X files
+.DS_Store


### PR DESCRIPTION
Since the repo is now possible to run on mac, I am adding the `.DS_Store` file to .gitignore.