### PR TITLE
ResourceReference should not resolve to Chained parameter #35

### DIFF
--- a/src/Spark.Engine/Extensions/NetCore/IServiceCollectionExtensions.cs
+++ b/src/Spark.Engine/Extensions/NetCore/IServiceCollectionExtensions.cs
@@ -32,6 +32,9 @@ namespace Spark.Engine.Extensions
             services.TryAddSingleton<SparkSettings>(settings);
             services.TryAddTransient<ElementIndexer>();
             services.TryAddTransient<ResourceVisitor>();
+
+            services.TryAddTransient<IReferenceNormalizationService, ReferenceNormalizationService>();
+
             services.TryAddTransient<IIndexService, IndexService>();
             services.TryAddTransient<ILocalhost>((provider) => new Localhost(settings.Endpoint));
             services.TryAddTransient<IFhirModel>((provider) => new FhirModel(SparkModelInfo.SparkSearchParameters));

--- a/src/Spark.Engine/Search/ElementIndexer.cs
+++ b/src/Spark.Engine/Search/ElementIndexer.cs
@@ -18,10 +18,12 @@ namespace Spark.Engine.Search
     {
         private SparkEngineEventSource _log = SparkEngineEventSource.Log;
         private IFhirModel _fhirModel;
+        private readonly IReferenceNormalizationService _referenceNormalizationService;
 
-        public ElementIndexer(IFhirModel fhirModel)
+        public ElementIndexer(IFhirModel fhirModel, IReferenceNormalizationService referenceNormalizationService = null)
         {
             _fhirModel = fhirModel;
+            _referenceNormalizationService = referenceNormalizationService;
         }
 
         private List<Expression> ListOf(params Expression[] args)
@@ -311,7 +313,13 @@ namespace Spark.Engine.Search
             if (uri.IsAbsoluteUri)
             {
                 //This is a fully specified url, either internal or external. Don't change it.
-                value = new StringValue(uri.ToString());
+                var stringValue = new StringValue(uri.ToString());
+
+                // normalize reference value to be able to use normalized criteria for search.
+                // https://github.com/FirelyTeam/spark/issues/35 
+                value = _referenceNormalizationService != null
+                    ? _referenceNormalizationService.GetNormalizedReferenceValue(stringValue, null)
+                    : stringValue;
             }
             else if (uri.ToString().StartsWith("#"))
             {

--- a/src/Spark.Engine/Search/IReferenceNormalizationService.cs
+++ b/src/Spark.Engine/Search/IReferenceNormalizationService.cs
@@ -1,0 +1,24 @@
+﻿using Spark.Search;
+
+namespace Spark.Engine.Search
+{
+    public interface IReferenceNormalizationService
+    {
+        /// <summary>
+        /// <see cref="GetNormalizedReferenceCriteria(Criterium)"/>
+        /// </summary>
+        /// <param name="originalValue">Can be <c>null</c></param>
+        /// <param name="resourceType">Optional</param>
+        /// <returns><c>null</c> if the given <c>originalValue</c> is <c>null</c> or can't be used for search for any other reason, normalized value otherwise.</returns>
+        ValueExpression GetNormalizedReferenceValue(ValueExpression originalValue, string resourceType);
+
+        /// <summary>
+        /// Makes the following transformations on the original criteria operand:
+        /// 1. Adds modifier to the reference, if present. Example: <code>?subject:Patient=1001</code> becomes <code>?subject=Patient/1001</code>
+        /// 2. Removes local base uri from references. Example: <code>?subject=http://localhost:xyz/fhir/Patient/10014</code> is transformed to
+        /// <code>?subject=Patient/10014</code>. Note: external references are not transformed.
+        /// </summary>
+        /// <returns>Normalized criteria if <c>c</c> is valid, <c>null</c> otherwise</returns>
+        Criterium GetNormalizedReferenceCriteria(Criterium c);
+    }
+}

--- a/src/Spark.Engine/Search/ReferenceNormalizationService.cs
+++ b/src/Spark.Engine/Search/ReferenceNormalizationService.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Linq;
+using Spark.Engine.Core;
+using Spark.Search;
+
+namespace Spark.Engine.Search
+{
+    public class ReferenceNormalizationService : IReferenceNormalizationService
+    {
+        private readonly ILocalhost _localhost;
+
+        public ReferenceNormalizationService(ILocalhost localhost)
+        {
+            _localhost = localhost ?? throw new ArgumentNullException(nameof(localhost));
+        }
+
+        public ValueExpression GetNormalizedReferenceValue(ValueExpression originalValue, string resourceType)
+        {
+            if (originalValue == null)
+            {
+                return null;
+            }
+            var value = originalValue.ToString();
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return originalValue;
+            }
+            if (!value.Contains("/") && !string.IsNullOrWhiteSpace(resourceType))
+            {
+                return new StringValue($"{resourceType}/{value}");
+            }
+            if (Uri.TryCreate(value, UriKind.RelativeOrAbsolute, out var uri))
+            {
+                var key = KeyExtensions.ExtractKey(uri);
+                if (_localhost.GetKeyKind(key) != KeyKind.Foreign) // Don't normalize external references (https://github.com/FirelyTeam/spark/issues/244).
+                {
+                    var refUri = _localhost.RemoveBase(uri);
+                    return new StringValue(refUri.ToString().TrimStart('/'));
+                }
+            }
+            return originalValue;
+        }
+
+        public Criterium GetNormalizedReferenceCriteria(Criterium c)
+        {
+            if (c == null)
+            {
+                throw new ArgumentNullException(nameof(c));
+            }
+
+            Expression operand;
+
+            if (c.Operand is ChoiceValue choiceOperand)
+            {
+                var normalizedChoicesList = new ChoiceValue(
+                    choiceOperand.Choices.Select(choice =>
+                            GetNormalizedReferenceValue(choice as UntypedValue, c.Modifier))
+                        .Where(normalizedValue => normalizedValue != null)
+                        .ToList());
+
+                if (!normalizedChoicesList.Choices.Any())
+                {
+                    return null; // Choice operator without choices: ignore it.
+                }
+
+                operand = normalizedChoicesList;
+            }
+            else
+            {
+                var normalizedValue = GetNormalizedReferenceValue(c.Operand as UntypedValue, c.Modifier);
+                if (normalizedValue == null)
+                {
+                    return null;
+                }
+
+                operand = normalizedValue;
+            }
+
+            var cloned = c.Clone();
+            cloned.Modifier = null;
+            cloned.Operand = operand;
+            cloned.SearchParameters.AddRange(c.SearchParameters);
+            return cloned;
+        }
+    }
+}

--- a/src/Spark.Engine/Search/SearchSettings.cs
+++ b/src/Spark.Engine/Search/SearchSettings.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Linq;
+
+namespace Spark.Engine.Search
+{
+    public class SearchSettings
+    {
+        /// <summary>
+        /// Whether to check missing references. See https://github.com/FirelyTeam/spark/issues/35.
+        /// If ths is set to <c>true</c>, then every search that uses reference value would be first checked for
+        /// the reference state. If it's is broken (no record was found having the referenced resource type and id) then
+        /// the search will return no results.
+        ///
+        /// Note this is added for backward compatibility only. Default is not to perform any reference state checks.
+        /// </summary>
+        public bool CheckReferences { get; set; }
+
+        /// <summary>
+        /// If <see cref="CheckReferences"/> is <c>true</c>, ensure they are checked only for the resources listed in this property.
+        /// If this is <c>null</c>, then reference check will be performed for all properties.
+        /// Reference check can be enabled for the whole resource:
+        /// <code>
+        /// CheckReferencesFor = [ "ResourceName" ]
+        /// </code>
+        /// or for the particular property or multiple properties:
+        /// <code>
+        /// CheckReferencesFor = [ "ResourceName.propertyName1", "ResourceName.propertyName2" ]
+        /// </code>
+        ///
+        /// Note this is added for backward compatibility only. Default is not to perform any reference state checks.
+        /// </summary>
+        public string[] CheckReferencesFor { get; set; }
+
+        /// <param name="resourceType">Not empty string</param>
+        /// <param name="paramName">Not empty string</param>
+        public bool ShouldSkipReferenceCheck(string resourceType, string paramName)
+        {
+            if (string.IsNullOrWhiteSpace(resourceType))
+            {
+                throw new ArgumentNullException(nameof(resourceType));
+            }
+            if (string.IsNullOrWhiteSpace(paramName))
+            {
+                throw new ArgumentNullException(nameof(paramName));
+            }
+            if (!CheckReferences)
+            {
+                return true;
+            }
+            if (CheckReferencesFor == null)
+            {
+                return false;
+            }
+            return !CheckReferencesFor.Contains(resourceType) &&
+                   !CheckReferencesFor.Contains($"{resourceType}.{paramName}");
+        }
+    }
+}

--- a/src/Spark.Engine/Search/ValueExpressionTypes/Expression.cs
+++ b/src/Spark.Engine/Search/ValueExpressionTypes/Expression.cs
@@ -15,5 +15,14 @@ namespace Spark.Search
 
     public abstract class ValueExpression : Expression
     {
+        public string ToUnescapedString()
+        {
+            var value = this;
+            if (value is UntypedValue untyped)
+            {
+                value = untyped.AsStringValue();
+            }
+            return value.ToString();
+        }
     }
 }

