### PR TITLE
 Integration test fixes (STU3)

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -15,6 +15,10 @@ jobs:
         run: docker build . --file .docker/linux/Spark.Dockerfile
           -t ${{ secrets.DOCKERHUB_ORGANIZATION }}/spark:stu3-latest
       - 
+        name: Build the latest Mongo Docker image
+        run: docker build . --file .docker/linux/Mongo.Dockerfile
+          -t ${{ secrets.DOCKERHUB_ORGANIZATION }}/mongo:stu3-latest
+      - 
         name: Run integration tests
         run: |
           cd tests/integration-tests

--- a/src/Spark.Engine/Extensions/HttpHeadersExtensions.cs
+++ b/src/Spark.Engine/Extensions/HttpHeadersExtensions.cs
@@ -85,7 +85,7 @@ namespace Spark.Engine.Extensions
                 list.Add(new Tuple<string, string>(parameter.Key, parameter.Value));
             }
 
-            return SearchParams.FromUriParamList(list);
+            return request.GetSearchParams().AddAll(list);
         }
 
         public static SearchParams GetSearchParams(this HttpRequest request)
@@ -107,7 +107,7 @@ namespace Spark.Engine.Extensions
                 list.Add(new Tuple<string, string>(p[0], Uri.UnescapeDataString(p[1])));
             }
 
-            return SearchParams.FromUriParamList(list);
+            return request.GetSearchParams().AddAll(list);
         }
 
         public static SearchParams GetSearchParams(this HttpRequestMessage request)

--- a/src/Spark.Engine/Extensions/HttpRequestFhirExtensions.cs
+++ b/src/Spark.Engine/Extensions/HttpRequestFhirExtensions.cs
@@ -142,6 +142,7 @@ namespace Spark.Engine.Extensions
             var ub = new UriBuilder(request.GetRequestUri());
             // TODO: KM: Path matching is not optimal should be replaced by a more solid solution.
             return ub.Path.Contains("Binary")
+                && !ub.Path.EndsWith("_search")
                 && !HttpRequestExtensions.IsContentTypeHeaderFhirMediaType(request.ContentType)
                 && (request.Method == "POST" || request.Method == "PUT");
         }
@@ -370,7 +371,8 @@ namespace Spark.Engine.Extensions
         {
             var ub = new UriBuilder(request.RequestUri);
             // TODO: KM: Path matching is not optimal should be replaced by a more solid solution.
-            return ub.Path.Contains("Binary") 
+            return ub.Path.Contains("Binary")
+                && !ub.Path.EndsWith("_search")
                 && !request.Content.IsContentTypeHeaderFhirMediaType()
                 && (request.Method == HttpMethod.Post || request.Method == HttpMethod.Put);
         }

--- a/src/Spark.Engine/Extensions/KeyExtensions.cs
+++ b/src/Spark.Engine/Extensions/KeyExtensions.cs
@@ -93,6 +93,35 @@ namespace Spark.Engine.Core
             return !string.IsNullOrEmpty(self.ResourceId);
         }
 
+        public static IKey WithoutResourceId(this IKey self)
+        {
+            var key = self.Clone();
+            key.ResourceId = null;
+            return key;
+        }
+
+        /// <summary>
+        /// If an id is provided, the server SHALL ignore it.
+        /// If the request body includes a meta, the server SHALL ignore
+        /// the existing versionId and lastUpdated values.
+        /// http://hl7.org/fhir/STU3/http.html#create
+        /// http://hl7.org/fhir/R4/http.html#create
+        /// </summary>
+        public static IKey CleanupForCreate(this IKey key)
+        {
+            if (key.HasResourceId())
+            {
+                key = key.WithoutResourceId();
+            }
+
+            if (key.HasVersionId())
+            {
+                key = key.WithoutVersion();
+            }
+
+            return key;
+        }
+
         public static IEnumerable<string> GetSegments(this IKey key)
         {
             if (key.Base != null) yield return key.Base;

--- a/src/Spark.Engine/Extensions/SearchParameterExtensions.cs
+++ b/src/Spark.Engine/Extensions/SearchParameterExtensions.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using Hl7.Fhir.Rest;
 
 namespace Spark.Engine.Extensions
 {
@@ -73,6 +74,15 @@ namespace Spark.Engine.Extensions
         public static void SetOriginalDefinition(this SearchParameter searchParameter, ModelInfo.SearchParamDefinition definition)
         {
             searchParameter.AddAnnotation(definition);
+        }
+
+        public static SearchParams AddAll(this SearchParams self, List<Tuple<string, string>> @params)
+        {
+            foreach (var (item1, item2) in @params)
+            {
+                self.Add(item1, item2);
+            }
+            return self;
         }
     }
 }

