### PR TITLE
CI/CD pipeline #206 - Follow up to Docker Image CI (r4/develop)

### DIFF
--- a/.docker/docker-compose.example.yml
+++ b/.docker/docker-compose.example.yml
@@ -3,7 +3,7 @@ services:
   spark:
     container_name: spark
     restart: always
-    image: sparkfhir/spark:v1.3-r4
+    image: sparkfhir/spark:r4-latest-develop
     environment:
       - StoreSettings__ConnectionString=mongodb://root:CosmicTopSecret@mongodb:27017/spark?authSource=admin
       - SparkSettings__Endpoint=http://localhost:5555/fhir
@@ -14,7 +14,7 @@ services:
       - mongodb
   mongodb:
     container_name: mongodb
-    image: sparkfhir/mongo:v1.3-r4
+    image: sparkfhir/mongo:r4-latest-develop
     environment:
       MONGO_INITDB_ROOT_USERNAME: root
       MONGO_INITDB_ROOT_PASSWORD: CosmicTopSecret

--- a/.github/workflows/docker_image_linux.yml
+++ b/.github/workflows/docker_image_linux.yml
@@ -15,10 +15,14 @@ jobs:
         id: vars
         run: echo ::set-output name=tag::$(echo ${GITHUB_REF:10})
       - name: Build the tagged Spark Docker image
-        run: docker build . --file .docker/linux/Spark.Dockerfile --tag ${{ secrets.DOCKERHUB_USERNAME }}/spark:${{steps.vars.outputs.tag}}
+        run: docker build . --file .docker/linux/Spark.Dockerfile 
+          -t ${{ secrets.DOCKERHUB_USERNAME }}/spark:${{steps.vars.outputs.tag}}
+          -t ${{ secrets.DOCKERHUB_USERNAME }}/spark:r4-latest-develop
       - name: Push the tagged Spark Docker image
         run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/spark:${{steps.vars.outputs.tag}}
       - name: Build the tagged Mongo Docker image
-        run: docker build . --file .docker/linux/Mongo.Dockerfile --tag ${{ secrets.DOCKERHUB_USERNAME }}/mongo:${{steps.vars.outputs.tag}}
+        run: docker build . --file .docker/linux/Mongo.Dockerfile 
+          -t ${{ secrets.DOCKERHUB_USERNAME }}/mongo:${{steps.vars.outputs.tag}}
+          -t ${{ secrets.DOCKERHUB_USERNAME }}/mongo:r4-latest-develop
       - name: Push the tagged Mongo Docker image
-        run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/mongo:${{steps.vars.outputs.tag}}
+        run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/mongo


### PR DESCRIPTION
Create multiple Docker image tags at once.
This will allow to use xxx-latest images.