### PR TITLE
Spark FHIR Integration Tests

### DIFF
--- a/.github/workflows/docker_image_linux.yml
+++ b/.github/workflows/docker_image_linux.yml
@@ -17,12 +17,12 @@ jobs:
       - name: Build the tagged Spark Docker image
         run: docker build . --file .docker/linux/Spark.Dockerfile 
           -t ${{ secrets.DOCKERHUB_ORGANIZATION }}/spark:${{steps.vars.outputs.tag}}
-          -t ${{ secrets.DOCKERHUB_ORGANIZATION }}/spark:stu3-latest-develop
+          -t ${{ secrets.DOCKERHUB_ORGANIZATION }}/spark:stu3-latest
       - name: Push the tagged Spark Docker image
         run: docker push ${{ secrets.DOCKERHUB_ORGANIZATION }}/spark
       - name: Build the tagged Mongo Docker image
         run: docker build . --file .docker/linux/Mongo.Dockerfile 
           -t ${{ secrets.DOCKERHUB_ORGANIZATION }}/mongo:${{steps.vars.outputs.tag}}
-          -t ${{ secrets.DOCKERHUB_ORGANIZATION }}/mongo:stu3-latest-develop
+          -t ${{ secrets.DOCKERHUB_ORGANIZATION }}/mongo:stu3-latest
       - name: Push the tagged Mongo Docker image
         run: docker push ${{ secrets.DOCKERHUB_ORGANIZATION }}/mongo

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1,0 +1,38 @@
+﻿name: Integration Tests
+
+on: 
+  workflow_dispatch:
+
+jobs:
+  build:  
+    runs-on: ubuntu-latest
+    steps:
+      - 
+        name: Checkout repo
+        uses: actions/checkout@v2
+      - 
+        name: Build the latest Spark Docker image
+        run: docker build . --file .docker/linux/Spark.Dockerfile
+          -t ${{ secrets.DOCKERHUB_ORGANIZATION }}/spark:stu3-latest
+      - 
+        name: Run integration tests
+        run: |
+          cd tests/integration-tests
+          mkdir -p logs html_summaries
+          docker-compose up -d spark
+          docker-compose run --rm --no-deps plan_executor ./execute_all.sh 'http://spark/fhir' stu3
+      - 
+        name: Archive logs
+        uses: actions/upload-artifact@v2
+        with:
+          name: logs-stu3-${{ github.sha }}
+          path: tests/integration-tests/logs/*.log*
+      - 
+        name: Archive test reports
+        uses: actions/upload-artifact@v2
+        with:
+          name: html_summaries-stu3-${{ github.sha }}
+          path: tests/integration-tests/html_summaries/**/*.html
+      - 
+        name: Cleanup
+        run: cd tests/integration-tests && docker-compose down

--- a/tests/integration-tests/docker-compose.yml
+++ b/tests/integration-tests/docker-compose.yml
@@ -1,0 +1,27 @@
+﻿version: "3"
+services:
+  spark:
+    container_name: spark
+    restart: always
+    image: sparkfhir/spark:stu3-latest
+    environment:
+      - StoreSettings__ConnectionString=mongodb://root:secret@mongodb:27017/spark?authSource=admin
+      - SparkSettings__Endpoint=http://spark/fhir
+    depends_on:
+      - mongodb
+  mongodb:
+    container_name: mongodb
+    image: sparkfhir/mongo:stu3-latest-develop
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: secret
+    ports:
+      - "17017:27017"
+  plan_executor:
+    container_name: plan_executor
+    image: incendi/plan_executor:latest
+    depends_on:
+      - spark
+    volumes:
+      - ./logs:/app/logs:rw
+      - ./html_summaries:/app/html_summaries:rw

--- a/tests/integration-tests/readme.md
+++ b/tests/integration-tests/readme.md
@@ -1,0 +1,40 @@
+﻿# Spark FHIR Integration Tests
+
+## Setup
+
+1. Build the latest Spark Docker image.
+2. Run Spark service:
+
+```
+mkdir -p logs html_summaries
+docker-compose up -d spark
+```
+
+## Running integration tests
+
+### Listing all available tests
+
+```
+docker-compose run --rm --no-deps plan_executor ./list_all.sh stu3
+```
+
+### Running particular test
+
+```
+docker-compose run --rm --no-deps plan_executor ./execute_test.sh http://spark.url/fhir stu3 FormatTest
+```
+
+### Running all tests
+
+```
+docker-compose run --rm --no-deps plan_executor ./execute_all.sh http://spark.url/fhir stu3
+```
+
+## Test results
+
+Test results are stored in HTML format in `html_summaries` directory. 
+Each test result is stored in a separate subdir.
+
+## Test logs
+
+Test logs can be found in `logs` directory.


### PR DESCRIPTION
Test run is triggered manually using GitHub -> Actions -> Run workflow.

For the test scenarios we use special fork of crucible/plan_executor repo.
The forked repo contains some fixes and hosts Dockerfile for the tool, so it could be used via docker-compose.

https://github.com/incendilabs/plan_executor

Here we just run it using GitHub action and store the produced artifacts like logs, and HTML summary reports.

NOTE: some tests are failing because of bugs, unimplemented features and so on.
It's assumed that we create issues for them and link them to test results, so it's possible to track the improvements progress.

fixes #225
fixes #226