### PR TITLE
Fix issue in test output + fix annotations.

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -33,13 +33,13 @@ jobs:
         name: Combine test results
         if: ${{ always() }}
         run: cd tests/integration-tests && ./combine-test-results.sh json_results annotations.json
-#      - 
-#        name: Attach test results
-#        if: ${{ always() }}
-#        uses: yuzutech/annotations-action@v0.1.0
-#        with:
-#          repo-token: "${{ secrets.GITHUB_TOKEN }}"
-#          input: tests/integration-tests/annotations.json
+      - 
+        name: Attach test results
+        if: github.event_name != 'pull_request'
+        uses: yuzutech/annotations-action@v0.1.0
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          input: tests/integration-tests/annotations.json
       - 
         name: Archive logs
         if: ${{ always() }}

--- a/src/Spark.Engine/Extensions/HttpHeadersExtensions.cs
+++ b/src/Spark.Engine/Extensions/HttpHeadersExtensions.cs
@@ -100,7 +100,7 @@ namespace Spark.Engine.Extensions
         {
             var list = new List<Tuple<string, string>>();
             string content = request.Content.ReadAsStringAsync().Result;
-            string[] parameters = string.IsNullOrEmpty(content) ? null : content.Split('&');
+            string[] parameters = string.IsNullOrEmpty(content) ? new string[0] : content.Split('&');
             foreach (string parameter in parameters)
             {
                 string[] p = parameter.Split('=');

--- a/tests/integration-tests/.gitignore
+++ b/tests/integration-tests/.gitignore
@@ -1,0 +1,2 @@
+﻿json_results
+annotations.json


### PR DESCRIPTION
It was failing to calculate summary from files containing whitespace in their names (STU3 only).

Plus, don't output summary as a JSON, do just regular output instead like

PASS: ...
FAIL: ...

etc.

As for the annotations, I'm guessing they were failing to attach to the nonexisting file.
So now I'm trying to attach them to `.github/workflow/integration_tests.yml` and put the test
name into message instead of the file name. Leaving them for commit to `master` only.
This means, they will be visible to 3rd-party contributors in their forked repos,
but not in the automatic test run when creating PR.