### PR TITLE
Fixing R4 integration tests

### DIFF
--- a/.github/workflows/docker_image_linux.yml
+++ b/.github/workflows/docker_image_linux.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
       - name: Login to DockerHub Registry

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -26,9 +26,20 @@ jobs:
         name: Run integration tests
         run: |
           cd tests/integration-tests
-          mkdir -p logs html_summaries
+          mkdir -p logs html_summaries json_results
           docker-compose up -d spark
-          docker-compose run --rm --no-deps plan_executor ./execute_all.sh 'http://spark/fhir' r4
+          docker-compose run --rm --no-deps plan_executor ./execute_all.sh 'http://spark/fhir' r4 'html|json'
+      - 
+        name: Combine test results
+        if: ${{ always() }}
+        run: cd tests/integration-tests && ./combine-test-results.sh json_results annotations.json
+      - 
+        name: Attach test results
+        if: ${{ always() }}
+        uses: yuzutech/annotations-action@v0.1.0
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          input: tests/integration-tests/annotations.json
       - 
         name: Archive logs
         if: ${{ always() }}
@@ -43,6 +54,20 @@ jobs:
         with:
           name: html_summaries-r4-${{ github.sha }}
           path: tests/integration-tests/html_summaries/**/*.html
+      - 
+        name: Archive JSON results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: json_results-r4-${{ github.sha }}
+          path: tests/integration-tests/json_results/**/*.json
+      - 
+        name: Archive annotations file
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: annotations-r4-${{ github.sha }}
+          path: tests/integration-tests/annotations.json
       - 
         name: Cleanup
         if: ${{ always() }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -33,13 +33,13 @@ jobs:
         name: Combine test results
         if: ${{ always() }}
         run: cd tests/integration-tests && ./combine-test-results.sh json_results annotations.json
-      - 
-        name: Attach test results
-        if: ${{ always() }}
-        uses: yuzutech/annotations-action@v0.1.0
-        with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
-          input: tests/integration-tests/annotations.json
+#      - 
+#        name: Attach test results
+#        if: ${{ always() }}
+#        uses: yuzutech/annotations-action@v0.1.0
+#        with:
+#          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+#          input: tests/integration-tests/annotations.json
       - 
         name: Archive logs
         if: ${{ always() }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -23,16 +23,19 @@ jobs:
           docker-compose run --rm --no-deps plan_executor ./execute_all.sh 'http://spark/fhir' r4
       - 
         name: Archive logs
+        if: ${{ always() }}
         uses: actions/upload-artifact@v2
         with:
           name: logs-r4-${{ github.sha }}
           path: tests/integration-tests/logs/*.log*
       - 
         name: Archive test reports
+        if: ${{ always() }}
         uses: actions/upload-artifact@v2
         with:
           name: html_summaries-r4-${{ github.sha }}
           path: tests/integration-tests/html_summaries/**/*.html
       - 
         name: Cleanup
+        if: ${{ always() }}
         run: cd tests/integration-tests && docker-compose down

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build:  
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       -
         name: Checkout repo

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -28,7 +28,7 @@ jobs:
           cd tests/integration-tests
           mkdir -p logs html_summaries json_results
           docker-compose up -d spark
-          docker-compose run --rm --no-deps plan_executor ./execute_all.sh 'http://spark/fhir' r4 'html|json'
+          docker-compose run --rm --no-deps plan_executor ./execute_all.sh 'http://spark/fhir' r4 'html|json|stdout'
       - 
         name: Combine test results
         if: ${{ always() }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1,7 +1,11 @@
 ﻿name: Integration Tests
 
-on: 
+on:
   workflow_dispatch:
+  push:
+    branches:
+      - 'r4/master'
+  pull_request:
 
 jobs:
   build:  
@@ -13,7 +17,11 @@ jobs:
       - 
         name: Build the latest Spark Docker image
         run: docker build . --file .docker/linux/Spark.Dockerfile
-          -t ${{ secrets.DOCKERHUB_ORGANIZATION }}/spark:r4-latest
+          -t sparkfhir/spark:r4-latest
+      - 
+        name: Build the latest Mongo Docker image
+        run: docker build . --file .docker/linux/Mongo.Dockerfile
+          -t sparkfhir/mongo:r4-latest
       - 
         name: Run integration tests
         run: |

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -3,18 +3,8 @@
 on:
   push:
     branches:
-      - '*'
-    tags-ignore:
-      - '*'
-    paths:
-      - 'src/**'
+      - 'r4/master'
   pull_request:
-    branches:
-      - '*'
-    tags-ignore:
-      - '*'
-    paths:
-      - 'src/**'
 
 jobs:
   build:

--- a/src/Spark.Engine/Extensions/HttpHeadersExtensions.cs
+++ b/src/Spark.Engine/Extensions/HttpHeadersExtensions.cs
@@ -85,7 +85,7 @@ namespace Spark.Engine.Extensions
                 list.Add(new Tuple<string, string>(parameter.Key, parameter.Value));
             }
 
-            return SearchParams.FromUriParamList(list);
+            return request.GetSearchParams().AddAll(list);
         }
 
         public static SearchParams GetSearchParams(this HttpRequest request)
@@ -107,7 +107,7 @@ namespace Spark.Engine.Extensions
                 list.Add(new Tuple<string, string>(p[0], Uri.UnescapeDataString(p[1])));
             }
 