--- a/src/Spark.Engine/Service/FhirService.cs
+++ b/src/Spark.Engine/Service/FhirService.cs
@@ -84,12 +84,8 @@ namespace Spark.Engine.Service
             Validate.HasTypeName(key);
             Validate.ResourceType(key, resource);
 
-            Validate.HasNoResourceId(key);
-            Validate.HasNoVersion(key);
-
-
-            Entry result = Store(Entry.POST(key, resource));
-
+            key = key.CleanupForCreate();
+            var result = Store(Entry.POST(key, resource));
             return Respond.WithResource(HttpStatusCode.Created, result);
         }
 

--- a/src/Spark.Mongo/Search/Searcher/CriteriaMongoExtensions.cs
+++ b/src/Spark.Mongo/Search/Searcher/CriteriaMongoExtensions.cs
@@ -97,7 +97,13 @@ namespace Spark.Search.Mongo
             {
                 string parameterName = parameter.Name;
                 if (parameterName == "_id")
+                {
                     parameterName = "fhir_id"; //See MongoIndexMapper for counterpart.
+
+                    // This search finds the patient resource with the given id (there can only be one resource for a given id).
+                    // Functionally, this is equivalent to a simple read operation
+                    modifier = Modifier.EXACT;
+                }
 
                 var valueOperand = (ValueExpression)operand;
                 switch (parameter.Type)

--- a/tests/integration-tests/docker-compose.yml
+++ b/tests/integration-tests/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - mongodb
   mongodb:
     container_name: mongodb
-    image: sparkfhir/mongo:stu3-latest-develop
+    image: sparkfhir/mongo:stu3-latest
     environment:
       MONGO_INITDB_ROOT_USERNAME: root
       MONGO_INITDB_ROOT_PASSWORD: secret


### PR DESCRIPTION
### Support of _count, _sort and other special params passed via query in _search

Before, it was only using POSTed data.

This fixes some integration tests.

### Fix issue with searching Binary by using POST /Binary/_search

It was assuming that the binary contents is requested instead of searching for it.

### Fix in seach using `_id` param.

Spec says:

The search parameter `_id` refers to the logical id of the resource, and can be used when the search context specifies a resource type:

```
GET [base]/Patient?_id=23
```

This search finds the patient resource with the given id (there can only be one resource for a given id). Functionally, this is equivalent to a simple read operation:

```
GET [base]/Patient/23
```

However it was using partial match by default which was translated to this regexp:

`/^23/i`

which produced multiple results.

Changed to exact match (always).

### STU3 archive updated.

Patient id counter restarted from 1000.
Previously it was 3 which caused some tests to fail.

Command executed:

```
db.counters.update(
   { _id: "Patient" },
   { "last": NumberInt(1000) }
);
```

### Use the latest Mongo Docker image when running integration tests.

### Fix in Create operation (ignore id, version).

As it's stated in STU3 and R4 spec:

> If an id is provided, the server SHALL ignore it.
> If the request body includes a meta, the server SHALL ignore the existing versionId and lastUpdated values.

http://hl7.org/fhir/STU3/http.html#create
http://hl7.org/fhir/R4/http.html#create

### Search by reference - exact search + type specification.

Before it was

`/fhir/CarePlan?patient=1058`

producing wildcard regexp query like

```
{
    "internal_level" : 0,
    "internal_resource" : "CarePlan",
    "patient" : /^1058/i
}
```

now it's replaced with

```
{
    "internal_level" : 0,
    "internal_resource" : "CarePlan",
    "patient" : /^(Patient|Group)/1058$/
}
```

Also, EXACT modifier is applied to reference search.