### PR TITLE
Automatic deployment of documentation to github pages

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -3,7 +3,7 @@ name: Deploy documentation
 on:
   push:
     branches:
-      - develop
+      - master
 
 jobs:
   build:

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -1,0 +1,34 @@
+name: Deploy documentation
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Set Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 10.x
+
+      - name: Install npm dependencies
+        working-directory: ./docs
+        run: npm install
+
+      - name: Run tests
+        working-directory: ./docs
+        continue-on-error: false
+        run: npm run test
+
+      - name: Deploy pages
+        working-directory: ./docs
+        run: |
+          git config --global user.name "Spark documentation bot"
+          git config --global user.email "spark@docbot.com"
+          npx gatsby build --prefix-paths && npx gh-pages -d public -r https://${{ secrets.GH_TOKEN }}@github.com/FirelyTeam/spark.git


### PR DESCRIPTION
To test this: 

## Get personal access token

In GitHub Settings -> Developer -> Personal access token, create a new Personal access token with repo scope: 
![image](https://user-images.githubusercontent.com/17168367/69485965-ad869780-0e46-11ea-91a3-dbbdf6c70be3.png)


## Add repo secret 
Then add a new secret to the repo settings, with name `GH_TOKEN`

![image](https://user-images.githubusercontent.com/17168367/69485949-4b2d9700-0e46-11ea-92f7-8b3098913918.png)