-            return SearchParams.FromUriParamList(list);
+            return request.GetSearchParams().AddAll(list);
         }
 
         public static SearchParams GetSearchParams(this HttpRequestMessage request)

--- a/src/Spark.Engine/Extensions/HttpRequestFhirExtensions.cs
+++ b/src/Spark.Engine/Extensions/HttpRequestFhirExtensions.cs
@@ -142,6 +142,7 @@ namespace Spark.Engine.Extensions
             var ub = new UriBuilder(request.GetRequestUri());
             // TODO: KM: Path matching is not optimal should be replaced by a more solid solution.
             return ub.Path.Contains("Binary")
+                && !ub.Path.EndsWith("_search")
                 && !HttpRequestExtensions.IsContentTypeHeaderFhirMediaType(request.ContentType)
                 && (request.Method == "POST" || request.Method == "PUT");
         }
@@ -370,7 +371,8 @@ namespace Spark.Engine.Extensions
         {
             var ub = new UriBuilder(request.RequestUri);
             // TODO: KM: Path matching is not optimal should be replaced by a more solid solution.
-            return ub.Path.Contains("Binary") 
+            return ub.Path.Contains("Binary")
+                && !ub.Path.EndsWith("_search")
                 && !request.Content.IsContentTypeHeaderFhirMediaType()
                 && (request.Method == HttpMethod.Post || request.Method == HttpMethod.Put);
         }

--- a/src/Spark.Engine/Extensions/KeyExtensions.cs
+++ b/src/Spark.Engine/Extensions/KeyExtensions.cs
@@ -93,6 +93,35 @@ namespace Spark.Engine.Core
             return !string.IsNullOrEmpty(self.ResourceId);
         }
 
+        public static IKey WithoutResourceId(this IKey self)
+        {
+            var key = self.Clone();
+            key.ResourceId = null;
+            return key;
+        }
+
+        /// <summary>
+        /// If an id is provided, the server SHALL ignore it.
+        /// If the request body includes a meta, the server SHALL ignore
+        /// the existing versionId and lastUpdated values.
+        /// http://hl7.org/fhir/STU3/http.html#create
+        /// http://hl7.org/fhir/R4/http.html#create
+        /// </summary>
+        public static IKey CleanupForCreate(this IKey key)
+        {
+            if (key.HasResourceId())
+            {
+                key = key.WithoutResourceId();
+            }
+
+            if (key.HasVersionId())
+            {
+                key = key.WithoutVersion();
+            }
+
+            return key;
+        }
+
         public static IEnumerable<string> GetSegments(this IKey key)
         {
             if (key.Base != null) yield return key.Base;

--- a/src/Spark.Engine/Extensions/SearchParameterExtensions.cs
+++ b/src/Spark.Engine/Extensions/SearchParameterExtensions.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using Hl7.Fhir.Rest;
 
 namespace Spark.Engine.Extensions
 {
@@ -73,6 +74,15 @@ namespace Spark.Engine.Extensions
         public static void SetOriginalDefinition(this SearchParameter searchParameter, ModelInfo.SearchParamDefinition definition)
         {
             searchParameter.AddAnnotation(definition);
+        }
+
+        public static SearchParams AddAll(this SearchParams self, List<Tuple<string, string>> @params)
+        {
+            foreach (var (item1, item2) in @params)
+            {
+                self.Add(item1, item2);
+            }
+            return self;
         }
     }
 }

--- a/src/Spark.Engine/Formatters/HtmlFhirFormatter.cs
+++ b/src/Spark.Engine/Formatters/HtmlFhirFormatter.cs
@@ -161,7 +161,7 @@ namespace Spark.Formatters
                 else
                 {
                     DomainResource resource = (DomainResource)value;
-                    string org = resource.ResourceBase + "/" + resource.ResourceType.ToString() + "/" + resource.Id;
+                    string org = resource.ResourceBase + "/" + resource.TypeName + "/" + resource.Id;
                     writer.WriteLine(string.Format("Retrieved: {0}<hr/>", org));
 
                     string text = (resource.Text != null) ? resource.Text.Div : null;

--- a/src/Spark.Engine/Search/Support/NullExtensions.cs
+++ b/src/Spark.Engine/Search/Support/NullExtensions.cs
@@ -20,7 +20,7 @@ namespace Spark.Search.Support
             return list.Count == 0;
         }
 
