### PR TITLE
Get rid of annoying GitHub warning annotation

### DIFF
--- a/.github/workflows/docker_image_linux.yml
+++ b/.github/workflows/docker_image_linux.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
       - name: Login to DockerHub Registry

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:  
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - 
         name: Checkout repo


### PR DESCRIPTION
Check warning

GitHub Actions
/ Integration Tests
.github#L1
Ubuntu-latest workflows will use Ubuntu-20.04 soon. For more details, see https://github.com/actions/virtual-environments/issues/1816