### PR TITLE
Merge R4 changes into STU3 + make some fixes

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -33,13 +33,13 @@ jobs:
         name: Combine test results
         if: ${{ always() }}
         run: cd tests/integration-tests && ./combine-test-results.sh json_results annotations.json
-      - 
-        name: Attach test results
-        if: ${{ always() }}
-        uses: yuzutech/annotations-action@v0.1.0
-        with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
-          input: tests/integration-tests/annotations.json
+#      - 
+#        name: Attach test results
+#        if: ${{ always() }}
+#        uses: yuzutech/annotations-action@v0.1.0
+#        with:
+#          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+#          input: tests/integration-tests/annotations.json
       - 
         name: Archive logs
         if: ${{ always() }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -28,7 +28,7 @@ jobs:
           cd tests/integration-tests
           mkdir -p logs html_summaries json_results
           docker-compose up -d spark
-          docker-compose run --rm --no-deps plan_executor ./execute_all.sh 'http://spark/fhir' stu3 'html|json'
+          docker-compose run --rm --no-deps plan_executor ./execute_all.sh 'http://spark/fhir' stu3 'html|json|stdout'
       - 
         name: Combine test results
         if: ${{ always() }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -33,13 +33,13 @@ jobs:
         name: Combine test results
         if: ${{ always() }}
         run: cd tests/integration-tests && ./combine-test-results.sh json_results annotations.json
-#      - 
-#        name: Attach test results
-#        if: ${{ always() }}
-#        uses: yuzutech/annotations-action@v0.1.0
-#        with:
-#          repo-token: "${{ secrets.GITHUB_TOKEN }}"
-#          input: tests/integration-tests/annotations.json
+      - 
+        name: Attach test results
+        if: github.event_name != 'pull_request'
+        uses: yuzutech/annotations-action@v0.1.0
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          input: tests/integration-tests/annotations.json
       - 
         name: Archive logs
         if: ${{ always() }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -26,9 +26,20 @@ jobs:
         name: Run integration tests
         run: |
           cd tests/integration-tests
-          mkdir -p logs html_summaries
+          mkdir -p logs html_summaries json_results
           docker-compose up -d spark
-          docker-compose run --rm --no-deps plan_executor ./execute_all.sh 'http://spark/fhir' stu3
+          docker-compose run --rm --no-deps plan_executor ./execute_all.sh 'http://spark/fhir' stu3 'html|json'
+      - 
+        name: Combine test results
+        if: ${{ always() }}
+        run: cd tests/integration-tests && ./combine-test-results.sh json_results annotations.json
+      - 
+        name: Attach test results
+        if: ${{ always() }}
+        uses: yuzutech/annotations-action@v0.1.0
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          input: tests/integration-tests/annotations.json
       - 
         name: Archive logs
         if: ${{ always() }}
@@ -43,6 +54,20 @@ jobs:
         with:
           name: html_summaries-stu3-${{ github.sha }}
           path: tests/integration-tests/html_summaries/**/*.html
+      - 
+        name: Archive JSON results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: json_results-r4-${{ github.sha }}
+          path: tests/integration-tests/json_results/**/*.json
+      - 
+        name: Archive annotations file
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: annotations-r4-${{ github.sha }}
+          path: tests/integration-tests/annotations.json
       - 
         name: Cleanup
         if: ${{ always() }}

--- a/src/Spark.Engine/Extensions/HttpHeadersExtensions.cs
+++ b/src/Spark.Engine/Extensions/HttpHeadersExtensions.cs
@@ -93,7 +93,7 @@ namespace Spark.Engine.Extensions
         {
             var list = new List<Tuple<string, string>>();
             string content = request.Content.ReadAsStringAsync().Result;
-            string[] parameters = string.IsNullOrEmpty(content) ? null : content.Split('&');
+            string[] parameters = string.IsNullOrEmpty(content) ? new string[0] : content.Split('&');
             foreach (string parameter in parameters)
             {
                 string[] p = parameter.Split('=');

--- a/src/Spark.Engine/Formatters/HtmlFhirFormatter.cs
+++ b/src/Spark.Engine/Formatters/HtmlFhirFormatter.cs
@@ -161,7 +161,7 @@ namespace Spark.Formatters
                 else
                 {
                     DomainResource resource = (DomainResource)value;
-                    string org = resource.ResourceBase + "/" + resource.ResourceType.ToString() + "/" + resource.Id;
+                    string org = resource.ResourceBase + "/" + resource.TypeName + "/" + resource.Id;
                     writer.WriteLine(string.Format("Retrieved: {0}<hr/>", org));
 
                     string text = (resource.Text != null) ? resource.Text.Div : null;

--- a/src/Spark.Engine/Search/Support/NullExtensions.cs
+++ b/src/Spark.Engine/Search/Support/NullExtensions.cs
@@ -20,7 +20,7 @@ namespace Spark.Search.Support
             return list.Count == 0;
         }
 
-        public static bool IsNullOrEmpty(this Primitive element)
+        public static bool IsNullOrEmpty(this PrimitiveType element)
         {
             if (element == null) return true;
 

--- a/src/Spark.Engine/Service/FhirService.cs
+++ b/src/Spark.Engine/Service/FhirService.cs
@@ -174,7 +174,7 @@ namespace Spark.Engine.Service
             };
             foreach (var inc in includes)
             {
-                searchCommand.Include.Add(inc);
+                searchCommand.Include.Add((inc, IncludeModifier.None));
             }
             return Search(key.TypeName, searchCommand);
         }

--- a/src/Spark.Engine/Service/FhirServiceExtensions/ElementNavFhirExtensionsNew.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/ElementNavFhirExtensionsNew.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using Hl7.Fhir.ElementModel;
+using Hl7.Fhir.FhirPath;
+using Hl7.Fhir.Model;
+using Hl7.FhirPath;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Spark.Engine.Service.FhirServiceExtensions
+{
+    /// <summary>
+    /// FIXME: the aim of this extension is to fix a single issue in the original ElementNavFhirExtensions.Select.
+    /// The issue happens when it's used together with some expression selecting property of type Date, but the
+    /// underlying value is of PrimitiveType, say, "2020-12-10".
+    ///
+    /// Cause of this: it doesn't support Hl7.Fhir.ElementModel.Types.Date type (only Hl7.Fhir.ElementModel.Types.DateTime is originally supported).
+    ///
+    /// Test failing: X012_Goal.
+    ///
+    /// TODO: create PR in the original repo and fix it.
+    /// 
+    /// </summary>
+
+    internal static class ElementNavFhirExtensionsNew
+    {
+        public static IEnumerable<Base> SelectNew(
+            this Base input,
+            string expression,
+            FhirEvaluationContext ctx = null)
+        {
+            var inputNav = input.ToTypedElement();
+            var result = inputNav.Select(expression, ctx ?? FhirEvaluationContext.CreateDefault());
+            return result.ToFhirValues();
+        }
+
+        public static IEnumerable<Base> ToFhirValues(this IEnumerable<ITypedElement> results)
+        {
+            return results.Select(r =>
+            {
+                if (r == null)
+                {
+                    return null;
+                }
+                var fhirValueProvider = r.Annotation<IFhirValueProvider>();
+                if (fhirValueProvider != null)
+                {
+                    return fhirValueProvider.FhirValue;
+                }
+                var obj = r.Value;
+                switch (obj)
+                {
+                    case bool flag:
+                        return new FhirBoolean(flag);
+                    case long num:
+                        return new Integer((int)num);
+                    case decimal num:
+                        return new FhirDecimal(num);
+                    case string s:
+                        return new FhirString(s);
+                    case Hl7.Fhir.ElementModel.Types.Date date:
+                        return new Date(date.ToString());
+                    case Hl7.Fhir.ElementModel.Types.DateTime dateTime:
+                        return new FhirDateTime(dateTime.ToDateTimeOffset(TimeSpan.Zero).ToUniversalTime());
+                }
+                return r.Value as Base;
+            });
+        }
+    }
+}

--- a/src/Spark.Engine/Service/FhirServiceExtensions/IndexService.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/IndexService.cs
@@ -69,7 +69,7 @@ namespace Spark.Engine.Service.FhirServiceExtensions
                 if (searchParameter.Type == Hl7.Fhir.Model.SearchParamType.Composite) continue;
 
                 var indexValue = new IndexValue(searchParameter.Code);
-                var resolvedValues = resource.Select(searchParameter.Expression);
+                var resolvedValues = resource.SelectNew(searchParameter.Expression);
                 foreach(var value in resolvedValues)
                 {
                     Element element = value as Element;

--- a/src/Spark.Engine/Service/FhirServiceExtensions/IndexService.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/IndexService.cs
@@ -60,7 +60,9 @@ namespace Spark.Engine.Service.FhirServiceExtensions
             var rootIndexValue = new IndexValue(rootPartName);
             AddMetaParts(resource, key, rootIndexValue);
 
-            foreach(var searchParameter in searchParameters)
+            ElementNavFhirExtensions.PrepareFhirSymbolTableFunctions();
+
+            foreach (var searchParameter in searchParameters)
             {
                 if (string.IsNullOrWhiteSpace(searchParameter.Expression)) continue;
                 // TODO: Do we need to index composite search parameters, some 

--- a/src/Spark.Engine/Service/FhirServiceExtensions/PostManipulationOperation.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/PostManipulationOperation.cs
@@ -21,7 +21,7 @@ namespace Spark.Engine.Service.FhirServiceExtensions
             {
                 if (string.IsNullOrEmpty(entry.Request?.IfNoneExist) == false)
                 {
-                    return new Uri(string.Format("{0}?{1}", entry.TypeName, entry.Request.IfNoneExist), UriKind.Relative);
+                    return new Uri(string.Format("{0}?{1}", entry.Resource.TypeName, entry.Request.IfNoneExist), UriKind.Relative);
                 }
                 return null;
             }

--- a/src/Spark.Engine/Service/FhirServiceExtensions/SearchService.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/SearchService.cs
@@ -56,7 +56,7 @@ namespace Spark.Engine.Service.FhirServiceExtensions
             {
                 foreach (var ri in compartment.ReverseIncludes)
                 {
-                    searchCommand.RevInclude.Add(ri);
+                    searchCommand.RevInclude.Add((ri, IncludeModifier.None));
                 }
             }
 
@@ -77,7 +77,7 @@ namespace Spark.Engine.Service.FhirServiceExtensions
 
             if (searchCommand.Sort.Any())
             {
-                foreach (Tuple<string, SortOrder> tuple in searchCommand.Sort)
+                foreach (var tuple in searchCommand.Sort)
                 {
                     selflink = selflink.AddParam(SearchParams.SEARCH_PARAM_SORT,
                         string.Format("{0}:{1}", tuple.Item1, tuple.Item2 == SortOrder.Ascending ? "asc" : "desc"));
@@ -86,15 +86,16 @@ namespace Spark.Engine.Service.FhirServiceExtensions
 
             if (searchCommand.Include.Any())
             {
-                selflink = selflink.AddParam(SearchParams.SEARCH_PARAM_INCLUDE, searchCommand.Include.ToArray());
+                selflink = selflink.AddParam(SearchParams.SEARCH_PARAM_INCLUDE, searchCommand.Include.Select(inc => inc.Item1).ToArray());
             }
 
             if (searchCommand.RevInclude.Any())
             {
-                selflink = selflink.AddParam(SearchParams.SEARCH_PARAM_REVINCLUDE, searchCommand.RevInclude.ToArray());
+                selflink = selflink.AddParam(SearchParams.SEARCH_PARAM_REVINCLUDE, searchCommand.RevInclude.Select(inc => inc.Item1).ToArray());
             }
 
-            return Snapshot.Create(Bundle.BundleType.Searchset, selflink, keys, sort, count, searchCommand.Include, searchCommand.RevInclude);
+            return Snapshot.Create(Bundle.BundleType.Searchset, selflink, keys, sort, count, searchCommand.Include.Select(inc => inc.Item1).ToList(), 
+                searchCommand.RevInclude.Select(inc => inc.Item1).ToList());
         }
 
         private static string GetFirstSort(SearchParams searchCommand)

--- a/src/Spark.Engine/Spark.Engine.csproj
+++ b/src/Spark.Engine/Spark.Engine.csproj
@@ -14,7 +14,7 @@
 
     <ItemGroup>
         <PackageReference Include="Fhir.Metrics" Version="1.2.0" />
-        <PackageReference Include="Hl7.Fhir.STU3" Version="1.9.0" />
+        <PackageReference Include="Hl7.Fhir.STU3" Version="2.0.1" />
         <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.8" />
         <PackageReference Include="System.Security.Cryptography.Xml" Version="4.7.0" />

--- a/src/Spark.Mongo/Search/Searcher/MongoSearcher.cs
+++ b/src/Spark.Mongo/Search/Searcher/MongoSearcher.cs
@@ -102,7 +102,7 @@ namespace Spark.Search.Mongo
             return CollectKeys(resultQuery);
         }
 
-        private List<BsonValue> CollectSelfLinks(string resourceType, IEnumerable<Criterium> criteria, SearchResults results, int level, IList<Tuple<string, SortOrder>> sortItems )
+        private List<BsonValue> CollectSelfLinks(string resourceType, IEnumerable<Criterium> criteria, SearchResults results, int level, IList<(string, SortOrder)> sortItems )
         {
             Dictionary<Criterium, Criterium> closedCriteria = CloseChainedCriteria(resourceType, criteria, results, level);
 
@@ -112,7 +112,7 @@ namespace Spark.Search.Mongo
             return CollectSelfLinks(resultQuery, sortBy);
         }
 
-        private static SortDefinition<BsonDocument> CreateSortBy(IList<Tuple<string, SortOrder>> sortItems)
+        private static SortDefinition<BsonDocument> CreateSortBy(IList<(string, SortOrder)> sortItems)
         {
             if (sortItems.Any() == false)
                 return null;
@@ -128,7 +128,7 @@ namespace Spark.Search.Mongo
                 sortDefinition = Builders<BsonDocument>.Sort.Descending(first.Item1);
             }
             sortItems.Remove(first);
-            foreach (Tuple<string, SortOrder> sortItem in sortItems)
+            foreach (var sortItem in sortItems)
             {
                 if (sortItem.Item2 == SortOrder.Ascending)
                 {
@@ -407,29 +407,29 @@ namespace Spark.Search.Mongo
             return results;
         }
 
-        private IList<Tuple<string, SortOrder>> NormalizeSortItems(string resourceType, SearchParams searchCommand)
+        private IList<(string, SortOrder)> NormalizeSortItems(string resourceType, SearchParams searchCommand)
         {
             var sortItems = searchCommand.Sort.Select(s => NormalizeSortItem(resourceType, s)).ToList();
             return sortItems;
         }
 
 
-        private Tuple<string, SortOrder> NormalizeSortItem(string resourceType, Tuple<string, SortOrder> sortItem)
+        private (string, SortOrder) NormalizeSortItem(string resourceType, (string, SortOrder) sortItem)
         {
             ModelInfo.SearchParamDefinition definition =
                 _fhirModel.FindSearchParameter(resourceType, sortItem.Item1)?.GetOriginalDefinition();
 
             if (definition?.Type == SearchParamType.Token)
             {
-                return new Tuple<string, SortOrder>(sortItem.Item1 + ".code", sortItem.Item2);
+                return (sortItem.Item1 + ".code", sortItem.Item2);
             }
             if (definition?.Type == SearchParamType.Date)
             {
-                return new Tuple<string, SortOrder>(sortItem.Item1 + ".start", sortItem.Item2);
+                return (sortItem.Item1 + ".start", sortItem.Item2);
             }
             if (definition?.Type == SearchParamType.Quantity)
             {
-                return new Tuple<string, SortOrder>(sortItem.Item1 + ".value", sortItem.Item2);
+                return (sortItem.Item1 + ".value", sortItem.Item2);
             }
             return sortItem;
         }

--- a/src/Spark.Mongo/Spark.Mongo.csproj
+++ b/src/Spark.Mongo/Spark.Mongo.csproj
@@ -13,7 +13,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Hl7.Fhir.STU3" Version="1.9.0" />
+        <PackageReference Include="Hl7.Fhir.STU3" Version="2.0.1" />
         <PackageReference Include="MongoDB.Driver" Version="2.11.1" />
         <None Include="..\..\LICENSE" Pack="true" Visible="false" PackagePath="" />
     </ItemGroup>

--- a/src/Spark.Web/Hubs/MaintenanceHub.cs
+++ b/src/Spark.Web/Hubs/MaintenanceHub.cs
@@ -134,7 +134,7 @@ namespace Spark.Web.Hubs
                 {
                     var res = resarray[x];
                     // Sending message:
-                    var msg = Message("Importing " + res.ResourceType.ToString() + " " + res.Id + "...", x);
+                    var msg = Message("Importing " + res.TypeName + " " + res.Id + "...", x);
                     await notifier.SendProgressUpdate(msg.Progress, msg.Message);
 
                     try
@@ -153,7 +153,7 @@ namespace Spark.Web.Hubs
                     catch (Exception e)
                     {
                         // Sending message:
-                        var msgError = Message("ERROR Importing " + res.ResourceType.ToString() + " " + res.Id + "... ", x);
+                        var msgError = Message("ERROR Importing " + res.TypeName + " " + res.Id + "... ", x);
                         await Clients.All.SendAsync("Error", msg);
                         messages.AppendLine(msgError.Message + ": " + e.Message);
                     }

--- a/src/Spark/Hubs/InitializerHub.cs
+++ b/src/Spark/Hubs/InitializerHub.cs
@@ -129,7 +129,7 @@ namespace Spark.Import
                 {
                     var res = resarray[x];
                     // Sending message:
-                    var msg = Message("Importing " + res.ResourceType.ToString() + " " + res.Id + "...", x);
+                    var msg = Message("Importing " + res.TypeName + " " + res.Id + "...", x);
                     Clients.Caller.sendMessage(msg);
 
                     try
@@ -150,7 +150,7 @@ namespace Spark.Import
                     catch (Exception e)
                     {
                         // Sending message:
-                        var msgError = Message("ERROR Importing " + res.ResourceType.ToString() + " " + res.Id + "... ", x);
+                        var msgError = Message("ERROR Importing " + res.TypeName + " " + res.Id + "... ", x);
                         Clients.Caller.sendMessage(msg);
                         messages.AppendLine(msgError.Message + ": " + e.Message);
                     }

--- a/src/Spark/Spark.csproj
+++ b/src/Spark/Spark.csproj
@@ -53,23 +53,23 @@
     <Reference Include="DnsClient, Version=1.3.2.0, Culture=neutral, PublicKeyToken=4574bb5573c51424, processorArchitecture=MSIL">
       <HintPath>..\..\packages\DnsClient.1.3.2\lib\net45\DnsClient.dll</HintPath>
     </Reference>
-    <Reference Include="Hl7.Fhir.STU3.Core, Version=1.9.0.0, Culture=neutral, PublicKeyToken=d706911480550fc3, processorArchitecture=MSIL">
-        <HintPath>..\..\packages\Hl7.Fhir.STU3.1.9.0\lib\net45\Hl7.Fhir.STU3.Core.dll</HintPath>
+    <Reference Include="Hl7.Fhir.STU3.Core, Version=2.0.1.0, Culture=neutral, PublicKeyToken=d706911480550fc3, processorArchitecture=MSIL">
+        <HintPath>..\..\packages\Hl7.Fhir.STU3.2.0.1\lib\net45\Hl7.Fhir.STU3.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Hl7.Fhir.ElementModel, Version=1.9.0.0, Culture=neutral, PublicKeyToken=d706911480550fc3, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Hl7.Fhir.ElementModel.1.9.0\lib\net45\Hl7.Fhir.ElementModel.dll</HintPath>
+    <Reference Include="Hl7.Fhir.ElementModel, Version=2.0.1.0, Culture=neutral, PublicKeyToken=d706911480550fc3, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Hl7.Fhir.ElementModel.2.0.1\lib\net45\Hl7.Fhir.ElementModel.dll</HintPath>
     </Reference>
-    <Reference Include="Hl7.Fhir.Serialization, Version=1.9.0.0, Culture=neutral, PublicKeyToken=d706911480550fc3, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Hl7.Fhir.Serialization.1.9.0\lib\net45\Hl7.Fhir.Serialization.dll</HintPath>
+    <Reference Include="Hl7.Fhir.Serialization, Version=2.0.1.0, Culture=neutral, PublicKeyToken=d706911480550fc3, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Hl7.Fhir.Serialization.2.0.1\lib\net45\Hl7.Fhir.Serialization.dll</HintPath>
     </Reference>
-    <Reference Include="Hl7.Fhir.Support, Version=1.9.0.0, Culture=neutral, PublicKeyToken=d706911480550fc3, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Hl7.Fhir.Support.1.9.0\lib\net45\Hl7.Fhir.Support.dll</HintPath>
+    <Reference Include="Hl7.Fhir.Support, Version=2.0.1.0, Culture=neutral, PublicKeyToken=d706911480550fc3, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Hl7.Fhir.Support.2.0.1\lib\net45\Hl7.Fhir.Support.dll</HintPath>
     </Reference>
-    <Reference Include="Hl7.Fhir.Support.Poco, Version=1.9.0.0, Culture=neutral, PublicKeyToken=d706911480550fc3, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Hl7.Fhir.Support.Poco.1.9.0\lib\net45\Hl7.Fhir.Support.Poco.dll</HintPath>
+    <Reference Include="Hl7.Fhir.Support.Poco, Version=2.0.1.0, Culture=neutral, PublicKeyToken=d706911480550fc3, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Hl7.Fhir.Support.Poco.2.0.1\lib\net45\Hl7.Fhir.Support.Poco.dll</HintPath>
     </Reference>
-    <Reference Include="Hl7.FhirPath, Version=1.9.0.0, Culture=neutral, PublicKeyToken=d706911480550fc3, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Hl7.FhirPath.1.9.0\lib\net45\Hl7.FhirPath.dll</HintPath>
+    <Reference Include="Hl7.FhirPath, Version=2.0.1.0, Culture=neutral, PublicKeyToken=d706911480550fc3, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Hl7.FhirPath.2.0.1\lib\net45\Hl7.FhirPath.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.AspNet.SignalR.Core, Version=2.4.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNet.SignalR.Core.2.4.1\lib\net45\Microsoft.AspNet.SignalR.Core.dll</HintPath>
@@ -120,8 +120,8 @@
     <Reference Include="MongoDB.Libmongocrypt, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\MongoDB.Libmongocrypt.1.0.0\lib\net452\MongoDB.Libmongocrypt.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>

--- a/src/Spark/Web.config
+++ b/src/Spark/Web.config
@@ -257,7 +257,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />

--- a/src/Spark/packages.config
+++ b/src/Spark/packages.config
@@ -6,12 +6,12 @@
   <package id="DnsClient" version="1.3.2" targetFramework="net461" />
   <package id="EnterpriseLibrary.SemanticLogging" version="2.0.1406.1" targetFramework="net461" />
   <package id="EnterpriseLibrary.SemanticLogging.TextFile" version="2.0.1406.1" targetFramework="net461" />
-  <package id="Hl7.Fhir.STU3" version="1.9.0" targetFramework="net461" />
-  <package id="Hl7.Fhir.ElementModel" version="1.9.0" targetFramework="net461" />
-  <package id="Hl7.Fhir.Serialization" version="1.9.0" targetFramework="net461" />
-  <package id="Hl7.Fhir.Support" version="1.9.0" targetFramework="net461" />
-  <package id="Hl7.Fhir.Support.Poco" version="1.9.0" targetFramework="net461" />
-  <package id="Hl7.FhirPath" version="1.9.0" targetFramework="net461" />
+  <package id="Hl7.Fhir.STU3" version="2.0.1" targetFramework="net461" />
+  <package id="Hl7.Fhir.ElementModel" version="2.0.1" targetFramework="net461" />
+  <package id="Hl7.Fhir.Serialization" version="2.0.1" targetFramework="net461" />
+  <package id="Hl7.Fhir.Support" version="2.0.1" targetFramework="net461" />
+  <package id="Hl7.Fhir.Support.Poco" version="2.0.1" targetFramework="net461" />
+  <package id="Hl7.FhirPath" version="2.0.1" targetFramework="net461" />
   <package id="jQuery" version="3.5.1" targetFramework="net461" />
   <package id="Microsoft.AspNet.Cors" version="5.2.7" targetFramework="net461" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.7" targetFramework="net461" />
@@ -40,7 +40,7 @@
   <package id="MongoDB.Driver" version="2.11.1" targetFramework="net461" />
   <package id="MongoDB.Driver.Core" version="2.11.1" targetFramework="net461" />
   <package id="MongoDB.Libmongocrypt" version="1.0.0" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net461" />
   <package id="Owin" version="1.0" targetFramework="net461" />
   <package id="Respond" version="1.4.2" targetFramework="net461" />
   <package id="SharpCompress" version="0.26.0" targetFramework="net461" />

--- a/tests/integration-tests/.gitignore
+++ b/tests/integration-tests/.gitignore
@@ -1,0 +1,2 @@
+﻿json_results
+annotations.json

--- a/tests/integration-tests/combine-test-results.sh
+++ b/tests/integration-tests/combine-test-results.sh
@@ -7,6 +7,9 @@ ANNOTATIONS_FILE=$2
 
 function usage() {
   me=`basename "$0"`
+  if [ ! -z "$1" ]; then
+    echo $1
+  fi
   echo "Usage: ./${me} path/to/input/json_results path/to/output/annotations.json"
   exit 1
 }
@@ -15,14 +18,24 @@ function usage() {
 
 [ ! -z "${JSON_PATH}" ] || usage
 
-[ -d "${JSON_PATH}" ] || usage
+[ -d "${JSON_PATH}" ] || usage "${JSON_PATH} must be a directory"
 
-touch $ANNOTATIONS_FILE || usage
+touch $ANNOTATIONS_FILE || "$ANNOTATIONS_FILE is not writable"
 
-ls ${JSON_PATH}/*.json | xargs jq -c '[ .[]
+DIR=$(pwd)
+
+cd ${JSON_PATH}
+
+# Have to use warning annotation level, notice isn't working anymore (but could be in future).
+
+SUMMARY=$(ls _summary*.json | xargs jq -c '[ .
+  | { "file": "summary",  "line": 1, "message": ("PASS: \(.pass // 0)\nFAIL: \(.fail // 0)\nERROR: \(.error // 0)\nSKIP: \(.skip // 0)"), "annotation_level": "warning" }
+]')
+
+FAILURES=$(ls -I '_summary*.json' | xargs jq -c '[ .[]
     | select(((.status == "skip") and (.message | contains("TODO") | not))
         or .status == "fail"
-	or .status == "error")
+        or .status == "error")
     | .id as $id
     | .status as $status
     | .message as $message
@@ -30,5 +43,8 @@ ls ${JSON_PATH}/*.json | xargs jq -c '[ .[]
     | .test_method as $method
     | input_filename as $file
     | { "file": $id,  "line": 1, "message": $message, "annotation_level": "failure" }
-]' | jq 'reduce inputs as $i (.; . += $i)' > ${ANNOTATIONS_FILE}
+]')
 
+cd $DIR
+
+jq 'reduce inputs as $i (.; . += $i)' <(echo "${SUMMARY}") <(echo "${FAILURES}") > ${ANNOTATIONS_FILE}

--- a/tests/integration-tests/combine-test-results.sh
+++ b/tests/integration-tests/combine-test-results.sh
@@ -28,11 +28,13 @@ cd ${JSON_PATH}
 
 # Have to use warning annotation level, notice isn't working anymore (but could be in future).
 
-SUMMARY=$(ls _summary*.json | xargs jq -c '[ .
+SUMMARY=$(ls _summary*.json | xargs jq '[ .
   | { "file": "summary",  "line": 1, "message": ("PASS: \(.pass // 0)\nFAIL: \(.fail // 0)\nERROR: \(.error // 0)\nSKIP: \(.skip // 0)"), "annotation_level": "warning" }
 ]')
 
-FAILURES=$(ls -I '_summary*.json' | xargs jq -c '[ .[]
+echo "${SUMMARY}"
+
+FAILURES=$(ls -I '_summary*.json' | xargs jq '[ .[]
     | select(((.status == "skip") and (.message | contains("TODO") | not))
         or .status == "fail"
         or .status == "error")

--- a/tests/integration-tests/combine-test-results.sh
+++ b/tests/integration-tests/combine-test-results.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -e
+
+JSON_PATH=$1
+ANNOTATIONS_FILE=$2
+
+function usage() {
+  me=`basename "$0"`
+  echo "Usage: ./${me} path/to/input/json_results path/to/output/annotations.json"
+  exit 1
+}
+
+[ $# -eq 2 ] || usage
+
+[ ! -z "${JSON_PATH}" ] || usage
+
+[ -d "${JSON_PATH}" ] || usage
+
+touch $ANNOTATIONS_FILE || usage
+
+ls ${JSON_PATH}/*.json | xargs jq -c '[ .[]
+    | select(((.status == "skip") and (.message | contains("TODO") | not))
+        or .status == "fail"
+	or .status == "error")
+    | .id as $id
+    | .status as $status
+    | .message as $message
+    | .description as $description
+    | .test_method as $method
+    | input_filename as $file
+    | { "file": $id,  "line": 1, "message": $message, "annotation_level": "failure" }
+]' | jq 'reduce inputs as $i (.; . += $i)' > ${ANNOTATIONS_FILE}
+

--- a/tests/integration-tests/docker-compose.yml
+++ b/tests/integration-tests/docker-compose.yml
@@ -25,3 +25,5 @@ services:
     volumes:
       - ./logs:/app/logs:rw
       - ./html_summaries:/app/html_summaries:rw
+      - ./json_results:/app/json_results:rw
+      


### PR DESCRIPTION
### Attaching integration test results to test run as check annotations

### Write information notice with the summary results of test run.

### Upgrade Hl7.Fhir packages to 2.0.1

This fixed some integration tests.

### HACKY FIX for X012 (Goal)

The aim of this extension is to fix a single issue in the original `ElementNavFhirExtensions.Select`.
The issue happens when it's used together with some expression selecting property of type `Date`, and the
underlying value is, say, `"2020-12-10"`.

Root cause of this: it doesn't support `Hl7.Fhir.ElementModel.Types.Date` type (only `Hl7.Fhir.ElementModel.Types.DateTime` is originally supported).

Test failing: `X012_Goal`.

TODO: create PR in the original repo and fix it.

https://github.com/FirelyTeam/firely-net-sdk/pull/1575

### Print test results to stdout.

In case when tests are run manually, it doesn't attach annotations (because it makes it for changes only).
So the only way to see the test output is to download logs and open the `execute_all.log` file.

### Fixing XFER3

### Consent search by patient reference appears broken #329

Issue was caused by an exception saying that resolve() symbol is not supported in FhirPath.

Calling ElementNavFhirExtensions.PrepareFhirSymbolTableFunctions(); solved it.

### Mongo STU3 archive updated.

Command executed:

```
db.counters.update( { _id: "Location" }, { "last": NumberInt(1000) }, { "upsert": true } );
```

### Fix NullReferenceException in .NET Framework search implementation

Bug discovered by integration tests running against .NET Framework-driven server.