### PR TITLE
Fixing DSTU2 integration tests

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -15,6 +15,10 @@ jobs:
         run: docker build . --file .docker/linux/Spark.Dockerfile
           -t ${{ secrets.DOCKERHUB_ORGANIZATION }}/spark:dstu2-latest
       - 
+        name: Build the latest Mongo Docker image
+        run: docker build . --file .docker/linux/Mongo.Dockerfile
+          -t ${{ secrets.DOCKERHUB_ORGANIZATION }}/mongo:dstu2-latest
+      - 
         name: Run integration tests
         run: |
           cd tests/integration-tests

--- a/src/Spark.Engine/Extensions/HttpHeadersExtensions.cs
+++ b/src/Spark.Engine/Extensions/HttpHeadersExtensions.cs
@@ -85,7 +85,7 @@ namespace Spark.Engine.Extensions
                 list.Add(new Tuple<string, string>(parameter.Key, parameter.Value));
             }
 
-            return SearchParams.FromUriParamList(list);
+            return request.GetSearchParams().AddAll(list);
         }
 
         public static SearchParams GetSearchParams(this HttpRequest request)
@@ -107,7 +107,7 @@ namespace Spark.Engine.Extensions
                 list.Add(new Tuple<string, string>(p[0], Uri.UnescapeDataString(p[1])));
             }
 
-            return SearchParams.FromUriParamList(list);
+            return request.GetSearchParams().AddAll(list);
         }
 
         public static SearchParams GetSearchParams(this HttpRequestMessage request)

--- a/src/Spark.Engine/Extensions/HttpRequestFhirExtensions.cs
+++ b/src/Spark.Engine/Extensions/HttpRequestFhirExtensions.cs
@@ -142,6 +142,7 @@ namespace Spark.Engine.Extensions
             var ub = new UriBuilder(request.GetRequestUri());
             // TODO: KM: Path matching is not optimal should be replaced by a more solid solution.
             return ub.Path.Contains("Binary")
+                && !ub.Path.EndsWith("_search")
                 && !HttpRequestExtensions.IsContentTypeHeaderFhirMediaType(request.ContentType)
                 && (request.Method == "POST" || request.Method == "PUT");
         }
@@ -370,7 +371,8 @@ namespace Spark.Engine.Extensions
         {
             var ub = new UriBuilder(request.RequestUri);
             // TODO: KM: Path matching is not optimal should be replaced by a more solid solution.
-            return ub.Path.Contains("Binary") 
+            return ub.Path.Contains("Binary")
+                && !ub.Path.EndsWith("_search")
                 && !request.Content.IsContentTypeHeaderFhirMediaType()
                 && (request.Method == HttpMethod.Post || request.Method == HttpMethod.Put);
         }

--- a/src/Spark.Engine/Extensions/SearchParameterExtensions.cs
+++ b/src/Spark.Engine/Extensions/SearchParameterExtensions.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using Hl7.Fhir.Rest;
 
 namespace Spark.Engine.Extensions
 {
@@ -71,6 +72,15 @@ namespace Spark.Engine.Extensions
         public static void SetOriginalDefinition(this SearchParameter searchParameter, ModelInfo.SearchParamDefinition definition)
         {
             searchParameter.AddAnnotation(definition);
+        }
+
+        public static SearchParams AddAll(this SearchParams self, List<Tuple<string, string>> @params)
+        {
+            foreach (var (item1, item2) in @params)
+            {
+                self.Add(item1, item2);
+            }
+            return self;
         }
     }
 }