-        public static bool IsNullOrEmpty(this Primitive element)
+        public static bool IsNullOrEmpty(this PrimitiveType element)
         {
             if (element == null) return true;
 

--- a/src/Spark.Engine/Service/FhirService.cs
+++ b/src/Spark.Engine/Service/FhirService.cs
@@ -174,7 +174,7 @@ namespace Spark.Engine.Service
             };
             foreach (var inc in includes)
             {
-                searchCommand.Include.Add(inc);
+                searchCommand.Include.Add((inc, IncludeModifier.None));
             }
             return Search(key.TypeName, searchCommand);
         }

--- a/src/Spark.Engine/Service/FhirService.cs
+++ b/src/Spark.Engine/Service/FhirService.cs
@@ -84,12 +84,8 @@ namespace Spark.Engine.Service
             Validate.HasTypeName(key);
             Validate.ResourceType(key, resource);
 
-            Validate.HasNoResourceId(key);
-            Validate.HasNoVersion(key);
-
-
-            Entry result = Store(Entry.POST(key, resource));
-
+            key = key.CleanupForCreate();
+            var result = Store(Entry.POST(key, resource));
             return Respond.WithResource(HttpStatusCode.Created, result);
         }
 

--- a/src/Spark.Engine/Service/FhirServiceExtensions/ElementNavFhirExtensionsNew.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/ElementNavFhirExtensionsNew.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using Hl7.Fhir.ElementModel;
+using Hl7.Fhir.FhirPath;
+using Hl7.Fhir.Model;
+using Hl7.FhirPath;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Spark.Engine.Service.FhirServiceExtensions
+{
+    /// <summary>
+    /// FIXME: the aim of this extension is to fix a single issue in the original ElementNavFhirExtensions.Select.
+    /// The issue happens when it's used together with some expression selecting property of type Date, but the
+    /// underlying value is of PrimitiveType, say, "2020-12-10".
+    ///
+    /// Cause of this: it doesn't support Hl7.Fhir.ElementModel.Types.Date type (only Hl7.Fhir.ElementModel.Types.DateTime is originally supported).
+    ///
+    /// Test failing: X012_Goal.
+    ///
+    /// TODO: create PR in the original repo and fix it.
+    /// 
+    /// </summary>
+
+    internal static class ElementNavFhirExtensionsNew
+    {
+        public static IEnumerable<Base> SelectNew(
+            this Base input,
+            string expression,
+            FhirEvaluationContext ctx = null)
+        {
+            var inputNav = input.ToTypedElement();
+            var result = inputNav.Select(expression, ctx ?? FhirEvaluationContext.CreateDefault());
+            return result.ToFhirValues();
+        }
+
+        public static IEnumerable<Base> ToFhirValues(this IEnumerable<ITypedElement> results)
+        {
+            return results.Select(r =>
+            {
+                if (r == null)
+                {
+                    return null;
+                }
+                var fhirValueProvider = r.Annotation<IFhirValueProvider>();
+                if (fhirValueProvider != null)
+                {
+                    return fhirValueProvider.FhirValue;
+                }
+                var obj = r.Value;
+                switch (obj)
+                {
+                    case bool flag:
+                        return new FhirBoolean(flag);
+                    case long num:
+                        return new Integer((int)num);
+                    case decimal num:
+                        return new FhirDecimal(num);
+                    case string s:
+                        return new FhirString(s);
+                    case Hl7.Fhir.ElementModel.Types.Date date:
+                        return new Date(date.ToString());
+                    case Hl7.Fhir.ElementModel.Types.DateTime dateTime:
+                        return new FhirDateTime(dateTime.ToDateTimeOffset(TimeSpan.Zero).ToUniversalTime());
+                }
+                return r.Value as Base;
+            });
+        }
+    }
+}

--- a/src/Spark.Engine/Service/FhirServiceExtensions/IndexService.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/IndexService.cs
@@ -71,9 +71,9 @@ namespace Spark.Engine.Service.FhirServiceExtensions
                 var indexValue = new IndexValue(searchParameter.Code);
                 IEnumerable<Base> resolvedValues;
                 // HACK: Ignoring search parameter expressions which the FhirPath engine does not yet have support for
-                try { resolvedValues = resource.Select(searchParameter.Expression); }
+                try { resolvedValues = resource.SelectNew(searchParameter.Expression); }
                 catch { resolvedValues = new List<Base>(); }