--- a/src/Spark.Engine/SparkSettings.cs
+++ b/src/Spark.Engine/SparkSettings.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Diagnostics;
 using System.Reflection;
+using Spark.Engine.Search;
 
 namespace Spark.Engine
 {
@@ -12,6 +13,7 @@ namespace Spark.Engine
         public SerializerSettings SerializerSettings { get; set; }
         public ExportSettings ExportSettings { get; set; }
         public IndexSettings IndexSettings { get; set; }
+        public SearchSettings Search { get; set; }
         public string FhirRelease { get; set; }
         public string Version
         {

--- a/src/Spark.Mongo/Search/Infrastructure/MongoFhirIndex.cs
+++ b/src/Spark.Mongo/Search/Infrastructure/MongoFhirIndex.cs
@@ -10,7 +10,9 @@ using System.Collections.Generic;
 using System.Linq;
 using Spark.Core;
 using Hl7.Fhir.Rest;
+using Spark.Engine;
 using Spark.Engine.Core;
+using Spark.Engine.Search;
 using Spark.Search.Mongo;
 using Spark.Engine.Store.Interfaces;
 
@@ -20,12 +22,13 @@ namespace Spark.Mongo.Search.Common
     {
         private MongoSearcher _searcher;
         private IIndexStore _indexStore;
+        private SearchSettings _searchSettings;
 
-
-        public MongoFhirIndex(IIndexStore indexStore, MongoSearcher searcher)
+        public MongoFhirIndex(IIndexStore indexStore, MongoSearcher searcher, SparkSettings sparkSettings = null)
         {
             _indexStore = indexStore;
             _searcher = searcher;
+            _searchSettings = sparkSettings?.Search ?? new SearchSettings();
         }
 
         private object transaction = new object();
@@ -38,16 +41,16 @@ namespace Spark.Mongo.Search.Common
             }
         }
 
-         public SearchResults Search(string resource, SearchParams searchCommand)
+        public SearchResults Search(string resource, SearchParams searchCommand)
         {
-            return _searcher.Search(resource, searchCommand);
+            return _searcher.Search(resource, searchCommand, _searchSettings);
         }
 
         public Key FindSingle(string resource, SearchParams searchCommand)
         {
             // todo: this needs optimization
 
-            SearchResults results = _searcher.Search(resource, searchCommand);
+            SearchResults results = _searcher.Search(resource, searchCommand, _searchSettings);
             if (results.Count > 1)
             {
                 throw Error.BadRequest("The search for a single resource yielded more than one.");

--- a/src/Spark.Mongo/Search/Searcher/CriteriaMongoExtensions.cs
+++ b/src/Spark.Mongo/Search/Searcher/CriteriaMongoExtensions.cs
@@ -169,7 +169,7 @@ namespace Spark.Search.Mongo
             switch (optor)
             {
                 case Operator.EQ:
-                    var typedOperand = ((UntypedValue)operand).AsStringValue().ToString();
+                    var typedOperand = operand.ToUnescapedString();
                     switch (modifier)
                     {
                         case Modifier.EXACT:
@@ -189,7 +189,7 @@ namespace Spark.Search.Mongo
                     }
                 case Operator.IN: //We'll only handle choice like :exact
                     IEnumerable<ValueExpression> opMultiple = ((ChoiceValue)operand).Choices;
-                    return SafeIn(parameterName, new BsonArray(opMultiple.Cast<UntypedValue>().Select(sv => sv.Value)));
+                    return SafeIn(parameterName, new BsonArray(opMultiple.Select(sv => sv.ToUnescapedString())));
                 case Operator.ISNULL:
                     return Builders<BsonDocument>.Filter.Or(Builders<BsonDocument>.Filter.Exists(parameterName, false), Builders<BsonDocument>.Filter.Eq(parameterName, BsonNull.Value)); //With only Builders<BsonDocument>.Filter.NotExists, that would exclude resources that have this field with an explicit null in it.
                 case Operator.NOTNULL:

--- a/src/Spark/Settings.cs
+++ b/src/Spark/Settings.cs
@@ -140,5 +140,22 @@ namespace Spark
 
             return s;
         }
+
+        public static bool SearchCheckReferences => !string.IsNullOrWhiteSpace(ConfigurationManager.AppSettings.Get("SearchCheckReferences"));
+
+        public static string[] SearchCheckReferencesFor
+        {
+            get
+            {
+                var configValue = ConfigurationManager.AppSettings.Get("SearchCheckReferences");
+                if (string.IsNullOrWhiteSpace(configValue) ||
+                    bool.TryParse(configValue, out var checkRefs) && checkRefs)
+                {
+                    return null; // Check refs for all resources and their properties
+                }
+
+                return configValue.Split(',');
+            }
+        }
     }
 }


### PR DESCRIPTION
Alternative implementation that doesn't perform reference check when searching by references.

I made it enabled by default. It's also an option to disable it and return to the previous impl completely
or partially for the limited number of resources.

To return to the previous implementation having reference checks add this into `appsettings.json`:

```
   ...
    "SparkSettings": {
        ...
        "Search": {
            "CheckReferences": true
        }
    }
   ...
```

Or, in `Web.config`:

```
<add key="SearchCheckReferences" value="true" />
```

To partially enable reference check for the limited number of resources add this:

```
   ...
    "SparkSettings": {
        ...
        "Search": {
            "CheckReferences": true,
            "CheckReferencesFor": ["Encounter"] // Encounter is just an example
        }
    }
   ...
```

and finally to partially enable reference check on resource property level use this example:

```
   ...
    "SparkSettings": {
        ...
        "Search": {
            "CheckReferences": true,
            "CheckReferencesFor": ["Encounter.subject", "Encounter.participant"]
        }
    }
   ...
```

Here's the `Web.config` analogue:

```
<add key="SearchCheckReferences" value="Encounter.subject,Encounter.participant" />
```

NOTE: index rebuild may be required if using absolute local URLs for storing references.