--- a/src/Spark.Mongo/Search/Searcher/CriteriaMongoExtensions.cs
+++ b/src/Spark.Mongo/Search/Searcher/CriteriaMongoExtensions.cs
@@ -97,7 +97,13 @@ namespace Spark.Search.Mongo
             {
                 string parameterName = parameter.Name;
                 if (parameterName == "_id")
+                {
                     parameterName = "fhir_id"; //See MongoIndexMapper for counterpart.
+
+                    // This search finds the patient resource with the given id (there can only be one resource for a given id).
+                    // Functionally, this is equivalent to a simple read operation
+                    modifier = Modifier.EXACT;
+                }
 
                 var valueOperand = (ValueExpression)operand;
                 switch (parameter.Type)

--- a/tests/integration-tests/docker-compose.yml
+++ b/tests/integration-tests/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - mongodb
   mongodb:
     container_name: mongodb
-    image: sparkfhir/mongo:dstu2-latest-develop
+    image: sparkfhir/mongo:dstu2-latest
     environment:
       MONGO_INITDB_ROOT_USERNAME: root
       MONGO_INITDB_ROOT_PASSWORD: secret


### PR DESCRIPTION
## Results

```
PASS: 2096
FAIL: 11
SKIP: 345
ERROR: 1
```

## Fixes

### Add support of _count, _sort and other special params passed via query in _search

Before, it was only using POSTed data.

### DSTU2 archive cleaned up & search index rebuilt.

Unsupported properties removed:

 - AllergyIntolerance.clinicalStatus
 - Binary.clinicalStatus
 - Condition.clinicalStatus
 - DiagnosticReport.clinicalStatus
 - DocumentReference.clinicalStatus
 - MedicationStatement.clinicalStatus
 - Observation.derivedFrom

Commands executed:

```
db.resources.update(
   { resourceType: {$in:["AllergyIntolerance", "Binary", "Condition", "DiagnosticReport", "DocumentReference", "MedicationStatement"]} },
   { $unset: { clinicalStatus: "" } },false,true
);

db.resources.update(
   { resourceType: {$in:["Observation"]} },
   { $unset: { derivedFrom: "" } },false,true
)
```

Patient id counter restarted from 1000.
Previously it was 3 which caused some tests to fail.

```
db.counters.update(
   { _id: "Patient" },
   { "last": NumberInt(1000) }
);
```

### Fix issue with searching Binary by using POST /Binary/_search

It was assuming that the binary contents is requested instead of searching for it.

### Fix in seach using `_id` param.

Spec says:

The search parameter `_id` refers to the logical id of the resource, and can be used when the search context specifies a resource type:

```
GET [base]/Patient?_id=23
```

This search finds the patient resource with the given id (there can only be one resource for a given id). Functionally, this is equivalent to a simple read operation:

```
GET [base]/Patient/23
```

However it was using partial match by default which was translated to this regexp:

`/^23/i`

which produced multiple results.

Changed to exact match (always).

## Tests skipped

1. All validation tests (`X060`, `X065` and `X067`). `$validate` is not yet implemented.
2. Some "Argonaut" tests relaying on some data presense and security enabled on server. Argonaut tests are for DSTU2 only.

## Tests failing (still)

### TransactionBatchTest

1. `XFER5` (Fetch patient record and then present the unaltered record as an update transaction)

Reason: server doesn't return entry id if updating something with bundle PUT interaction but without any changes.
Solution: return entry id?

2. `XFER4` (Transaction Processing Order of Operations), `XFER11` (Create Patient Record and then Batch create and search Observations)

Reason: server currently doesn't support GET Batch interaction 
Solution: implement GET interactions?

3. `XFER10` (Invalid Batch with Interdependencies)

Reason: server doesn't perform resource interdependence check.

### Search001

1. `SE07P`, `SE07G` (Search patient and _revinclude)

Reason: search `_revinclude` is not supported.
Solution: implement `_revinclude` search param?

2. `SE21P`, `SE21G` (Search for quantity (in observation) - precision tests)

Reason: Search by quantity with units is not working.
Solution: fix it

More details:

http://hl7.org/fhir/DSTU2/search.html#quantity

```
> db.resources.find({resourceType: "Observation", "id":"80"}, {"valueQuantity":1});
{ "_id" : "Observation/80/_history/1", "valueQuantity" : { "value" : 2, "unit" : "mmol", "system" : "http://unitsofmeasure.org" } }
```

```
> db.searchindex.find({"internal_id" : "Observation/80"}, {"value-quantity":1, "internal_justid":1})
{ "_id" : ObjectId("5f9d5bde896f3f0b43f23d8b"), "internal_justid" : "80", "value-quantity" : { "system" : "http://unitsofmeasure.org", "value" : 2, "decimals" : "E00x2.0", "unit" : "" } }
```

`{{baseUrl}}/fhir/Observation?value-quantity=2.0||mmol`

```
{
                "find" : "searchindex",
                "filter" : {
                        "internal_level" : 0,
                        "internal_resource" : "Observation",
                        "$or" : [
                                {
                                        "value-quantity" : {
                                                "$elemMatch" : {
                                                        "decimals" : /^E21x1.2/,
                                                        "unit" : ""
                                                }
                                        }
                                },
                                {
                                        "value-quantity" : {
                                                "$not" : {
                                                        "$type" : 4
                                                }
                                        },
                                        "value-quantity.decimals" : /^E21x1.2/,
                                        "value-quantity.unit" : ""
                                }
                        ]
                },
                "projection" : {
                        "internal_selflink" : 1
                },
                "$db" : "spark",
                "lsid" : {
                        "id" : UUID("3bcf5075-2e89-4ccd-80ea-37667866dcd3")
                }
        }
```

```
db.searchindex.count({
                        "internal_level" : 0,
                        "internal_resource" : "Observation",
                        "$or" : [
                                {
                                        "value-quantity" : {
                                                "$elemMatch" : {
                                                        "decimals" : /^E21x1.2/,
                                                        "unit" : ""
                                                }
                                        }
                                },
                                {
                                        "value-quantity" : {
                                                "$not" : {
                                                        "$type" : 4
                                                }
                                        },
                                        "value-quantity.decimals" : /^E21x1.2/,
                                        "value-quantity.unit" : ""
                                }
                        ]
                });
0
```

3. `SE22P`, `SE22G` (Search for quantity (in observation) - operators)

Reason: may be related to 2.?

4. `SE25P`, `SE25G` (Search with malformed parameters)

Reason: passing malformed parameter produces 400 result.
Solution: fix it so it returns 200 + some operation outcome, like warning, as it's done in https://vonk.fire.ly/

## TODO

1. Implement validation, enable tests `X060`, `X065` and `X067`
2. Fix all the bugs? Reach 100% test passed?
3. Make the same for STU3 and R4 tests.