-                foreach (Base value in resolvedValues)
+                foreach (var value in resolvedValues)
                 {
                     Element element = value as Element;
                     if (element == null) continue;

--- a/src/Spark.Engine/Service/FhirServiceExtensions/PostManipulationOperation.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/PostManipulationOperation.cs
@@ -21,7 +21,7 @@ namespace Spark.Engine.Service.FhirServiceExtensions
             {
                 if (string.IsNullOrEmpty(entry.Request?.IfNoneExist) == false)
                 {
-                    return new Uri(string.Format("{0}?{1}", entry.TypeName, entry.Request.IfNoneExist), UriKind.Relative);
+                    return new Uri(string.Format("{0}?{1}", entry.Resource.TypeName, entry.Request.IfNoneExist), UriKind.Relative);
                 }
                 return null;
             }

--- a/src/Spark.Engine/Service/FhirServiceExtensions/SearchService.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/SearchService.cs
@@ -56,7 +56,7 @@ namespace Spark.Engine.Service.FhirServiceExtensions
             {
                 foreach (var ri in compartment.ReverseIncludes)
                 {
-                    searchCommand.RevInclude.Add(ri);
+                    searchCommand.RevInclude.Add((ri, IncludeModifier.None));
                 }
             }
 
@@ -77,7 +77,7 @@ namespace Spark.Engine.Service.FhirServiceExtensions
 
             if (searchCommand.Sort.Any())
             {
-                foreach (Tuple<string, SortOrder> tuple in searchCommand.Sort)
+                foreach (var tuple in searchCommand.Sort)
                 {
                     selflink = selflink.AddParam(SearchParams.SEARCH_PARAM_SORT,
                         string.Format("{0}:{1}", tuple.Item1, tuple.Item2 == SortOrder.Ascending ? "asc" : "desc"));
@@ -86,15 +86,16 @@ namespace Spark.Engine.Service.FhirServiceExtensions
 
             if (searchCommand.Include.Any())
             {
-                selflink = selflink.AddParam(SearchParams.SEARCH_PARAM_INCLUDE, searchCommand.Include.ToArray());
+                selflink = selflink.AddParam(SearchParams.SEARCH_PARAM_INCLUDE, searchCommand.Include.Select(inc => inc.Item1).ToArray());
             }
 
             if (searchCommand.RevInclude.Any())
             {
-                selflink = selflink.AddParam(SearchParams.SEARCH_PARAM_REVINCLUDE, searchCommand.RevInclude.ToArray());
+                selflink = selflink.AddParam(SearchParams.SEARCH_PARAM_REVINCLUDE, searchCommand.RevInclude.Select(inc => inc.Item1).ToArray());
             }
 
-            return Snapshot.Create(Bundle.BundleType.Searchset, selflink, keys, sort, count, searchCommand.Include, searchCommand.RevInclude);
+            return Snapshot.Create(Bundle.BundleType.Searchset, selflink, keys, sort, count, searchCommand.Include.Select(inc => inc.Item1).ToList(), 
+                searchCommand.RevInclude.Select(inc => inc.Item1).ToList());
         }
 
         private static string GetFirstSort(SearchParams searchCommand)

--- a/src/Spark.Engine/Spark.Engine.csproj
+++ b/src/Spark.Engine/Spark.Engine.csproj
@@ -14,7 +14,7 @@
 
     <ItemGroup>
         <PackageReference Include="Fhir.Metrics" Version="1.2.0" />
-        <PackageReference Include="Hl7.Fhir.R4" Version="1.9.0" />
+        <PackageReference Include="Hl7.Fhir.R4" Version="2.0.1" />
         <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.8" />
         <PackageReference Include="System.Security.Cryptography.Xml" Version="4.7.0" />

--- a/src/Spark.Mongo/Search/Searcher/CriteriaMongoExtensions.cs
+++ b/src/Spark.Mongo/Search/Searcher/CriteriaMongoExtensions.cs
@@ -97,7 +97,13 @@ namespace Spark.Search.Mongo
             {
                 string parameterName = parameter.Name;
                 if (parameterName == "_id")
+                {
                     parameterName = "fhir_id"; //See MongoIndexMapper for counterpart.
+
+                    // This search finds the patient resource with the given id (there can only be one resource for a given id).
+                    // Functionally, this is equivalent to a simple read operation
+                    modifier = Modifier.EXACT;
+                }
 
                 var valueOperand = (ValueExpression)operand;
                 switch (parameter.Type)

--- a/src/Spark.Mongo/Search/Searcher/MongoSearcher.cs
+++ b/src/Spark.Mongo/Search/Searcher/MongoSearcher.cs
@@ -102,7 +102,7 @@ namespace Spark.Search.Mongo
             return CollectKeys(resultQuery);
         }
 
-        private List<BsonValue> CollectSelfLinks(string resourceType, IEnumerable<Criterium> criteria, SearchResults results, int level, IList<Tuple<string, SortOrder>> sortItems )
+        private List<BsonValue> CollectSelfLinks(string resourceType, IEnumerable<Criterium> criteria, SearchResults results, int level, IList<(string, SortOrder)> sortItems )
         {
             Dictionary<Criterium, Criterium> closedCriteria = CloseChainedCriteria(resourceType, criteria, results, level);
 
@@ -112,7 +112,7 @@ namespace Spark.Search.Mongo
             return CollectSelfLinks(resultQuery, sortBy);
         }
 
-        private static SortDefinition<BsonDocument> CreateSortBy(IList<Tuple<string, SortOrder>> sortItems)
+        private static SortDefinition<BsonDocument> CreateSortBy(IList<(string, SortOrder)> sortItems)
         {
             if (sortItems.Any() == false)
                 return null;
@@ -128,7 +128,7 @@ namespace Spark.Search.Mongo
                 sortDefinition = Builders<BsonDocument>.Sort.Descending(first.Item1);
             }
             sortItems.Remove(first);
-            foreach (Tuple<string, SortOrder> sortItem in sortItems)
+            foreach (var sortItem in sortItems)
             {
                 if (sortItem.Item2 == SortOrder.Ascending)
                 {
@@ -407,29 +407,29 @@ namespace Spark.Search.Mongo
             return results;
         }
 
-        private IList<Tuple<string, SortOrder>> NormalizeSortItems(string resourceType, SearchParams searchCommand)
+        private IList<(string, SortOrder)> NormalizeSortItems(string resourceType, SearchParams searchCommand)
         {
             var sortItems = searchCommand.Sort.Select(s => NormalizeSortItem(resourceType, s)).ToList();
             return sortItems;
         }
 
 
-        private Tuple<string, SortOrder> NormalizeSortItem(string resourceType, Tuple<string, SortOrder> sortItem)
+        private (string, SortOrder) NormalizeSortItem(string resourceType, (string, SortOrder) sortItem)
         {
             ModelInfo.SearchParamDefinition definition =
                 _fhirModel.FindSearchParameter(resourceType, sortItem.Item1)?.GetOriginalDefinition();
 
             if (definition?.Type == SearchParamType.Token)
             {
-                return new Tuple<string, SortOrder>(sortItem.Item1 + ".code", sortItem.Item2);
+                return (sortItem.Item1 + ".code", sortItem.Item2);
             }
             if (definition?.Type == SearchParamType.Date)
             {
-                return new Tuple<string, SortOrder>(sortItem.Item1 + ".start", sortItem.Item2);
+                return (sortItem.Item1 + ".start", sortItem.Item2);
             }
             if (definition?.Type == SearchParamType.Quantity)
             {
-                return new Tuple<string, SortOrder>(sortItem.Item1 + ".value", sortItem.Item2);
+                return (sortItem.Item1 + ".value", sortItem.Item2);
             }
             return sortItem;
         }

--- a/src/Spark.Mongo/Spark.Mongo.csproj
+++ b/src/Spark.Mongo/Spark.Mongo.csproj
@@ -13,7 +13,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Hl7.Fhir.R4" Version="1.9.0" />
+        <PackageReference Include="Hl7.Fhir.R4" Version="2.0.1" />
         <PackageReference Include="MongoDB.Driver" Version="2.11.1" />
         <None Include="..\..\LICENSE" Pack="true" Visible="false" PackagePath="" />
     </ItemGroup>

--- a/src/Spark.Web/Hubs/MaintenanceHub.cs
+++ b/src/Spark.Web/Hubs/MaintenanceHub.cs
@@ -134,7 +134,7 @@ namespace Spark.Web.Hubs
                 {
                     var res = resarray[x];
                     // Sending message:
-                    var msg = Message("Importing " + res.ResourceType.ToString() + " " + res.Id + "...", x);
+                    var msg = Message("Importing " + res.TypeName + " " + res.Id + "...", x);
                     await notifier.SendProgressUpdate(msg.Progress, msg.Message);
 
                     try
@@ -153,7 +153,7 @@ namespace Spark.Web.Hubs
                     catch (Exception e)
                     {
                         // Sending message:
-                        var msgError = Message("ERROR Importing " + res.ResourceType.ToString() + " " + res.Id + "... ", x);
+                        var msgError = Message("ERROR Importing " + res.TypeName + " " + res.Id + "... ", x);
                         await Clients.All.SendAsync("Error", msg);
                         messages.AppendLine(msgError.Message + ": " + e.Message);
                     }

--- a/src/Spark/Hubs/InitializerHub.cs
+++ b/src/Spark/Hubs/InitializerHub.cs
@@ -129,7 +129,7 @@ namespace Spark.Import
                 {
                     var res = resarray[x];
                     // Sending message:
-                    var msg = Message("Importing " + res.ResourceType.ToString() + " " + res.Id + "...", x);
+                    var msg = Message("Importing " + res.TypeName + " " + res.Id + "...", x);
                     Clients.Caller.sendMessage(msg);
 
                     try
@@ -150,7 +150,7 @@ namespace Spark.Import
                     catch (Exception e)
                     {
                         // Sending message:
-                        var msgError = Message("ERROR Importing " + res.ResourceType.ToString() + " " + res.Id + "... ", x);
+                        var msgError = Message("ERROR Importing " + res.TypeName + " " + res.Id + "... ", x);
                         Clients.Caller.sendMessage(msg);
                         messages.AppendLine(msgError.Message + ": " + e.Message);
                     }

--- a/src/Spark/Spark.csproj
+++ b/src/Spark/Spark.csproj
@@ -53,23 +53,23 @@
     <Reference Include="DnsClient, Version=1.3.2.0, Culture=neutral, PublicKeyToken=4574bb5573c51424, processorArchitecture=MSIL">
       <HintPath>..\..\packages\DnsClient.1.3.2\lib\net45\DnsClient.dll</HintPath>
     </Reference>
-    <Reference Include="Hl7.Fhir.R4.Core, Version=1.9.0.0, Culture=neutral, PublicKeyToken=d706911480550fc3, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Hl7.Fhir.R4.1.9.0\lib\net45\Hl7.Fhir.R4.Core.dll</HintPath>
+    <Reference Include="Hl7.Fhir.ElementModel, Version=2.0.1.0, Culture=neutral, PublicKeyToken=d706911480550fc3, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Hl7.Fhir.ElementModel.2.0.1\lib\net45\Hl7.Fhir.ElementModel.dll</HintPath>
     </Reference>
-    <Reference Include="Hl7.Fhir.ElementModel, Version=1.9.0.0, Culture=neutral, PublicKeyToken=d706911480550fc3, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Hl7.Fhir.ElementModel.1.9.0\lib\net45\Hl7.Fhir.ElementModel.dll</HintPath>
+    <Reference Include="Hl7.Fhir.R4.Core, Version=2.0.1.0, Culture=neutral, PublicKeyToken=d706911480550fc3, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Hl7.Fhir.R4.2.0.1\lib\net45\Hl7.Fhir.R4.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Hl7.Fhir.Serialization, Version=1.9.0.0, Culture=neutral, PublicKeyToken=d706911480550fc3, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Hl7.Fhir.Serialization.1.9.0\lib\net45\Hl7.Fhir.Serialization.dll</HintPath>
+    <Reference Include="Hl7.Fhir.Serialization, Version=2.0.1.0, Culture=neutral, PublicKeyToken=d706911480550fc3, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Hl7.Fhir.Serialization.2.0.1\lib\net45\Hl7.Fhir.Serialization.dll</HintPath>
     </Reference>
-    <Reference Include="Hl7.Fhir.Support, Version=1.9.0.0, Culture=neutral, PublicKeyToken=d706911480550fc3, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Hl7.Fhir.Support.1.9.0\lib\net45\Hl7.Fhir.Support.dll</HintPath>
+    <Reference Include="Hl7.Fhir.Support, Version=2.0.1.0, Culture=neutral, PublicKeyToken=d706911480550fc3, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Hl7.Fhir.Support.2.0.1\lib\net45\Hl7.Fhir.Support.dll</HintPath>
     </Reference>
-    <Reference Include="Hl7.Fhir.Support.Poco, Version=1.9.0.0, Culture=neutral, PublicKeyToken=d706911480550fc3, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Hl7.Fhir.Support.Poco.1.9.0\lib\net45\Hl7.Fhir.Support.Poco.dll</HintPath>
+    <Reference Include="Hl7.Fhir.Support.Poco, Version=2.0.1.0, Culture=neutral, PublicKeyToken=d706911480550fc3, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Hl7.Fhir.Support.Poco.2.0.1\lib\net45\Hl7.Fhir.Support.Poco.dll</HintPath>
     </Reference>
-    <Reference Include="Hl7.FhirPath, Version=1.9.0.0, Culture=neutral, PublicKeyToken=d706911480550fc3, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Hl7.FhirPath.1.9.0\lib\net45\Hl7.FhirPath.dll</HintPath>
+    <Reference Include="Hl7.FhirPath, Version=2.0.1.0, Culture=neutral, PublicKeyToken=d706911480550fc3, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Hl7.FhirPath.2.0.1\lib\net45\Hl7.FhirPath.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.AspNet.SignalR.Core, Version=2.4.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNet.SignalR.Core.2.4.1\lib\net45\Microsoft.AspNet.SignalR.Core.dll</HintPath>
@@ -120,8 +120,8 @@
     <Reference Include="MongoDB.Libmongocrypt, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\MongoDB.Libmongocrypt.1.0.0\lib\net452\MongoDB.Libmongocrypt.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>

--- a/src/Spark/Web.config
+++ b/src/Spark/Web.config
@@ -257,7 +257,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />

--- a/src/Spark/packages.config
+++ b/src/Spark/packages.config
@@ -6,12 +6,12 @@
   <package id="DnsClient" version="1.3.2" targetFramework="net461" />
   <package id="EnterpriseLibrary.SemanticLogging" version="2.0.1406.1" targetFramework="net461" />
   <package id="EnterpriseLibrary.SemanticLogging.TextFile" version="2.0.1406.1" targetFramework="net461" />
-  <package id="Hl7.Fhir.R4" version="1.9.0" targetFramework="net461" />
-  <package id="Hl7.Fhir.ElementModel" version="1.9.0" targetFramework="net461" />
-  <package id="Hl7.Fhir.Serialization" version="1.9.0" targetFramework="net461" />
-  <package id="Hl7.Fhir.Support" version="1.9.0" targetFramework="net461" />
-  <package id="Hl7.Fhir.Support.Poco" version="1.9.0" targetFramework="net461" />
-  <package id="Hl7.FhirPath" version="1.9.0" targetFramework="net461" />
+  <package id="Hl7.Fhir.ElementModel" version="2.0.1" targetFramework="net461" />
+  <package id="Hl7.Fhir.R4" version="2.0.1" targetFramework="net461" />
+  <package id="Hl7.Fhir.Serialization" version="2.0.1" targetFramework="net461" />
+  <package id="Hl7.Fhir.Support" version="2.0.1" targetFramework="net461" />
+  <package id="Hl7.Fhir.Support.Poco" version="2.0.1" targetFramework="net461" />
+  <package id="Hl7.FhirPath" version="2.0.1" targetFramework="net461" />
   <package id="jQuery" version="3.5.1" targetFramework="net461" />
   <package id="Microsoft.AspNet.Cors" version="5.2.7" targetFramework="net461" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.7" targetFramework="net461" />
@@ -40,7 +40,7 @@
   <package id="MongoDB.Driver" version="2.11.1" targetFramework="net461" />
   <package id="MongoDB.Driver.Core" version="2.11.1" targetFramework="net461" />
   <package id="MongoDB.Libmongocrypt" version="1.0.0" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net461" />
   <package id="Owin" version="1.0" targetFramework="net461" />
   <package id="Respond" version="1.4.2" targetFramework="net461" />
   <package id="SharpCompress" version="0.26.0" targetFramework="net461" />

--- a/tests/integration-tests/combine-test-results.sh
+++ b/tests/integration-tests/combine-test-results.sh
@@ -7,6 +7,9 @@ ANNOTATIONS_FILE=$2
 
 function usage() {
   me=`basename "$0"`
+  if [ ! -z "$1" ]; then
+    echo $1
+  fi
   echo "Usage: ./${me} path/to/input/json_results path/to/output/annotations.json"
   exit 1
 }
@@ -15,14 +18,24 @@ function usage() {
 
 [ ! -z "${JSON_PATH}" ] || usage
 
-[ -d "${JSON_PATH}" ] || usage
+[ -d "${JSON_PATH}" ] || usage "${JSON_PATH} must be a directory"
 
-touch $ANNOTATIONS_FILE || usage
+touch $ANNOTATIONS_FILE || "$ANNOTATIONS_FILE is not writable"
 
-ls ${JSON_PATH}/*.json | xargs jq -c '[ .[]
+DIR=$(pwd)
+
+cd ${JSON_PATH}
+
+# Have to use warning annotation level, notice isn't working anymore (but could be in future).
+
+SUMMARY=$(ls _summary*.json | xargs jq -c '[ .
+  | { "file": "summary",  "line": 1, "message": ("PASS: \(.pass // 0)\nFAIL: \(.fail // 0)\nERROR: \(.error // 0)\nSKIP: \(.skip // 0)"), "annotation_level": "warning" }
+]')
+
+FAILURES=$(ls -I '_summary*.json' | xargs jq -c '[ .[]
     | select(((.status == "skip") and (.message | contains("TODO") | not))
         or .status == "fail"
-	or .status == "error")
+        or .status == "error")
     | .id as $id
     | .status as $status
     | .message as $message
@@ -30,5 +43,8 @@ ls ${JSON_PATH}/*.json | xargs jq -c '[ .[]
     | .test_method as $method
     | input_filename as $file
     | { "file": $id,  "line": 1, "message": $message, "annotation_level": "failure" }
-]' | jq 'reduce inputs as $i (.; . += $i)' > ${ANNOTATIONS_FILE}
+]')
 
+cd $DIR
+
+jq 'reduce inputs as $i (.; . += $i)' <(echo "${SUMMARY}") <(echo "${FAILURES}") > ${ANNOTATIONS_FILE}

--- a/tests/integration-tests/combine-test-results.sh
+++ b/tests/integration-tests/combine-test-results.sh
@@ -28,11 +28,13 @@ cd ${JSON_PATH}
 
 # Have to use warning annotation level, notice isn't working anymore (but could be in future).
 
-SUMMARY=$(ls _summary*.json | xargs jq -c '[ .
+SUMMARY=$(ls _summary*.json | xargs jq '[ .
   | { "file": "summary",  "line": 1, "message": ("PASS: \(.pass // 0)\nFAIL: \(.fail // 0)\nERROR: \(.error // 0)\nSKIP: \(.skip // 0)"), "annotation_level": "warning" }
 ]')
 
-FAILURES=$(ls -I '_summary*.json' | xargs jq -c '[ .[]
+echo "${SUMMARY}"
+
+FAILURES=$(ls -I '_summary*.json' | xargs jq '[ .[]
     | select(((.status == "skip") and (.message | contains("TODO") | not))
         or .status == "fail"
         or .status == "error")

--- a/tests/integration-tests/combine-test-results.sh
+++ b/tests/integration-tests/combine-test-results.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -e
+
+JSON_PATH=$1
+ANNOTATIONS_FILE=$2
+
+function usage() {
+  me=`basename "$0"`
+  echo "Usage: ./${me} path/to/input/json_results path/to/output/annotations.json"
+  exit 1
+}
+
+[ $# -eq 2 ] || usage
+
+[ ! -z "${JSON_PATH}" ] || usage
+
+[ -d "${JSON_PATH}" ] || usage
+
+touch $ANNOTATIONS_FILE || usage
+
+ls ${JSON_PATH}/*.json | xargs jq -c '[ .[]
+    | select(((.status == "skip") and (.message | contains("TODO") | not))
+        or .status == "fail"
+	or .status == "error")
+    | .id as $id
+    | .status as $status
+    | .message as $message
+    | .description as $description
+    | .test_method as $method
+    | input_filename as $file
+    | { "file": $id,  "line": 1, "message": $message, "annotation_level": "failure" }
+]' | jq 'reduce inputs as $i (.; . += $i)' > ${ANNOTATIONS_FILE}
+

--- a/tests/integration-tests/docker-compose.yml
+++ b/tests/integration-tests/docker-compose.yml
@@ -25,3 +25,5 @@ services:
     volumes:
       - ./logs:/app/logs:rw
       - ./html_summaries:/app/html_summaries:rw
+      - ./json_results:/app/json_results:rw
+      

--- a/tests/integration-tests/docker-compose.yml
+++ b/tests/integration-tests/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - mongodb
   mongodb:
     container_name: mongodb
-    image: sparkfhir/mongo:r4-latest-develop
+    image: sparkfhir/mongo:r4-latest
     environment:
       MONGO_INITDB_ROOT_USERNAME: root
       MONGO_INITDB_ROOT_PASSWORD: secret


### PR DESCRIPTION
### Run all tests on new PR + on push to r4/master. (#319)

When PR is merged it will run tests second time, seems there's no way to avoid it.

### Support of _count, _sort and other special params passed via query in _search

Before, it was only using POSTed data.

This fixes some integration tests.

### Fix issue with searching Binary by using POST /Binary/_search

It was assuming that the binary contents is requested instead of searching for it.

### Fix in seach using `_id` param.

Spec says:

The search parameter `_id` refers to the logical id of the resource, and can be used when the search context specifies a resource type:

```
GET [base]/Patient?_id=23
```

This search finds the patient resource with the given id (there can only be one resource for a given id). Functionally, this is equivalent to a simple read operation:

```
GET [base]/Patient/23
```

However it was using partial match by default which was translated to this regexp:

`/^23/i`

which produced multiple results.

Changed to exact match (always).

### Fix in Create operation (ignore id, version).

As it's stated in STU3 and R4 spec:

> If an id is provided, the server SHALL ignore it.
> If the request body includes a meta, the server SHALL ignore the existing versionId and lastUpdated values.

### Search by reference - exact search + type specification.

Before it was

`/fhir/CarePlan?patient=1058`

producing wildcard regexp query like

```
{
    "internal_level" : 0,
    "internal_resource" : "CarePlan",
    "patient" : /^1058/i
}
```

now it's replaced with

```
{
    "internal_level" : 0,
    "internal_resource" : "CarePlan",
    "patient" : /^(Patient|Group)/1058$/
}
```

Also, EXACT modifier is applied to reference search.

### R4 archive updated.

 - Patient id counter restarted from 1000.
 - Practitioner id counter restarted from 1000.
 - Search index rebuilt.

Commands executed:

```
db.counters.update(
   { _id: "Patient" },
   { "last": NumberInt(1000) }
);

db.counters.update(    { _id: "Practitioner" },    { "last": NumberInt(1000) }, { "upsert": true } );
```

### Upgrade Hl7.Fhir packages to 2.0.1

This fixed some R4 integration tests.

### HACKY FIX for X012 (Goal)

The aim is to fix a single issue in the original `ElementNavFhirExtensions.Select`.
The issue happens when it's used together with some expression selecting property of type `Date`, and the
underlying value is, say, `"2020-12-10"`.

Root cause of this: it doesn't support `Hl7.Fhir.ElementModel.Types.Date` type (only `Hl7.Fhir.ElementModel.Types.DateTime` is originally supported).

Test failing: `X012_Goal`.

TODO: create PR in the original repo and fix it.