### PR TITLE
Some properties of StructureDefinition do not need Export.Externalize…

### DIFF
--- a/src/Spark.Engine/Service/Export.cs
+++ b/src/Spark.Engine/Service/Export.cs
@@ -11,6 +11,7 @@ using System;
 using System.Collections.Generic;
 using Spark.Core;
 using System.Xml.Linq;
+using Spark.Engine;
 using Spark.Engine.Core;
 using Spark.Engine.Extensions;
 using Spark.Engine.Auxiliary;
@@ -24,10 +25,12 @@ namespace Spark.Service
     {
         ILocalhost localhost;
         List<Entry> entries;
+        ExportSettings exportSettings;
 
-        public Export(ILocalhost localhost)
+        public Export(ILocalhost localhost, ExportSettings exportSettings)
         {
             this.localhost = localhost;
+            this.exportSettings = exportSettings;
             entries = new List<Entry>();
         }
 
@@ -148,7 +151,7 @@ namespace Spark.Service
 
             Uri uri = new Uri(uristring, UriKind.RelativeOrAbsolute);
 
-            if (!uri.IsAbsoluteUri)
+            if (!uri.IsAbsoluteUri && exportSettings.ExternalizeFhirUri)
             {
                 var absoluteUri = localhost.Absolute(uri);
                 if (absoluteUri.Fragment == uri.ToString()) //don't externalize uri's that are just anchor fragments

--- a/src/Spark.Engine/Service/FhirServiceExtensions/FhirExtensionsBuilder.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/FhirExtensionsBuilder.cs
@@ -14,11 +14,13 @@ namespace Spark.Engine.Service.FhirServiceExtensions
         private readonly IStorageBuilder fhirStoreBuilder;
         private readonly Uri baseUri;
         private readonly IList<IFhirServiceExtension> extensions;
+        private readonly SparkSettings sparkSettings;
 
-        public FhirExtensionsBuilder(IStorageBuilder fhirStoreBuilder, Uri baseUri)
+        public FhirExtensionsBuilder(IStorageBuilder fhirStoreBuilder, Uri baseUri, SparkSettings sparkSettings = null)
         {
             this.fhirStoreBuilder = fhirStoreBuilder;
             this.baseUri = baseUri;
+            this.sparkSettings = sparkSettings;
             var extensionBuilders = new Func<IFhirServiceExtension>[]
            {
                 GetSearch,
@@ -58,7 +60,7 @@ namespace Spark.Engine.Service.FhirServiceExtensions
             ISnapshotStore snapshotStore = fhirStoreBuilder.GetStore<ISnapshotStore>();
             IGenerator storeGenerator = fhirStoreBuilder.GetStore<IGenerator>();
             if (fhirStore != null)
-                return new PagingService(snapshotStore, new SnapshotPaginationProvider(fhirStore, new Transfer(storeGenerator, new Localhost(baseUri)), new Localhost(baseUri), new SnapshotPaginationCalculator()));
+                return new PagingService(snapshotStore, new SnapshotPaginationProvider(fhirStore, new Transfer(storeGenerator, new Localhost(baseUri), sparkSettings), new Localhost(baseUri), new SnapshotPaginationCalculator()));
             return null;
         }
 
@@ -67,7 +69,7 @@ namespace Spark.Engine.Service.FhirServiceExtensions
             IFhirStore fhirStore = fhirStoreBuilder.GetStore<IFhirStore>();
             IGenerator fhirGenerator = fhirStoreBuilder.GetStore<IGenerator>();
             if (fhirStore != null)
-                return new ResourceStorageService(new Transfer(fhirGenerator, new Localhost(baseUri)),  fhirStore);
+                return new ResourceStorageService(new Transfer(fhirGenerator, new Localhost(baseUri), sparkSettings),  fhirStore);
             return null;
         }
 

--- a/src/Spark.Engine/Service/Transfer.cs
+++ b/src/Spark.Engine/Service/Transfer.cs
@@ -2,6 +2,7 @@
 using Spark.Core;
 using System.Collections.Generic;
 using Hl7.Fhir.Model;
+using Spark.Engine;
 using Spark.Engine.Core;
 using Spark.Engine.Extensions;
 
@@ -16,11 +17,13 @@ namespace Spark.Service
     {
         ILocalhost localhost;
         IGenerator generator;
+        SparkSettings sparkSettings;
 
-        public Transfer(IGenerator generator, ILocalhost localhost)
+        public Transfer(IGenerator generator, ILocalhost localhost, SparkSettings sparkSettings = null)
         {
             this.generator = generator;
             this.localhost = localhost;
+            this.sparkSettings = sparkSettings;
         }
 
         public void Internalize(Entry entry)
@@ -44,14 +47,14 @@ namespace Spark.Service
 
         public void Externalize(Entry interaction)
         {
-            Export export = new Export(this.localhost);
+            Export export = new Export(this.localhost, this.sparkSettings?.ExportSettings ?? new ExportSettings());
             export.Add(interaction);
             export.Externalize();
         }
 
         public void Externalize(IEnumerable<Entry> interactions)
         {
-            Export export = new Export(this.localhost);
+            Export export = new Export(this.localhost, this.sparkSettings?.ExportSettings ?? new ExportSettings());
             export.Add(interactions);
             export.Externalize();
         }

--- a/src/Spark.Engine/SparkSettings.cs
+++ b/src/Spark.Engine/SparkSettings.cs
@@ -10,6 +10,7 @@ namespace Spark.Engine
         public Uri Endpoint { get; set; }
         public ParserSettings ParserSettings { get; set; }
         public SerializerSettings SerializerSettings { get; set; }
+        public ExportSettings ExportSettings { get; set; }
         public string FhirRelease { get; set; }
         public string Version
         {
@@ -20,5 +21,14 @@ namespace Spark.Engine
                 return string.Format("{0}.{1}", version.ProductMajorPart, version.ProductMinorPart);
             }
         }
+    }
+
+    public class ExportSettings
+    {
+        /// <summary>
+        /// Whether to externalize FHIR URIs, for example, <code>"Patient"</code> ->
+        /// <code>"https://your.fhir.url/fhir/Patient"</code> (<code>false</code> by default).
+        /// </summary>
+        public bool ExternalizeFhirUri { get; set; }
     }
 }


### PR DESCRIPTION
…References #235

This is configured via "SparkSettings:ExportSettings:ExternalizeFhirUri" config property now.
By default it's `false` which means don't expose FHIR URL in responses.