### PR TITLE
Async interfaces.

### DIFF
--- a/src/Spark.Engine.Test/Service/IndexServiceTests.cs
+++ b/src/Spark.Engine.Test/Service/IndexServiceTests.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using static Hl7.Fhir.Model.ModelInfo;
+using Task = System.Threading.Tasks.Task;
 
 namespace Spark.Engine.Test.Service
 {
@@ -66,7 +67,7 @@ namespace Spark.Engine.Test.Service
         }
         
         [TestMethod]
-        public void TestIndexCustomSearchParameter()
+        public async Task TestIndexCustomSearchParameter()
         {
             var patient = new Patient();
             HumanName name = new HumanName().WithGiven("Adriaan").AndFamily("Bestevaer");
@@ -74,7 +75,7 @@ namespace Spark.Engine.Test.Service
             patient.Name.Add(name);
 
             IKey patientKey = new Key("http://localhost/", "Patient", "002", "1");
-            IndexValue result = _limitedIndexService.IndexResource(patient, patientKey);
+            IndexValue result = await _limitedIndexService.IndexResourceAsync(patient, patientKey);
 
             var middleName = result.NonInternalValues().Skip(1).First();
             Assert.AreEqual("middlename", middleName.Name);
@@ -84,14 +85,14 @@ namespace Spark.Engine.Test.Service
         }
 
         [TestMethod]
-        public void TestIndexResourceSimple()
+        public async Task TestIndexResourceSimple()
         {
             var patient = new Patient();
             patient.Name.Add(new HumanName().WithGiven("Adriaan").AndFamily("Bestevaer"));
 
             IKey patientKey = new Key("http://localhost/", "Patient", "001", "v02");
 
-            IndexValue result = _limitedIndexService.IndexResource(patient, patientKey);
+            IndexValue result = await _limitedIndexService.IndexResourceAsync(patient, patientKey);
 
             Assert.AreEqual("root", result.Name);
             Assert.AreEqual(1, result.NonInternalValues().Count(), "Expected 1 non-internal result for searchparameter 'name'");
@@ -103,67 +104,67 @@ namespace Spark.Engine.Test.Service
         }
 
         [TestMethod]
-        public void TestIndexResourcePatientComplete()
+        public async Task TestIndexResourcePatientComplete()
         {
             FhirJsonParser parser = new FhirJsonParser();
             var patientResource = parser.Parse<Resource>(_examplePatientJson);
 
             IKey patientKey = new Key("http://localhost/", "Patient", "001", null);
 
-            IndexValue result = _fullIndexService.IndexResource(patientResource, patientKey);
+            IndexValue result = await _fullIndexService.IndexResourceAsync(patientResource, patientKey);
 
             Assert.IsNotNull(result);
         }
 
         [TestMethod]
-        public void TestIndexResourceAppointmentComplete()
+        public async Task TestIndexResourceAppointmentComplete()
         {
             FhirJsonParser parser = new FhirJsonParser();
             var appResource = parser.Parse<Resource>(_exampleAppointmentJson);
 
             IKey appKey = new Key("http://localhost/", "Appointment", "2docs", null);
 
-            IndexValue result = _fullIndexService.IndexResource(appResource, appKey);
+            IndexValue result = await _fullIndexService.IndexResourceAsync(appResource, appKey);
 
             Assert.IsNotNull(result);
         }
 
         [TestMethod]
-        public void TestIndexResourceCareplanWithContainedGoal()
+        public async Task TestIndexResourceCareplanWithContainedGoal()
         {
             FhirJsonParser parser = new FhirJsonParser();
             var cpResource = parser.Parse<Resource>(_carePlanWithContainedGoal);
 
             IKey cpKey = new Key("http://localhost/", "Careplan", "f002", null);
 
-            IndexValue result = _fullIndexService.IndexResource(cpResource, cpKey);
+            IndexValue result = await _fullIndexService.IndexResourceAsync(cpResource, cpKey);
 
             Assert.IsNotNull(result);
         }
 
 
         [TestMethod]
-        public void TestIndexResourceObservation()
+        public async Task TestIndexResourceObservation()
         {
             FhirJsonParser parser = new FhirJsonParser();
             var obsResource = parser.Parse<Resource>(_exampleObservationJson);
 
             IKey cpKey = new Key("http://localhost/", "Observation", "blood-pressure", null);
 
-            IndexValue result = _fullIndexService.IndexResource(obsResource, cpKey);
+            IndexValue result = await _fullIndexService.IndexResourceAsync(obsResource, cpKey);
 
             Assert.IsNotNull(result);
         }
 
         [TestMethod]
-        public void TestMultiValueIndexCanIndexFhirDateTime()
+        public async Task TestMultiValueIndexCanIndexFhirDateTime()
         {
             Condition cd = new Condition();
             cd.Onset = new FhirDateTime(2015, 6, 15);
 
             IKey cdKey = new Key("http://localhost/", "Condition", "test", null);
 
-            IndexValue result = _fullIndexService.IndexResource(cd, cdKey);
+            IndexValue result = await _fullIndexService.IndexResourceAsync(cd, cdKey);
 
             Assert.IsNotNull(result);
             IndexValue onsetIndex = result.Values.Where(iv => (iv as IndexValue).Name == "onset-date").SingleOrDefault() as IndexValue;
@@ -171,7 +172,7 @@ namespace Spark.Engine.Test.Service
         }
 
         [TestMethod]
-        public void TestMultiValueIndexCanIndexFhirString()
+        public async Task TestMultiValueIndexCanIndexFhirString()
         {
             string onsetInfo = "approximately November 2012";
             Condition cd = new Condition
@@ -181,7 +182,7 @@ namespace Spark.Engine.Test.Service
 
             IKey cdKey = new Key("http://localhost/", "Condition", "test", null);
 
-            IndexValue result = _fullIndexService.IndexResource(cd, cdKey);
+            IndexValue result = await _fullIndexService.IndexResourceAsync(cd, cdKey);
 
             Assert.IsNotNull(result);
             IndexValue onsetIndex = result.Values.Where(iv => (iv as IndexValue).Name == "onset-info").SingleOrDefault() as IndexValue;
@@ -192,7 +193,7 @@ namespace Spark.Engine.Test.Service
         }
 
         [TestMethod]
-        public void TestMultiValueIndexCanIndexAge()
+        public async Task TestMultiValueIndexCanIndexAge()
         {
             decimal onsetAge = 73;
             Condition cd = new Condition
@@ -207,7 +208,7 @@ namespace Spark.Engine.Test.Service
 
             IKey cdKey = new Key("http://localhost/", "Condition", "test", null);
 
-            IndexValue result = _fullIndexService.IndexResource(cd, cdKey);
+            IndexValue result = await _fullIndexService.IndexResourceAsync(cd, cdKey);
 
             Assert.IsNotNull(result);
             IndexValue onsetIndex = result.Values.Where(iv => (iv as IndexValue).Name == "onset-age").Single() as IndexValue;

--- a/src/Spark.Engine/Core/IIndexService.cs
+++ b/src/Spark.Engine/Core/IIndexService.cs
@@ -1,11 +1,21 @@
-﻿using Hl7.Fhir.Model;
+﻿using System;
+using System.Threading.Tasks;
+using Hl7.Fhir.Model;
 using Spark.Engine.Model;
+using Task = System.Threading.Tasks.Task;
 
 namespace Spark.Engine.Core
 {
     public interface IIndexService
     {
+        [Obsolete("Use Async method version instead")]
         void Process(Entry entry);
+
+        [Obsolete("Use Async method version instead")]
         IndexValue IndexResource(Resource resource, IKey key);
+
+        Task ProcessAsync(Entry entry);
+
+        Task<IndexValue> IndexResourceAsync(Resource resource, IKey key);
     }
 }

--- a/src/Spark.Engine/Extensions/NetCore/IServiceCollectionExtensions.cs
+++ b/src/Spark.Engine/Extensions/NetCore/IServiceCollectionExtensions.cs
@@ -79,6 +79,7 @@ namespace Spark.Engine.Extensions
             services.TryAddSingleton((provder) => new FhirXmlSerializer(settings.SerializerSettings));
 
             services.TryAddSingleton<IFhirService, FhirService>();
+            services.TryAddSingleton<IAsyncFhirService, AsyncFhirService>();
 
             IMvcCoreBuilder builder = services.AddFhirFormatters(settings, setupAction);
 

--- a/src/Spark.Engine/Interfaces/IFhirIndex.cs
+++ b/src/Spark.Engine/Interfaces/IFhirIndex.cs
@@ -6,7 +6,9 @@
  * available at https://raw.github.com/furore-fhir/spark/master/LICENSE
  */
 
+using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Hl7.Fhir.Rest;
 using Spark.Engine.Core;
 
@@ -15,11 +17,24 @@ namespace Spark.Core
 
     public interface IFhirIndex
     {
+        [Obsolete("Use Async method version instead")]
         void Clean();
+
+        [Obsolete("Use Async method version instead")]
         SearchResults Search(string resource, SearchParams searchCommand);
+
+        [Obsolete("Use Async method version instead")]
         Key FindSingle(string resource, SearchParams searchCommand);
+
+        [Obsolete("Use Async method version instead")]
         SearchResults GetReverseIncludes(IList<IKey> keys, IList<string> revIncludes);
 
-    }
+        Task CleanAsync();
 
+        Task<SearchResults> SearchAsync(string resource, SearchParams searchCommand);
+
+        Task<Key> FindSingleAsync(string resource, SearchParams searchCommand);
+
+        Task<SearchResults> GetReverseIncludesAsync(IList<IKey> keys, IList<string> revIncludes);
+    }
 }

--- a/src/Spark.Engine/Interfaces/IFhirStoreFull.cs
+++ b/src/Spark.Engine/Interfaces/IFhirStoreFull.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Rest;
 using Spark.Engine.Core;
+using Task = System.Threading.Tasks.Task;
 
 namespace Spark.Engine.Interfaces
 {
@@ -40,7 +41,10 @@ namespace Spark.Engine.Interfaces
 
     public interface IFhirStoreAdministration
     {
+        [Obsolete("Use Async method version instead")]
         void Clean();
+
+        Task CleanAsync();
     }
 
 

--- a/src/Spark.Engine/Service/AsyncFhirService.cs
+++ b/src/Spark.Engine/Service/AsyncFhirService.cs
@@ -306,7 +306,7 @@ namespace Spark.Engine.Service
 
         public FhirResponse HandleInteraction(Entry interaction)
         {
-            return Task.Run(() => HandleInteractionAsync(interaction)).Result;
+            return Task.Run(() => HandleInteractionAsync(interaction)).GetAwaiter().GetResult();
         }
 
         public async Task<FhirResponse> HandleInteractionAsync(Entry interaction)

--- a/src/Spark.Engine/Service/AsyncFhirService.cs
+++ b/src/Spark.Engine/Service/AsyncFhirService.cs
@@ -1,0 +1,389 @@
+﻿using Hl7.Fhir.Model;
+using Hl7.Fhir.Rest;
+using Spark.Engine.Core;
+using Spark.Engine.FhirResponseFactory;
+using Spark.Engine.Service.FhirServiceExtensions;
+using Spark.Engine.Storage;
+using Spark.Service;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading.Tasks;
+using Spark.Core;
+using Spark.Engine.Extensions;
+using Task = System.Threading.Tasks.Task;
+
+namespace Spark.Engine.Service
+{
+    public class AsyncFhirService : ExtendableWith<IFhirServiceExtension>, IAsyncFhirService, IInteractionHandler
+    {
+        // CCR: FhirService now implements InteractionHandler that is used by the TransactionService to actually perform the operation. 
+        // This creates a circular reference that is solved by sending the handler on each call. 
+        // A future step might be to split that part into a different service (maybe StorageService?)
+
+        private readonly IFhirResponseFactory _responseFactory;
+        private readonly ITransfer _transfer;
+        private readonly ICompositeServiceListener _serviceListener;
+
+        public AsyncFhirService(
+            IFhirServiceExtension[] extensions,
+            IFhirResponseFactory responseFactory, // TODO: can we remove this dependency?
+            ITransfer transfer,
+            ICompositeServiceListener serviceListener = null) // TODO: can we remove this dependency? - CCR
+        {
+            _responseFactory = responseFactory ?? throw new ArgumentNullException(nameof(responseFactory));
+            _transfer = transfer ?? throw new ArgumentNullException(nameof(transfer));
+            _serviceListener = serviceListener ?? throw new ArgumentNullException(nameof(serviceListener));
+
+            foreach (var serviceExtension in extensions)
+            {
+                AddExtension(serviceExtension);
+            }
+        }
+
+        public async Task<FhirResponse> AddMetaAsync(IKey key, Parameters parameters)
+        {
+            var storageService = GetFeature<IResourceStorageService>();
+            var entry = await storageService.GetAsync(key).ConfigureAwait(false);
+            if (entry != null && !entry.IsDeleted())
+            {
+                entry.Resource.AffixTags(parameters);
+                await storageService.AddAsync(entry).ConfigureAwait(false);
+            }
+            return _responseFactory.GetMetadataResponse(entry, key);
+        }
+
+        public Task<FhirResponse> ConditionalCreateAsync(IKey key, Resource resource, IEnumerable<Tuple<string, string>> parameters)
+        {
+            return ConditionalCreateAsync(key, resource, SearchParams.FromUriParamList(parameters));
+        }
+
+        public async Task<FhirResponse> ConditionalCreateAsync(IKey key, Resource resource, SearchParams parameters)
+        {
+            var searchStore = GetFeature<ISearchService>();
+            var transactionService = GetFeature<ITransactionService>();
+            var operation = await ResourceManipulationOperationFactory.CreatePostAsync(resource, key, searchStore, parameters).ConfigureAwait(false);
+            return await transactionService.HandleTransactionAsync(operation, this).ConfigureAwait(false);
+        }
+
+        public async Task<FhirResponse> ConditionalDeleteAsync(IKey key, IEnumerable<Tuple<string, string>> parameters)
+        {
+            var searchStore = GetFeature<ISearchService>();
+            var transactionService = GetFeature<ITransactionService>();
+            var deleteOperation = await ResourceManipulationOperationFactory.CreateDeleteAsync(key, searchStore, SearchParams.FromUriParamList(parameters)).ConfigureAwait(false);
+            return await transactionService.HandleTransactionAsync(deleteOperation, this)
+                .ConfigureAwait(false) ?? Respond.WithCode(HttpStatusCode.NotFound);
+        }
+
+        public async Task<FhirResponse> ConditionalUpdateAsync(IKey key, Resource resource, SearchParams parameters)
+        {
+            var searchStore = GetFeature<ISearchService>();
+            var transactionService = GetFeature<ITransactionService>();
+
+            // FIXME: if update receives a key with no version how do we handle concurrency?
+
+            var operation = await ResourceManipulationOperationFactory.CreatePutAsync(resource, key, searchStore, parameters).ConfigureAwait(false);
+            return await transactionService.HandleTransactionAsync(operation, this).ConfigureAwait(false);
+        }
+
+        public Task<FhirResponse> CapabilityStatementAsync(string sparkVersion)
+        {
+            var capabilityStatementService = GetFeature<ICapabilityStatementService>();
+            var response = Respond.WithResource(capabilityStatementService.GetSparkCapabilityStatement(sparkVersion));
+            return Task.FromResult(response);
+        }
+
+        public async Task<FhirResponse> CreateAsync(IKey key, Resource resource)
+        {
+            Validate.Key(key);
+            Validate.HasTypeName(key);
+            Validate.ResourceType(key, resource);
+
+            key = key.CleanupForCreate();
+            var result = await StoreAsync(Entry.POST(key, resource)).ConfigureAwait(false);
+            return Respond.WithResource(HttpStatusCode.Created, result);
+        }
+
+        public async Task<FhirResponse> DeleteAsync(IKey key)
+        {
+            Validate.Key(key);
+            Validate.HasNoVersion(key);
+
+            var resourceStorage = GetFeature<IResourceStorageService>();
+
+            var current = await resourceStorage.GetAsync(key).ConfigureAwait(false);
+            if (current != null && current.IsPresent)
+            {
+                return await DeleteAsync(Entry.DELETE(key, DateTimeOffset.UtcNow)).ConfigureAwait(false);
+            }
+            return Respond.WithCode(HttpStatusCode.NoContent);
+        }
+
+        public async Task<FhirResponse> DeleteAsync(Entry entry)
+        {
+            Validate.Key(entry.Key);
+            await StoreAsync(entry).ConfigureAwait(false);
+            return Respond.WithCode(HttpStatusCode.NoContent);
+        }
+
+        public async Task<FhirResponse> GetPageAsync(string snapshotKey, int index)
+        {
+            var pagingExtension = GetFeature<IPagingService>();
+            var snapshot = await pagingExtension.StartPaginationAsync(snapshotKey).ConfigureAwait(false);
+            return _responseFactory.GetFhirResponse(await snapshot.GetPageAsync(index).ConfigureAwait(false));
+        }
+
+        public async Task<FhirResponse> HistoryAsync(HistoryParameters parameters)
+        {
+            var historyExtension = GetFeature<IHistoryService>();
+            var snapshot = await historyExtension.HistoryAsync(parameters).ConfigureAwait(false);
+            return await CreateSnapshotResponseAsync(snapshot).ConfigureAwait(false);
+        }
+
+        public async Task<FhirResponse> HistoryAsync(string type, HistoryParameters parameters)
+        {
+            var historyExtension = GetFeature<IHistoryService>();
+            var snapshot = await historyExtension.HistoryAsync(type, parameters).ConfigureAwait(false);
+            return await CreateSnapshotResponseAsync(snapshot).ConfigureAwait(false);
+        }
+
+        public async Task<FhirResponse> HistoryAsync(IKey key, HistoryParameters parameters)
+        {
+            var storageService = GetFeature<IResourceStorageService>();
+            if (await storageService.GetAsync(key).ConfigureAwait(false) == null)
+            {
+                return Respond.NotFound(key);
+            }
+            var historyExtension = GetFeature<IHistoryService>();
+            var snapshot = await historyExtension.HistoryAsync(key, parameters).ConfigureAwait(false);
+            return await CreateSnapshotResponseAsync(snapshot).ConfigureAwait(false);
+        }
+
+        public Task<FhirResponse> MailboxAsync(Bundle bundle, Binary body)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<FhirResponse> PutAsync(IKey key, Resource resource)
+        {
+            Validate.HasResourceId(resource);
+            Validate.IsResourceIdEqual(key, resource);
+            return PutAsync(Entry.PUT(key, resource));
+        }
+
+        public async Task<FhirResponse> PutAsync(Entry entry)
+        {
+            Validate.Key(entry.Key);
+            Validate.ResourceType(entry.Key, entry.Resource);
+            Validate.HasTypeName(entry.Key);
+            Validate.HasResourceId(entry.Key);
+
+            var storageService = GetFeature<IResourceStorageService>();
+            var current = await storageService.GetAsync(entry.Key.WithoutVersion()).ConfigureAwait(false);
+            var result = await StoreAsync(entry).ConfigureAwait(false);
+            return Respond.WithResource(current != null ? HttpStatusCode.OK : HttpStatusCode.Created, result);
+        }
+
+        public async Task<FhirResponse> ReadAsync(IKey key, ConditionalHeaderParameters parameters = null)
+        {
+            ValidateKey(key);
+            var entry = await GetFeature<IResourceStorageService>().GetAsync(key).ConfigureAwait(false);
+            return _responseFactory.GetFhirResponse(entry, key, parameters);
+        }
+
+        public async Task<FhirResponse> ReadMetaAsync(IKey key)
+        {
+            ValidateKey(key);
+            var entry = await GetFeature<IResourceStorageService>().GetAsync(key).ConfigureAwait(false);
+            return _responseFactory.GetMetadataResponse(entry, key);
+        }
+
+        public async Task<FhirResponse> SearchAsync(string type, SearchParams searchCommand, int pageIndex = 0)
+        {
+            var searchService = GetFeature<ISearchService>();
+            var snapshot = await searchService.GetSnapshotAsync(type, searchCommand).ConfigureAwait(false);
+            return await CreateSnapshotResponseAsync(snapshot, pageIndex).ConfigureAwait(false);
+        }
+
+        public async Task<FhirResponse> TransactionAsync(IList<Entry> interactions)
+        {
+            var transactionExtension = GetFeature<ITransactionService>();
+            var responses = await transactionExtension.HandleTransactionAsync(interactions, this).ConfigureAwait(false);
+            return _responseFactory.GetFhirResponse(responses, Bundle.BundleType.TransactionResponse);
+        }
+
+        public async Task<FhirResponse> TransactionAsync(Bundle bundle)
+        {
+            var transactionExtension = GetFeature<ITransactionService>();
+            var responses = await transactionExtension.HandleTransactionAsync(bundle, this).ConfigureAwait(false);
+            return _responseFactory.GetFhirResponse(responses, Bundle.BundleType.TransactionResponse);
+        }
+
+        public async Task<FhirResponse> UpdateAsync(IKey key, Resource resource)
+        {
+            return key.HasVersionId()
+                ? await VersionSpecificUpdateAsync(key, resource).ConfigureAwait(false)
+                : await PutAsync(key, resource).ConfigureAwait(false);
+        }
+
+        public Task<FhirResponse> ValidateOperationAsync(IKey key, Resource resource)
+        {
+            if (resource == null)
+            {
+                throw Error.BadRequest("Validate needs a Resource in the body payload");
+            }
+
+            Validate.ResourceType(key, resource);
+
+            var outcome = Validate.AgainstSchema(resource);
+            return Task.FromResult(outcome == null
+                ? Respond.WithCode(HttpStatusCode.OK)
+                : Respond.WithResource(422, outcome));
+        }
+
+        public async Task<FhirResponse> VersionReadAsync(IKey key)
+        {
+            ValidateKey(key, true);
+            var entry = await GetFeature<IResourceStorageService>().GetAsync(key).ConfigureAwait(false);
+            return _responseFactory.GetFhirResponse(entry, key);
+        }
+
+        public async Task<FhirResponse> VersionSpecificUpdateAsync(IKey versionedKey, Resource resource)
+        {
+            Validate.HasTypeName(versionedKey);
+            Validate.HasVersion(versionedKey);
+            var key = versionedKey.WithoutVersion();
+            var current = await GetFeature<IResourceStorageService>().GetAsync(key).ConfigureAwait(false);
+            Validate.IsSameVersion(current.Key, versionedKey);
+            return await PutAsync(key, resource).ConfigureAwait(false);
+        }
+
+        public async Task<FhirResponse> EverythingAsync(IKey key)
+        {
+            var searchService = GetFeature<ISearchService>();
+            var snapshot = await searchService.GetSnapshotForEverythingAsync(key).ConfigureAwait(false);
+            return await CreateSnapshotResponseAsync(snapshot).ConfigureAwait(false);
+        }
+
+        public async Task<FhirResponse> DocumentAsync(IKey key)
+        {
+            Validate.HasResourceType(key, ResourceType.Composition);
+
+            var searchCommand = new SearchParams();
+            searchCommand.Add("_id", key.ResourceId);
+            var includes = new List<string>()
+            {
+                "Composition:subject"
+                , "Composition:author"
+                , "Composition:attester" //Composition.attester.party
+                , "Composition:custodian"
+                , "Composition:eventdetail" //Composition.event.detail
+                , "Composition:encounter"
+                , "Composition:entry" //Composition.section.entry
+            };
+            foreach (var inc in includes)
+            {
+                searchCommand.Include.Add((inc, IncludeModifier.None));
+            }
+            return await SearchAsync(key.TypeName, searchCommand).ConfigureAwait(false);
+        }
+
+        private async Task<FhirResponse> CreateAsync(Entry entry)
+        {
+            Validate.Key(entry.Key);
+            Validate.HasTypeName(entry.Key);
+            Validate.ResourceType(entry.Key, entry.Resource);
+
+            if (entry.State != EntryState.Internal)
+            {
+                Validate.HasNoResourceId(entry.Key);
+                Validate.HasNoVersion(entry.Key);
+            }
+
+            var result = await StoreAsync(entry).ConfigureAwait(false);
+            return Respond.WithResource(HttpStatusCode.Created, result);
+        }
+
+        public FhirResponse HandleInteraction(Entry interaction)
+        {
+            return Task.Run(() => HandleInteractionAsync(interaction)).Result;
+        }
+
+        public async Task<FhirResponse> HandleInteractionAsync(Entry interaction)
+        {
+            switch (interaction.Method)
+            {
+                case Bundle.HTTPVerb.PUT:
+                    return await PutAsync(interaction).ConfigureAwait(false);
+                case Bundle.HTTPVerb.POST:
+                    return await CreateAsync(interaction).ConfigureAwait(false);
+                case Bundle.HTTPVerb.DELETE:
+                    var resourceStorage = GetFeature<IResourceStorageService>();
+                    var current = await resourceStorage.GetAsync(interaction.Key.WithoutVersion()).ConfigureAwait(false);
+                    if (current != null && current.IsPresent)
+                    {
+                        return await DeleteAsync(interaction).ConfigureAwait(false);
+                    }
+                    // FIXME: there's no way to distinguish between "successfully deleted"
+                    // and "resource not deleted because it doesn't exist" responses, all return NoContent.
+                    // Same with Delete method above.
+                    return Respond.WithCode(HttpStatusCode.NoContent);
+                case Bundle.HTTPVerb.GET:
+                    return await VersionReadAsync((Key)interaction.Key).ConfigureAwait(false);
+                default:
+                    return Respond.Success;
+            }
+        }
+
+        private static void ValidateKey(IKey key, bool withVersion = false)
+        {
+            Validate.HasTypeName(key);
+            Validate.HasResourceId(key);
+            if (withVersion)
+            {
+                Validate.HasVersion(key);
+            }
+            else
+            {
+                Validate.HasNoVersion(key);
+            }
+            Validate.Key(key);
+        }
+
+        private async Task<FhirResponse> CreateSnapshotResponseAsync(Snapshot snapshot, int pageIndex = 0)
+        {
+            var pagingExtension = FindExtension<IPagingService>();
+            if (pagingExtension == null)
+            {
+                var bundle = new Bundle
+                {
+                    Type = snapshot.Type,
+                    Total = snapshot.Count
+                };
+                var resourceStorage = FindExtension<IResourceStorageService>();
+                bundle.Append(await resourceStorage.GetAsync(snapshot.Keys).ConfigureAwait(false));
+                return _responseFactory.GetFhirResponse(bundle);
+            }
+            else
+            {
+                var pagination = await pagingExtension.StartPaginationAsync(snapshot).ConfigureAwait(false);
+                var bundle = await pagination.GetPageAsync(pageIndex).ConfigureAwait(false);
+                return _responseFactory.GetFhirResponse(bundle);
+            }
+        }
+
+        private T GetFeature<T>() where T : IFhirServiceExtension
+        {
+            return FindExtension<T>() ??
+                   throw new NotSupportedException($"Feature {typeof(T)} not supported");
+        }
+
+        internal async Task<Entry> StoreAsync(Entry entry)
+        {
+            var result = await GetFeature<IResourceStorageService>()
+                .AddAsync(entry).ConfigureAwait(false);
+            _serviceListener.Inform(entry);
+            return result;
+        }
+    }
+}

--- a/src/Spark.Engine/Service/FhirService.cs
+++ b/src/Spark.Engine/Service/FhirService.cs
@@ -20,137 +20,137 @@ namespace Spark.Engine.Service
 
         public FhirResponse Read(IKey key, ConditionalHeaderParameters parameters = null)
         {
-            return Task.Run(() => _asyncFhirService.ReadAsync(key, parameters)).Result;
+            return Task.Run(() => _asyncFhirService.ReadAsync(key, parameters)).GetAwaiter().GetResult();
         }
 
         public FhirResponse ReadMeta(IKey key)
         {
-            return Task.Run(() => _asyncFhirService.ReadMetaAsync(key)).Result;
+            return Task.Run(() => _asyncFhirService.ReadMetaAsync(key)).GetAwaiter().GetResult();
         }
 
         public FhirResponse AddMeta(IKey key, Parameters parameters)
         {
-            return Task.Run(() => _asyncFhirService.AddMetaAsync(key, parameters)).Result;
+            return Task.Run(() => _asyncFhirService.AddMetaAsync(key, parameters)).GetAwaiter().GetResult();
         }
 
         public FhirResponse VersionRead(IKey key)
         {
-            return Task.Run(() => _asyncFhirService.VersionReadAsync(key)).Result;
+            return Task.Run(() => _asyncFhirService.VersionReadAsync(key)).GetAwaiter().GetResult();
         }
 
         public FhirResponse Create(IKey key, Resource resource)
         {
-            return Task.Run(() => _asyncFhirService.CreateAsync(key, resource)).Result;
+            return Task.Run(() => _asyncFhirService.CreateAsync(key, resource)).GetAwaiter().GetResult();
         }
 
         public FhirResponse Put(Entry entry)
         {
-            return Task.Run(() => _asyncFhirService.PutAsync(entry)).Result;
+            return Task.Run(() => _asyncFhirService.PutAsync(entry)).GetAwaiter().GetResult();
         }
 
         public FhirResponse Put(IKey key, Resource resource)
         {
-            return Task.Run(() => _asyncFhirService.PutAsync(key, resource)).Result;
+            return Task.Run(() => _asyncFhirService.PutAsync(key, resource)).GetAwaiter().GetResult();
         }
 
         public FhirResponse ConditionalCreate(IKey key, Resource resource, IEnumerable<Tuple<string, string>> parameters)
         {
-            return Task.Run(() => _asyncFhirService.ConditionalCreateAsync(key, resource, parameters)).Result;
+            return Task.Run(() => _asyncFhirService.ConditionalCreateAsync(key, resource, parameters)).GetAwaiter().GetResult();
         }
 
         public FhirResponse ConditionalCreate(IKey key, Resource resource, SearchParams parameters)
         {
-            return Task.Run(() => _asyncFhirService.ConditionalCreateAsync(key, resource, parameters)).Result;
+            return Task.Run(() => _asyncFhirService.ConditionalCreateAsync(key, resource, parameters)).GetAwaiter().GetResult();
         }
 
         public FhirResponse Everything(IKey key)
         {
-            return Task.Run(() => _asyncFhirService.EverythingAsync(key)).Result;
+            return Task.Run(() => _asyncFhirService.EverythingAsync(key)).GetAwaiter().GetResult();
         }
 
         public FhirResponse Document(IKey key)
         {
-            return Task.Run(() => _asyncFhirService.DocumentAsync(key)).Result;
+            return Task.Run(() => _asyncFhirService.DocumentAsync(key)).GetAwaiter().GetResult();
         }
 
         public FhirResponse VersionSpecificUpdate(IKey versionedkey, Resource resource)
         {
-            return Task.Run(() => _asyncFhirService.VersionSpecificUpdateAsync(versionedkey, resource)).Result;
+            return Task.Run(() => _asyncFhirService.VersionSpecificUpdateAsync(versionedkey, resource)).GetAwaiter().GetResult();
         }
 
         public FhirResponse Update(IKey key, Resource resource)
         {
-            return Task.Run(() => _asyncFhirService.UpdateAsync(key, resource)).Result;
+            return Task.Run(() => _asyncFhirService.UpdateAsync(key, resource)).GetAwaiter().GetResult();
         }
 
         public FhirResponse ConditionalUpdate(IKey key, Resource resource, SearchParams @params)
         {
-            return Task.Run(() => _asyncFhirService.ConditionalUpdateAsync(key, resource, @params)).Result;
+            return Task.Run(() => _asyncFhirService.ConditionalUpdateAsync(key, resource, @params)).GetAwaiter().GetResult();
         }
 
         public FhirResponse Delete(IKey key)
         {
-            return Task.Run(() => _asyncFhirService.DeleteAsync(key)).Result;
+            return Task.Run(() => _asyncFhirService.DeleteAsync(key)).GetAwaiter().GetResult();
         }
 
         public FhirResponse Delete(Entry entry)
         {
-            return Task.Run(() => _asyncFhirService.DeleteAsync(entry)).Result;
+            return Task.Run(() => _asyncFhirService.DeleteAsync(entry)).GetAwaiter().GetResult();
         }
 
         public FhirResponse ConditionalDelete(IKey key, IEnumerable<Tuple<string, string>> parameters)
         {
-            return Task.Run(() => _asyncFhirService.ConditionalDeleteAsync(key, parameters)).Result;
+            return Task.Run(() => _asyncFhirService.ConditionalDeleteAsync(key, parameters)).GetAwaiter().GetResult();
         }
 
         public FhirResponse ValidateOperation(IKey key, Resource resource)
         {
-            return Task.Run(() => _asyncFhirService.ValidateOperationAsync(key, resource)).Result;
+            return Task.Run(() => _asyncFhirService.ValidateOperationAsync(key, resource)).GetAwaiter().GetResult();
         }
 
         public FhirResponse Search(string type, SearchParams searchCommand, int pageIndex = 0)
         {
-            return Task.Run(() => _asyncFhirService.SearchAsync(type, searchCommand, pageIndex)).Result;
+            return Task.Run(() => _asyncFhirService.SearchAsync(type, searchCommand, pageIndex)).GetAwaiter().GetResult();
         }
 
         public FhirResponse Transaction(IList<Entry> interactions)
         {
-            return Task.Run(() => _asyncFhirService.TransactionAsync(interactions)).Result;
+            return Task.Run(() => _asyncFhirService.TransactionAsync(interactions)).GetAwaiter().GetResult();
         }
 
         public FhirResponse Transaction(Bundle bundle)
         {
-            return Task.Run(() => _asyncFhirService.TransactionAsync(bundle)).Result;
+            return Task.Run(() => _asyncFhirService.TransactionAsync(bundle)).GetAwaiter().GetResult();
         }
 
         public FhirResponse History(HistoryParameters parameters)
         {
-            return Task.Run(() => _asyncFhirService.HistoryAsync(parameters)).Result;
+            return Task.Run(() => _asyncFhirService.HistoryAsync(parameters)).GetAwaiter().GetResult();
         }
 
         public FhirResponse History(string type, HistoryParameters parameters)
         {
-            return Task.Run(() => _asyncFhirService.HistoryAsync(type, parameters)).Result;
+            return Task.Run(() => _asyncFhirService.HistoryAsync(type, parameters)).GetAwaiter().GetResult();
         }
 
         public FhirResponse History(IKey key, HistoryParameters parameters)
         {
-            return Task.Run(() => _asyncFhirService.HistoryAsync(key, parameters)).Result;
+            return Task.Run(() => _asyncFhirService.HistoryAsync(key, parameters)).GetAwaiter().GetResult();
         }
 
         public FhirResponse Mailbox(Bundle bundle, Binary body)
         {
-            return Task.Run(() => _asyncFhirService.MailboxAsync(bundle, body)).Result;
+            return Task.Run(() => _asyncFhirService.MailboxAsync(bundle, body)).GetAwaiter().GetResult();
         }
 
         public FhirResponse CapabilityStatement(string sparkVersion)
         {
-            return Task.Run(() => _asyncFhirService.CapabilityStatementAsync(sparkVersion)).Result;
+            return Task.Run(() => _asyncFhirService.CapabilityStatementAsync(sparkVersion)).GetAwaiter().GetResult();
         }
 
         public FhirResponse GetPage(string snapshotkey, int index)
         {
-            return Task.Run(() => _asyncFhirService.GetPageAsync(snapshotkey, index)).Result;
+            return Task.Run(() => _asyncFhirService.GetPageAsync(snapshotkey, index)).GetAwaiter().GetResult();
         }
     }
 }

--- a/src/Spark.Engine/Service/FhirService.cs
+++ b/src/Spark.Engine/Service/FhirService.cs
@@ -1,422 +1,156 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net;
-using Hl7.Fhir.Model;
+﻿using Hl7.Fhir.Model;
 using Hl7.Fhir.Rest;
-using Spark.Core;
 using Spark.Engine.Core;
-using Spark.Engine.Extensions;
-using Spark.Engine.FhirResponseFactory;
-using Spark.Engine.Service.FhirServiceExtensions;
-using Spark.Engine.Storage;
 using Spark.Service;
+using System;
+using System.Collections.Generic;
+using Task = System.Threading.Tasks.Task;
 
 namespace Spark.Engine.Service
 {
-    public class FhirService : ExtendableWith<IFhirServiceExtension>, IFhirService, IInteractionHandler 
-        //CCCR: FhirService now implementents InteractionHandler that is used by the TransactionService to actually perform the operation. 
-        //This creates a circular reference that is solved by sending the handler on each call. 
-        //A future step might be to split that part into a different service (maybe StorageService?)
+    [Obsolete("Use AsyncFhirService instead")]
+    public class FhirService : IFhirService
     {
-        private readonly IFhirResponseFactory responseFactory;
-        private readonly ITransfer transfer;
-        private readonly ICompositeServiceListener serviceListener;
-        public FhirService(IFhirServiceExtension[] extensions, 
-            IFhirResponseFactory responseFactory, //TODO: can we remove this dependency?
-            ITransfer transfer,
-            ICompositeServiceListener serviceListener = null) //TODO: can we remove this dependency? - CCR
-        {
-            this.responseFactory = responseFactory;
-            this.transfer = transfer;
-            this.serviceListener = serviceListener;
+        private readonly IAsyncFhirService _asyncFhirService;
 
-            foreach (IFhirServiceExtension serviceExtension in extensions)
-            {
-                this.AddExtension(serviceExtension);
-            }
+        public FhirService(IAsyncFhirService asyncFhirService)
+        {
+            _asyncFhirService = asyncFhirService ?? throw new ArgumentNullException(nameof(asyncFhirService));
         }
 
         public FhirResponse Read(IKey key, ConditionalHeaderParameters parameters = null)
         {
-            ValidateKey(key);
-
-            Entry entry = GetFeature<IResourceStorageService>().Get(key);
-
-            return responseFactory.GetFhirResponse(entry, key, parameters);
+            return Task.Run(() => _asyncFhirService.ReadAsync(key, parameters)).Result;
         }
 
         public FhirResponse ReadMeta(IKey key)
         {
-            ValidateKey(key);
-
-            Entry entry = GetFeature<IResourceStorageService>().Get(key);
-
-            return responseFactory.GetMetadataResponse(entry, key);
+            return Task.Run(() => _asyncFhirService.ReadMetaAsync(key)).Result;
         }
 
         public FhirResponse AddMeta(IKey key, Parameters parameters)
         {
-            var storageService = GetFeature<IResourceStorageService>();
-            Entry entry = storageService.Get(key);
-
-            if (entry != null && entry.IsDeleted() == false)
-            {
-                entry.Resource.AffixTags(parameters);
-                storageService.Add(entry);
-            }
-
-            return responseFactory.GetMetadataResponse(entry, key);
+            return Task.Run(() => _asyncFhirService.AddMetaAsync(key, parameters)).Result;
         }
 
         public FhirResponse VersionRead(IKey key)
         {
-            ValidateKey(key, true);
-            Entry entry = GetFeature<IResourceStorageService>().Get(key);
-
-            return responseFactory.GetFhirResponse(entry, key);
+            return Task.Run(() => _asyncFhirService.VersionReadAsync(key)).Result;
         }
 
         public FhirResponse Create(IKey key, Resource resource)
         {
-            Validate.Key(key);
-            Validate.HasTypeName(key);
-            Validate.ResourceType(key, resource);
-
-            key = key.CleanupForCreate();
-            var result = Store(Entry.POST(key, resource));
-            return Respond.WithResource(HttpStatusCode.Created, result);
-        }
-
-        public FhirResponse Create(Entry entry)
-        {
-            Validate.Key(entry.Key);
-            Validate.HasTypeName(entry.Key);
-            Validate.ResourceType(entry.Key, entry.Resource);
-
-            if (entry.State != EntryState.Internal)
-            {
-                Validate.HasNoResourceId(entry.Key);
-                Validate.HasNoVersion(entry.Key);
-            }
-
-
-            Entry result = Store(entry);
-
-            return Respond.WithResource(HttpStatusCode.Created, result);
+            return Task.Run(() => _asyncFhirService.CreateAsync(key, resource)).Result;
         }
 
         public FhirResponse Put(Entry entry)
         {
-            Validate.Key(entry.Key);
-            Validate.ResourceType(entry.Key, entry.Resource);
-            Validate.HasTypeName(entry.Key);
-            Validate.HasResourceId(entry.Key);
-           
-
-            var storageService = GetFeature<IResourceStorageService>();
-            Entry current = storageService.Get(entry.Key.WithoutVersion());
-
-            Entry result = Store(entry);
-
-            return Respond.WithResource(current != null ? HttpStatusCode.OK : HttpStatusCode.Created, result);
-
+            return Task.Run(() => _asyncFhirService.PutAsync(entry)).Result;
         }
+
         public FhirResponse Put(IKey key, Resource resource)
         {
-            Validate.HasResourceId(resource);
-            Validate.IsResourceIdEqual(key, resource);
-            return Put(Entry.PUT(key, resource));
+            return Task.Run(() => _asyncFhirService.PutAsync(key, resource)).Result;
         }
 
         public FhirResponse ConditionalCreate(IKey key, Resource resource, IEnumerable<Tuple<string, string>> parameters)
         {
-            return ConditionalCreate(key, resource, SearchParams.FromUriParamList(parameters));
+            return Task.Run(() => _asyncFhirService.ConditionalCreateAsync(key, resource, parameters)).Result;
         }
 
         public FhirResponse ConditionalCreate(IKey key, Resource resource, SearchParams parameters)
         {
-            ISearchService searchStore = this.FindExtension<ISearchService>();
-            ITransactionService transactionService = this.FindExtension<ITransactionService>();
-            if (searchStore == null || transactionService == null)
-                throw new NotSupportedException("Operation not supported");
-
-            return transactionService.HandleTransaction(
-                    ResourceManipulationOperationFactory.CreatePost(resource, key, searchStore, parameters),
-                    this);
+            return Task.Run(() => _asyncFhirService.ConditionalCreateAsync(key, resource, parameters)).Result;
         }
 
         public FhirResponse Everything(IKey key)
         {
-            ISearchService searchService = this.GetFeature<ISearchService>();
-
-            Snapshot snapshot = searchService.GetSnapshotForEverything(key);
-
-            return CreateSnapshotResponse(snapshot);
+            return Task.Run(() => _asyncFhirService.EverythingAsync(key)).Result;
         }
 
         public FhirResponse Document(IKey key)
         {
-            Validate.HasResourceType(key, ResourceType.Composition);
-
-            var searchCommand = new SearchParams();
-            searchCommand.Add("_id", key.ResourceId);
-            var includes = new List<string>()
-            {
-                "Composition:subject"
-                , "Composition:author"
-                , "Composition:attester" //Composition.attester.party
-                , "Composition:custodian"
-                , "Composition:eventdetail" //Composition.event.detail
-                , "Composition:encounter"
-                , "Composition:entry" //Composition.section.entry
-            };
-            foreach (var inc in includes)
-            {
-                searchCommand.Include.Add((inc, IncludeModifier.None));
-            }
-            return Search(key.TypeName, searchCommand);
+            return Task.Run(() => _asyncFhirService.DocumentAsync(key)).Result;
         }
 
         public FhirResponse VersionSpecificUpdate(IKey versionedkey, Resource resource)
         {
-            Validate.HasTypeName(versionedkey);
-            Validate.HasVersion(versionedkey);
-            Key key = versionedkey.WithoutVersion();
-            Entry current = GetFeature<IResourceStorageService>().Get(key);
-            Validate.IsSameVersion(current.Key, versionedkey);
-
-            return this.Put(key, resource);
+            return Task.Run(() => _asyncFhirService.VersionSpecificUpdateAsync(versionedkey, resource)).Result;
         }
 
         public FhirResponse Update(IKey key, Resource resource)
         {
-            return key.HasVersionId() ? this.VersionSpecificUpdate(key, resource)
-                : this.Put(key, resource);
+            return Task.Run(() => _asyncFhirService.UpdateAsync(key, resource)).Result;
         }
 
-        public FhirResponse ConditionalUpdate(IKey key, Resource resource, IEnumerable<Tuple<string, string>> parameters)
+        public FhirResponse ConditionalUpdate(IKey key, Resource resource, SearchParams @params)
         {
-            return ConditionalUpdate(key, resource, SearchParams.FromUriParamList(parameters));
-        }
-
-        public FhirResponse ConditionalUpdate(IKey key, Resource resource, SearchParams _params)
-        {
-            //if update receives a key with no version how do we handle concurrency?
-            ISearchService searchStore = this.FindExtension<ISearchService>();
-            ITransactionService transactionService = this.FindExtension<ITransactionService>();
-            if (searchStore == null || transactionService == null)
-                throw new NotSupportedException("Operation not supported");
-            return transactionService.HandleTransaction(
-                ResourceManipulationOperationFactory.CreatePut(resource, key, searchStore, _params),
-                this);
+            return Task.Run(() => _asyncFhirService.ConditionalUpdateAsync(key, resource, @params)).Result;
         }
 
         public FhirResponse Delete(IKey key)
         {
-            Validate.Key(key);
-            Validate.HasNoVersion(key);
-
-            var resourceStorage = GetFeature<IResourceStorageService>();
-
-            Entry current = resourceStorage.Get(key);
-            if (current != null && current.IsPresent)
-            {
-                return Delete(Entry.DELETE(key, DateTimeOffset.UtcNow));
-            }
-            return Respond.WithCode(HttpStatusCode.NoContent);
-
+            return Task.Run(() => _asyncFhirService.DeleteAsync(key)).Result;
         }
 
         public FhirResponse Delete(Entry entry)
         {
-            Validate.Key(entry.Key);
-            Store(entry);
-            return Respond.WithCode(HttpStatusCode.NoContent);
+            return Task.Run(() => _asyncFhirService.DeleteAsync(entry)).Result;
         }
 
         public FhirResponse ConditionalDelete(IKey key, IEnumerable<Tuple<string, string>> parameters)
         {
-            return ConditionalDelete(key, SearchParams.FromUriParamList(parameters));
-        }
-
-        public FhirResponse ConditionalDelete(IKey key, SearchParams _params)
-        {
-            ISearchService searchStore = this.FindExtension<ISearchService>();
-            ITransactionService transactionService = this.FindExtension<ITransactionService>();
-            if (searchStore == null || transactionService == null)
-                throw new NotSupportedException("Operation not supported");
-
-            return transactionService.HandleTransaction(ResourceManipulationOperationFactory.CreateDelete(key, searchStore, _params),
-                this)??  Respond.WithCode(HttpStatusCode.NotFound);
+            return Task.Run(() => _asyncFhirService.ConditionalDeleteAsync(key, parameters)).Result;
         }
 
         public FhirResponse ValidateOperation(IKey key, Resource resource)
         {
-            if (resource == null) throw Error.BadRequest("Validate needs a Resource in the body payload");
-            Validate.ResourceType(key, resource);
-
-            // DSTU2: validation
-            var outcome = Validate.AgainstSchema(resource);
-
-            if (outcome == null)
-                return Respond.WithCode(HttpStatusCode.OK);
-            else
-                return Respond.WithResource(422, outcome);
+            return Task.Run(() => _asyncFhirService.ValidateOperationAsync(key, resource)).Result;
         }
 
         public FhirResponse Search(string type, SearchParams searchCommand, int pageIndex = 0)
         {
-            ISearchService searchService = this.GetFeature<ISearchService>();
-
-            Snapshot snapshot = searchService.GetSnapshot(type, searchCommand);
-
-            return CreateSnapshotResponse(snapshot, pageIndex);
-        }
-
-        private FhirResponse CreateSnapshotResponse(Snapshot snapshot, int pageIndex = 0)
-        {
-            IPagingService pagingExtension = this.FindExtension<IPagingService>();
-            IResourceStorageService resourceStorage = this.FindExtension<IResourceStorageService>();
-            if (pagingExtension == null)
-            {
-                Bundle bundle = new Bundle()
-                {
-                    Type = snapshot.Type,
-                    Total = snapshot.Count
-                };
-                bundle.Append(resourceStorage.Get(snapshot.Keys));
-                return responseFactory.GetFhirResponse(bundle);
-            }
-            else
-            {
-                Bundle bundle = pagingExtension.StartPagination(snapshot).GetPage(pageIndex);
-                return responseFactory.GetFhirResponse(bundle);
-            }
+            return Task.Run(() => _asyncFhirService.SearchAsync(type, searchCommand, pageIndex)).Result;
         }
 
         public FhirResponse Transaction(IList<Entry> interactions)
         {
-            ITransactionService transactionExtension = this.GetFeature<ITransactionService>();
-            return responseFactory.GetFhirResponse(
-                transactionExtension.HandleTransaction(interactions, this), 
-                Bundle.BundleType.TransactionResponse);
+            return Task.Run(() => _asyncFhirService.TransactionAsync(interactions)).Result;
         }
 
         public FhirResponse Transaction(Bundle bundle)
         {
-            ITransactionService transactionExtension = this.GetFeature<ITransactionService>();
-            return responseFactory.GetFhirResponse(
-                transactionExtension.HandleTransaction(bundle, this), 
-                Bundle.BundleType.TransactionResponse);
+            return Task.Run(() => _asyncFhirService.TransactionAsync(bundle)).Result;
         }
 
         public FhirResponse History(HistoryParameters parameters)
         {
-            IHistoryService historyExtension = this.GetFeature<IHistoryService>();
-        
-            return CreateSnapshotResponse(historyExtension.History(parameters));
+            return Task.Run(() => _asyncFhirService.HistoryAsync(parameters)).Result;
         }
 
         public FhirResponse History(string type, HistoryParameters parameters)
         {
-            IHistoryService historyExtension = this.GetFeature<IHistoryService>();
-
-            return CreateSnapshotResponse(historyExtension.History(type, parameters));
+            return Task.Run(() => _asyncFhirService.HistoryAsync(type, parameters)).Result;
         }
 
         public FhirResponse History(IKey key, HistoryParameters parameters)
         {
-            IResourceStorageService storageService = GetFeature<IResourceStorageService>();
-            if (storageService.Get(key) == null)
-            {
-                return Respond.NotFound(key);
-            }
-            IHistoryService historyExtension = this.GetFeature<IHistoryService>();
-
-            return CreateSnapshotResponse(historyExtension.History(key, parameters));
+            return Task.Run(() => _asyncFhirService.HistoryAsync(key, parameters)).Result;
         }
 
         public FhirResponse Mailbox(Bundle bundle, Binary body)
         {
-            throw new NotImplementedException();
+            return Task.Run(() => _asyncFhirService.MailboxAsync(bundle, body)).Result;
         }
 
         public FhirResponse CapabilityStatement(string sparkVersion)
         {
-            ICapabilityStatementService capabilityStatementService = this.GetFeature<ICapabilityStatementService>();
-
-            return Respond.WithResource(capabilityStatementService.GetSparkCapabilityStatement(sparkVersion));
+            return Task.Run(() => _asyncFhirService.CapabilityStatementAsync(sparkVersion)).Result;
         }
 
         public FhirResponse GetPage(string snapshotkey, int index)
         {
-            IPagingService pagingExtension = this.FindExtension<IPagingService>();
-            if (pagingExtension == null)
-                throw new NotSupportedException("Operation not supported");
-
-            return responseFactory.GetFhirResponse(pagingExtension.StartPagination(snapshotkey).GetPage(index));
-        }
-
-        public FhirResponse HandleInteraction(Entry interaction)
-        {
-            switch (interaction.Method)
-            {
-                case Bundle.HTTPVerb.PUT:
-                    return this.Put(interaction);
-                case Bundle.HTTPVerb.POST:
-                    return this.Create(interaction);
-                case Bundle.HTTPVerb.DELETE:
-                    var resourceStorage = GetFeature<IResourceStorageService>();
-                    var current = resourceStorage.Get(interaction.Key.WithoutVersion());
-                    if (current != null && current.IsPresent)
-                    {
-                        return this.Delete(interaction);
-                    }
-                    // FIXME: there's no way to distinguish between "successfully deleted"
-                    // and "resource not deleted because it doesn't exist" responses, all return NoContent.
-                    // Same with Delete method above.
-                    return Respond.WithCode(HttpStatusCode.NoContent);
-                case Bundle.HTTPVerb.GET:
-                    return this.VersionRead((Key)interaction.Key);
-                default:
-                    return Respond.Success;
-            }
-        }
-
-        private static void ValidateKey(IKey key, bool withVersion = false)
-        {
-            Validate.HasTypeName(key);
-            Validate.HasResourceId(key);
-            if (withVersion)
-            {
-                Validate.HasVersion(key);
-            }
-            else
-            {
-                Validate.HasNoVersion(key);
-            }
-            Validate.Key(key);
-        }
-
-        private T GetFeature<T>() where T: IFhirServiceExtension
-        {
-            //TODO: return 501 - 	Requested HTTP operation not supported?
-
-            T feature = this.FindExtension<T>();
-            if (feature == null)
-                throw new NotSupportedException("Operation not supported");
-
-            return feature;
-        }
-
-        internal Entry Store(Entry entry)
-        {
-            Entry result = GetFeature<IResourceStorageService>()
-             .Add(entry);
-            serviceListener.Inform(entry);
-            return result;
+            return Task.Run(() => _asyncFhirService.GetPageAsync(snapshotkey, index)).Result;
         }
     }
 }

--- a/src/Spark.Engine/Service/FhirServiceExtensions/HistoryService.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/HistoryService.cs
@@ -1,4 +1,6 @@
-﻿using Spark.Engine.Core;
+﻿using System;
+using System.Threading.Tasks;
+using Spark.Engine.Core;
 using Spark.Engine.Store.Interfaces;
 
 namespace Spark.Engine.Service.FhirServiceExtensions
@@ -12,21 +14,39 @@ namespace Spark.Engine.Service.FhirServiceExtensions
             this.historyStore = historyStore;
         }
 
+        [Obsolete("Use Async method version instead")]
         public Snapshot History(string typename, HistoryParameters parameters)
         {
-            return historyStore.History(typename, parameters);
+            return Task.Run(() => HistoryAsync(typename, parameters)).Result;
         }
 
+        [Obsolete("Use Async method version instead")]
         public Snapshot History(IKey key, HistoryParameters parameters)
         {
-            
-            return historyStore.History(key, parameters);
+            return Task.Run(() => HistoryAsync(key, parameters)).Result;
         }
 
+        [Obsolete("Use Async method version instead")]
         public Snapshot History(HistoryParameters parameters)
         {
-            return historyStore.History(parameters);
+            return Task.Run(() => HistoryAsync(parameters)).Result;
         }
-      
+
+        public async Task<Snapshot> HistoryAsync(string typename, HistoryParameters parameters)
+        {
+            return await historyStore.HistoryAsync(typename, parameters).ConfigureAwait(false);
+        }
+
+        public async Task<Snapshot> HistoryAsync(IKey key, HistoryParameters parameters)
+        {
+
+            return await historyStore.HistoryAsync(key, parameters).ConfigureAwait(false);
+        }
+
+        public async Task<Snapshot> HistoryAsync(HistoryParameters parameters)
+        {
+            return await historyStore.HistoryAsync(parameters).ConfigureAwait(false);
+        }
+
     }
 }

--- a/src/Spark.Engine/Service/FhirServiceExtensions/HistoryService.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/HistoryService.cs
@@ -17,19 +17,19 @@ namespace Spark.Engine.Service.FhirServiceExtensions
         [Obsolete("Use Async method version instead")]
         public Snapshot History(string typename, HistoryParameters parameters)
         {
-            return Task.Run(() => HistoryAsync(typename, parameters)).Result;
+            return Task.Run(() => HistoryAsync(typename, parameters)).GetAwaiter().GetResult();
         }
 
         [Obsolete("Use Async method version instead")]
         public Snapshot History(IKey key, HistoryParameters parameters)
         {
-            return Task.Run(() => HistoryAsync(key, parameters)).Result;
+            return Task.Run(() => HistoryAsync(key, parameters)).GetAwaiter().GetResult();
         }
 
         [Obsolete("Use Async method version instead")]
         public Snapshot History(HistoryParameters parameters)
         {
-            return Task.Run(() => HistoryAsync(parameters)).Result;
+            return Task.Run(() => HistoryAsync(parameters)).GetAwaiter().GetResult();
         }
 
         public async Task<Snapshot> HistoryAsync(string typename, HistoryParameters parameters)

--- a/src/Spark.Engine/Service/FhirServiceExtensions/IHistoryService.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/IHistoryService.cs
@@ -1,11 +1,24 @@
-﻿using Spark.Engine.Core;
+﻿using System;
+using System.Threading.Tasks;
+using Spark.Engine.Core;
 
 namespace Spark.Engine.Service.FhirServiceExtensions
 {
     internal interface IHistoryService : IFhirServiceExtension
     {
+        [Obsolete("Use Async method version instead")]
         Snapshot History(string typename, HistoryParameters parameters);
+
+        [Obsolete("Use Async method version instead")]
         Snapshot History(IKey key, HistoryParameters parameters);
+
+        [Obsolete("Use Async method version instead")]
         Snapshot History(HistoryParameters parameters);
+
+        Task<Snapshot> HistoryAsync(string typename, HistoryParameters parameters);
+
+        Task<Snapshot> HistoryAsync(IKey key, HistoryParameters parameters);
+
+        Task<Snapshot> HistoryAsync(HistoryParameters parameters);
     }
 }

--- a/src/Spark.Engine/Service/FhirServiceExtensions/IPagingService.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/IPagingService.cs
@@ -1,6 +1,5 @@
-﻿using Hl7.Fhir.Model;
+﻿using System.Threading.Tasks;
 using Spark.Engine.Core;
-using Spark.Engine.Extensions;
 
 namespace Spark.Engine.Service.FhirServiceExtensions
 {
@@ -8,5 +7,8 @@ namespace Spark.Engine.Service.FhirServiceExtensions
     {
         ISnapshotPagination StartPagination(Snapshot snapshot);
         ISnapshotPagination StartPagination(string snapshotkey);
+
+        Task<ISnapshotPagination> StartPaginationAsync(Snapshot snapshot);
+        Task<ISnapshotPagination> StartPaginationAsync(string snapshotKey);
     }
 }

--- a/src/Spark.Engine/Service/FhirServiceExtensions/IResourceStorageService.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/IResourceStorageService.cs
@@ -1,12 +1,25 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using Spark.Engine.Core;
 
 namespace Spark.Engine.Service.FhirServiceExtensions
 {
     public interface IResourceStorageService : IFhirServiceExtension
     {
+        [Obsolete("Use Async method version instead")]
         Entry Get(IKey key);
+
+        [Obsolete("Use Async method version instead")]
         Entry Add(Entry entry);
+
+        [Obsolete("Use Async method version instead")]
         IList<Entry> Get(IEnumerable<string> localIdentifiers, string sortby = null);
+
+        Task<Entry> GetAsync(IKey key);
+
+        Task<Entry> AddAsync(Entry entry);
+
+        Task<IList<Entry>> GetAsync(IEnumerable<string> localIdentifiers, string sortby = null);
     }
 }

--- a/src/Spark.Engine/Service/FhirServiceExtensions/ISearchService.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/ISearchService.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Threading.Tasks;
 using Hl7.Fhir.Rest;
 using Spark.Engine.Core;
 
@@ -5,11 +7,29 @@ namespace Spark.Engine.Service.FhirServiceExtensions
 {
     public interface ISearchService : IFhirServiceExtension
     {
+        [Obsolete("Use Async method version instead")]
         Snapshot GetSnapshot(string type, SearchParams searchCommand);
+
+        [Obsolete("Use Async method version instead")]
         Snapshot GetSnapshotForEverything(IKey key);
+
+        [Obsolete("Use Async method version instead")]
         IKey FindSingle(string type, SearchParams searchCommand);
 
+        [Obsolete("Use Async method version instead")]
         IKey FindSingleOrDefault(string type, SearchParams searchCommand);
+
+        [Obsolete("Use Async method version instead")]
         SearchResults GetSearchResults(string type, SearchParams searchCommand);
+
+        Task<Snapshot> GetSnapshotAsync(string type, SearchParams searchCommand);
+
+        Task<Snapshot> GetSnapshotForEverythingAsync(IKey key);
+
+        Task<IKey> FindSingleAsync(string type, SearchParams searchCommand);
+
+        Task<IKey> FindSingleOrDefaultAsync(string type, SearchParams searchCommand);
+
+        Task<SearchResults> GetSearchResultsAsync(string type, SearchParams searchCommand);
     }
 }

--- a/src/Spark.Engine/Service/FhirServiceExtensions/ISnapshotPagination.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/ISnapshotPagination.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using Hl7.Fhir.Model;
 using Spark.Engine.Core;
 
@@ -6,6 +7,9 @@ namespace Spark.Engine.Service.FhirServiceExtensions
 {
     public interface ISnapshotPagination
     {
+        [Obsolete("Use Async method version instead")]
         Bundle GetPage(int? index = null, Action<Entry> transformElement = null);
+
+        Task<Bundle> GetPageAsync(int? index = null, Action<Entry> transformElement = null);
     }
 }

--- a/src/Spark.Engine/Service/FhirServiceExtensions/ITransactionService.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/ITransactionService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Hl7.Fhir.Model;
 using Spark.Engine.Core;
 
@@ -7,8 +8,19 @@ namespace Spark.Engine.Service.FhirServiceExtensions
 {
     public interface ITransactionService : IFhirServiceExtension
     {
+        [Obsolete("Use Async method version instead")]
         FhirResponse HandleTransaction(ResourceManipulationOperation operation, IInteractionHandler interactionHandler);
+
+        [Obsolete("Use Async method version instead")]
         IList<Tuple<Entry, FhirResponse>> HandleTransaction(Bundle bundle, IInteractionHandler interactionHandler);
+
+        [Obsolete("Use Async method version instead")]
         IList<Tuple<Entry, FhirResponse>> HandleTransaction(IList<Entry> interactions, IInteractionHandler interactionHandler);
+
+        Task<FhirResponse> HandleTransactionAsync(ResourceManipulationOperation operation, IInteractionHandler interactionHandler);
+
+        Task<IList<Tuple<Entry, FhirResponse>>> HandleTransactionAsync(Bundle bundle, IInteractionHandler interactionHandler);
+
+        Task<IList<Tuple<Entry, FhirResponse>>> HandleTransactionAsync(IList<Entry> interactions, IInteractionHandler interactionHandler);
     }
 }

--- a/src/Spark.Engine/Service/FhirServiceExtensions/IndexRebuildService.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/IndexRebuildService.cs
@@ -38,7 +38,7 @@ namespace Spark.Engine.Service.FhirServiceExtensions
                 if (indexSettings.ClearIndexOnRebuild)
                 {
                     await progress.CleanStartedAsync().ConfigureAwait(false);
-                    _indexStore.Clean();
+                    await _indexStore.CleanAsync().ConfigureAwait(false);
                     await progress.CleanCompletedAsync().ConfigureAwait(false);
                 }
 
@@ -54,10 +54,9 @@ namespace Spark.Engine.Service.FhirServiceExtensions
                     foreach (var entry in entries)
                     {
                         // TODO: use BulkWrite operation for this
-                        // TODO: use async API
                         try
                         {
-                            _indexService.Process(entry);
+                            await _indexService.ProcessAsync(entry).ConfigureAwait(false);
                         }
                         catch (Exception)
                         {

--- a/src/Spark.Engine/Service/FhirServiceExtensions/IndexService.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/IndexService.cs
@@ -31,13 +31,13 @@ namespace Spark.Engine.Service.FhirServiceExtensions
         [Obsolete("Use Async method version instead")]
         public void Process(Entry entry)
         {
-            Task.Run(() => ProcessAsync(entry)).Wait();
+            Task.Run(() => ProcessAsync(entry)).GetAwaiter().GetResult();
         }
 
         [Obsolete("Use Async method version instead")]
         public IndexValue IndexResource(Resource resource, IKey key)
         {
-            return Task.Run(() => IndexResourceAsync(resource, key)).Result;
+            return Task.Run(() => IndexResourceAsync(resource, key)).GetAwaiter().GetResult();
         }
 
         public async Task ProcessAsync(Entry entry)

--- a/src/Spark.Engine/Service/FhirServiceExtensions/IndexService.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/IndexService.cs
@@ -10,7 +10,8 @@ using Spark.Search;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Spark.Engine;
+using System.Threading.Tasks;
+using Task = System.Threading.Tasks.Task;
 
 namespace Spark.Engine.Service.FhirServiceExtensions
 {
@@ -27,27 +28,39 @@ namespace Spark.Engine.Service.FhirServiceExtensions
             _elementIndexer = elementIndexer;
         }
 
+        [Obsolete("Use Async method version instead")]
         public void Process(Entry entry)
+        {
+            Task.Run(() => ProcessAsync(entry)).Wait();
+        }
+
+        [Obsolete("Use Async method version instead")]
+        public IndexValue IndexResource(Resource resource, IKey key)
+        {
+            return Task.Run(() => IndexResourceAsync(resource, key)).Result;
+        }
+
+        public async Task ProcessAsync(Entry entry)
         {
             if (entry.HasResource())
             {
-                IndexResource(entry.Resource, entry.Key);
+                await IndexResourceAsync(entry.Resource, entry.Key).ConfigureAwait(false);
             }
             else
             {
                 if (entry.IsDeleted())
                 {
-                    _indexStore.Delete(entry);
+                    await _indexStore.DeleteAsync(entry).ConfigureAwait(false);
                 }
                 else throw new Exception("Entry is neither resource nor deleted");
             }
         }
 
-        public IndexValue IndexResource(Resource resource, IKey key)
+        public async Task<IndexValue> IndexResourceAsync(Resource resource, IKey key)
         {
             Resource resourceToIndex = MakeContainedReferencesUnique(resource);
             IndexValue indexValue = IndexResourceRecursively(resourceToIndex, key);
-            _indexStore.Save(indexValue);
+            await _indexStore.SaveAsync(indexValue).ConfigureAwait(false);
             return indexValue;
         }
 

--- a/src/Spark.Engine/Service/FhirServiceExtensions/InteractionHandler.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/InteractionHandler.cs
@@ -1,9 +1,14 @@
-﻿using Spark.Engine.Core;
+﻿using System;
+using System.Threading.Tasks;
+using Spark.Engine.Core;
 
 namespace Spark.Engine.Service.FhirServiceExtensions
 {
     public interface IInteractionHandler
     {
+        [Obsolete("Use Async method version instead")]
         FhirResponse HandleInteraction(Entry interaction);
+
+        Task<FhirResponse> HandleInteractionAsync(Entry interaction);
     }
 }

--- a/src/Spark.Engine/Service/FhirServiceExtensions/PagingService.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/PagingService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Spark.Engine.Core;
 using Spark.Engine.Store.Interfaces;
 
@@ -17,9 +18,19 @@ namespace Spark.Engine.Service.FhirServiceExtensions
 
         public ISnapshotPagination StartPagination(Snapshot snapshot)
         {
+            return Task.Run(() => StartPaginationAsync(snapshot)).Result;
+        }
+
+        public ISnapshotPagination StartPagination(string snapshotkey)
+        {
+            return Task.Run(() => StartPaginationAsync(snapshotkey)).Result;
+        }
+
+        public async Task<ISnapshotPagination> StartPaginationAsync(Snapshot snapshot)
+        {
             if (_snapshotstore != null)
             {
-                _snapshotstore.AddSnapshot(snapshot);
+                await _snapshotstore.AddSnapshotAsync(snapshot).ConfigureAwait(false);
             }
             else
             {
@@ -28,13 +39,13 @@ namespace Spark.Engine.Service.FhirServiceExtensions
 
             return _paginationProvider.StartPagination(snapshot);
         }
-        public ISnapshotPagination StartPagination(string snapshotkey)
+        public async Task<ISnapshotPagination> StartPaginationAsync(string snapshotkey)
         {
             if (_snapshotstore == null)
             {
                 throw new NotSupportedException("Stateful pagination is not currently supported.");
             }
-            return _paginationProvider.StartPagination(_snapshotstore.GetSnapshot(snapshotkey));
+            return _paginationProvider.StartPagination(await _snapshotstore.GetSnapshotAsync(snapshotkey).ConfigureAwait(false));
         }
     }
 }

--- a/src/Spark.Engine/Service/FhirServiceExtensions/PagingService.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/PagingService.cs
@@ -18,12 +18,12 @@ namespace Spark.Engine.Service.FhirServiceExtensions
 
         public ISnapshotPagination StartPagination(Snapshot snapshot)
         {
-            return Task.Run(() => StartPaginationAsync(snapshot)).Result;
+            return Task.Run(() => StartPaginationAsync(snapshot)).GetAwaiter().GetResult();
         }
 
         public ISnapshotPagination StartPagination(string snapshotkey)
         {
-            return Task.Run(() => StartPaginationAsync(snapshotkey)).Result;
+            return Task.Run(() => StartPaginationAsync(snapshotkey)).GetAwaiter().GetResult();
         }
 
         public async Task<ISnapshotPagination> StartPaginationAsync(Snapshot snapshot)

--- a/src/Spark.Engine/Service/FhirServiceExtensions/ResourceManipulationOperationFactory.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/ResourceManipulationOperationFactory.cs
@@ -3,67 +3,103 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
 using System.Net.Http;
+using System.Threading.Tasks;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Rest;
 using Spark.Engine.Core;
 using Spark.Engine.Extensions;
+using Task = System.Threading.Tasks.Task;
 
 namespace Spark.Engine.Service.FhirServiceExtensions
 {
     public static partial class ResourceManipulationOperationFactory
     {
-        private static Dictionary<Bundle.HTTPVerb, Func<Resource, IKey, ISearchService, SearchParams, ResourceManipulationOperation>> builders;
+        private static Dictionary<Bundle.HTTPVerb, Func<Resource, IKey, ISearchService, SearchParams, Task<ResourceManipulationOperation>>> builders;
         private static ISearchService searchService;
 
         static ResourceManipulationOperationFactory()
         {
-            builders = new Dictionary<Bundle.HTTPVerb, Func<Resource, IKey, ISearchService, SearchParams, ResourceManipulationOperation>>();
-            builders.Add(Bundle.HTTPVerb.POST, CreatePost);
-            builders.Add(Bundle.HTTPVerb.PUT, CreatePut);
-            builders.Add(Bundle.HTTPVerb.DELETE, CreateDelete);
+            builders = new Dictionary<Bundle.HTTPVerb, Func<Resource, IKey, ISearchService, SearchParams, Task<ResourceManipulationOperation>>>();
+            builders.Add(Bundle.HTTPVerb.POST, CreatePostAsync);
+            builders.Add(Bundle.HTTPVerb.PUT, CreatePutAsync);
+            builders.Add(Bundle.HTTPVerb.DELETE, CreateDeleteAsync);
         }
 
-        public static ResourceManipulationOperation CreatePost(Resource resource, IKey key, ISearchService service = null, SearchParams command = null)
+        [Obsolete("Use Async method version instead")]
+        public static ResourceManipulationOperation CreatePost(Resource resource, IKey key,
+            ISearchService service = null, SearchParams command = null)
+        {
+            return Task.Run(() => CreatePostAsync(resource, key, service, command)).Result;
+        }
+
+        public static async Task<ResourceManipulationOperation> CreatePostAsync(Resource resource, IKey key, ISearchService service = null, SearchParams command = null)
         {
             searchService = service;
-            return new PostManipulationOperation(resource, key, GetSearchResult(key, command), command);
+            return new PostManipulationOperation(resource, key, await GetSearchResultAsync(key, command).ConfigureAwait(false), command);
         }
 
-        private static SearchResults GetSearchResult(IKey key, SearchParams command = null)
+        private static async Task<SearchResults> GetSearchResultAsync(IKey key, SearchParams command = null)
         {
             if (command == null || command.Parameters.Count == 0)
                 return null;
             if (command != null && searchService == null)
                 throw new InvalidOperationException("Unallowed operation");
-            return searchService.GetSearchResults(key.TypeName, command);
+            return await searchService.GetSearchResultsAsync(key.TypeName, command).ConfigureAwait(false);
         }
 
-        public static ResourceManipulationOperation CreatePut(Resource resource, IKey key, ISearchService service = null, SearchParams command = null)
+        [Obsolete("Use Async method version instead")]
+        public static ResourceManipulationOperation CreatePut(Resource resource, IKey key,
+            ISearchService service = null, SearchParams command = null)
+        {
+            return Task.Run(() => CreatePutAsync(resource, key, service, command)).Result;
+        }
+
+        public static async Task<ResourceManipulationOperation> CreatePutAsync(Resource resource, IKey key, ISearchService service = null, SearchParams command = null)
         {
             searchService = service;
-            return new PutManipulationOperation(resource, key, GetSearchResult(key, command), command);
+            return new PutManipulationOperation(resource, key, await GetSearchResultAsync(key, command).ConfigureAwait(false), command);
         }
 
+        [Obsolete("Use Async method version instead")]
         public static ResourceManipulationOperation CreateDelete(IKey key, ISearchService service = null, SearchParams command = null)
         {
-            searchService = service;
-            return new DeleteManipulationOperation(null, key, GetSearchResult(key, command), command);
+            return Task.Run(() => CreateDeleteAsync(key, service, command)).Result;
         }
 
-        private static ResourceManipulationOperation CreateDelete(Resource  resource, IKey key, ISearchService service = null, SearchParams command = null)
+        public static async Task<ResourceManipulationOperation> CreateDeleteAsync(IKey key, ISearchService service = null, SearchParams command = null)
         {
             searchService = service;
-            return new DeleteManipulationOperation(null, key, GetSearchResult(key, command), command);
+            return new DeleteManipulationOperation(null, key, await GetSearchResultAsync(key, command).ConfigureAwait(false), command);
         }
 
-        public static ResourceManipulationOperation GetManipulationOperation(Bundle.EntryComponent entryComponent, ILocalhost localhost, ISearchService service = null)
+        [Obsolete("Use Async method version instead")]
+        private static ResourceManipulationOperation CreateDelete(Resource resource, IKey key, ISearchService service = null, SearchParams command = null)
+        {
+            return Task.Run(() => CreateDeleteAsync(resource, key, service, command)).Result;
+        }
+
+        private static async Task<ResourceManipulationOperation> CreateDeleteAsync(Resource resource, IKey key, ISearchService service = null, SearchParams command = null)
+        {
+            searchService = service;
+            return new DeleteManipulationOperation(null, key, await GetSearchResultAsync(key, command).ConfigureAwait(false), command);
+        }
+
+        [Obsolete("Use Async method version instead")]
+        public static ResourceManipulationOperation GetManipulationOperation(Bundle.EntryComponent entryComponent,
+            ILocalhost localhost, ISearchService service = null)
+        {
+            return Task.Run(() => GetManipulationOperationAsync(entryComponent, localhost, service)).Result;
+        }
+
+        public static async Task<ResourceManipulationOperation> GetManipulationOperationAsync(Bundle.EntryComponent entryComponent, ILocalhost localhost, ISearchService service = null)
         {
             searchService = service;
             Bundle.HTTPVerb method = localhost.ExtrapolateMethod(entryComponent, null); //CCR: is key needed? Isn't method required?
             Key key = localhost.ExtractKey(entryComponent);
             var searchUri = GetSearchUri(entryComponent, method);
 
-            return builders[method](entryComponent.Resource, key, service, searchUri != null? ParseQueryString(localhost, searchUri): null);
+            return await builders[method](entryComponent.Resource, key, service, searchUri != null? ParseQueryString(localhost, searchUri): null)
+                .ConfigureAwait(false);
         }
 
         private static Uri GetSearchUri(Bundle.EntryComponent entryComponent, Bundle.HTTPVerb method)

--- a/src/Spark.Engine/Service/FhirServiceExtensions/ResourceManipulationOperationFactory.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/ResourceManipulationOperationFactory.cs
@@ -29,7 +29,7 @@ namespace Spark.Engine.Service.FhirServiceExtensions
         public static ResourceManipulationOperation CreatePost(Resource resource, IKey key,
             ISearchService service = null, SearchParams command = null)
         {
-            return Task.Run(() => CreatePostAsync(resource, key, service, command)).Result;
+            return Task.Run(() => CreatePostAsync(resource, key, service, command)).GetAwaiter().GetResult();
         }
 
         public static async Task<ResourceManipulationOperation> CreatePostAsync(Resource resource, IKey key, ISearchService service = null, SearchParams command = null)
@@ -51,7 +51,7 @@ namespace Spark.Engine.Service.FhirServiceExtensions
         public static ResourceManipulationOperation CreatePut(Resource resource, IKey key,
             ISearchService service = null, SearchParams command = null)
         {
-            return Task.Run(() => CreatePutAsync(resource, key, service, command)).Result;
+            return Task.Run(() => CreatePutAsync(resource, key, service, command)).GetAwaiter().GetResult();
         }
 
         public static async Task<ResourceManipulationOperation> CreatePutAsync(Resource resource, IKey key, ISearchService service = null, SearchParams command = null)
@@ -63,7 +63,7 @@ namespace Spark.Engine.Service.FhirServiceExtensions
         [Obsolete("Use Async method version instead")]
         public static ResourceManipulationOperation CreateDelete(IKey key, ISearchService service = null, SearchParams command = null)
         {
-            return Task.Run(() => CreateDeleteAsync(key, service, command)).Result;
+            return Task.Run(() => CreateDeleteAsync(key, service, command)).GetAwaiter().GetResult();
         }
 
         public static async Task<ResourceManipulationOperation> CreateDeleteAsync(IKey key, ISearchService service = null, SearchParams command = null)
@@ -75,7 +75,7 @@ namespace Spark.Engine.Service.FhirServiceExtensions
         [Obsolete("Use Async method version instead")]
         private static ResourceManipulationOperation CreateDelete(Resource resource, IKey key, ISearchService service = null, SearchParams command = null)
         {
-            return Task.Run(() => CreateDeleteAsync(resource, key, service, command)).Result;
+            return Task.Run(() => CreateDeleteAsync(resource, key, service, command)).GetAwaiter().GetResult();
         }
 
         private static async Task<ResourceManipulationOperation> CreateDeleteAsync(Resource resource, IKey key, ISearchService service = null, SearchParams command = null)
@@ -88,7 +88,7 @@ namespace Spark.Engine.Service.FhirServiceExtensions
         public static ResourceManipulationOperation GetManipulationOperation(Bundle.EntryComponent entryComponent,
             ILocalhost localhost, ISearchService service = null)
         {
-            return Task.Run(() => GetManipulationOperationAsync(entryComponent, localhost, service)).Result;
+            return Task.Run(() => GetManipulationOperationAsync(entryComponent, localhost, service)).GetAwaiter().GetResult();
         }
 
         public static async Task<ResourceManipulationOperation> GetManipulationOperationAsync(Bundle.EntryComponent entryComponent, ILocalhost localhost, ISearchService service = null)

--- a/src/Spark.Engine/Service/FhirServiceExtensions/ResourceStorageService.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/ResourceStorageService.cs
@@ -1,5 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Spark.Engine.Core;
 using Spark.Engine.Store.Interfaces;
 using Spark.Service;
@@ -18,9 +20,27 @@ namespace Spark.Engine.Service.FhirServiceExtensions
             this.fhirStore = fhirStore;
         }
 
+        [Obsolete("Use Async method version instead")]
         public Entry Get(IKey key)
         {
-            var entry = fhirStore.Get(key);
+            return Task.Run(() => GetAsync(key)).Result;
+        }
+
+        [Obsolete("Use Async method version instead")]
+        public Entry Add(Entry entry)
+        {
+            return Task.Run(() => AddAsync(entry)).Result;
+        }
+
+        [Obsolete("Use Async method version instead")]
+        public IList<Entry> Get(IEnumerable<string> localIdentifiers, string sortby = null)
+        {
+            return Task.Run(() => GetAsync(localIdentifiers, sortby)).Result;
+        }
+
+        public async Task<Entry> GetAsync(IKey key)
+        {
+            var entry = await fhirStore.GetAsync(key).ConfigureAwait(false);
             if (entry != null)
             {
                 transfer.Externalize(entry);
@@ -28,13 +48,13 @@ namespace Spark.Engine.Service.FhirServiceExtensions
             return entry;
         }
 
-        public Entry Add(Entry entry)
+        public async Task<Entry> AddAsync(Entry entry)
         {
             if (entry.State != EntryState.Internal)
             {
                 transfer.Internalize(entry);
             }
-            fhirStore.Add(entry);
+            await fhirStore.AddAsync(entry).ConfigureAwait(false);
             Entry result;
             if (entry.IsDelete)
             {
@@ -42,16 +62,16 @@ namespace Spark.Engine.Service.FhirServiceExtensions
             }
             else
             {
-                result = fhirStore.Get(entry.Key);
+                result = await fhirStore.GetAsync(entry.Key).ConfigureAwait(false);
             }
             transfer.Externalize(result);
 
             return result;
         }
 
-        public IList<Entry> Get(IEnumerable<string> localIdentifiers, string sortby = null)
+        public async Task<IList<Entry>> GetAsync(IEnumerable<string> localIdentifiers, string sortby = null)
         {
-            IList<Entry> results = fhirStore.Get(localIdentifiers.Select(k => (IKey)Key.ParseOperationPath(k)));
+            IList<Entry> results = await fhirStore.GetAsync(localIdentifiers.Select(k => (IKey)Key.ParseOperationPath(k))).ConfigureAwait(false);
             transfer.Externalize(results);
             return results;
 

--- a/src/Spark.Engine/Service/FhirServiceExtensions/ResourceStorageService.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/ResourceStorageService.cs
@@ -23,19 +23,19 @@ namespace Spark.Engine.Service.FhirServiceExtensions
         [Obsolete("Use Async method version instead")]
         public Entry Get(IKey key)
         {
-            return Task.Run(() => GetAsync(key)).Result;
+            return Task.Run(() => GetAsync(key)).GetAwaiter().GetResult();
         }
 
         [Obsolete("Use Async method version instead")]
         public Entry Add(Entry entry)
         {
-            return Task.Run(() => AddAsync(entry)).Result;
+            return Task.Run(() => AddAsync(entry)).GetAwaiter().GetResult();
         }
 
         [Obsolete("Use Async method version instead")]
         public IList<Entry> Get(IEnumerable<string> localIdentifiers, string sortby = null)
         {
-            return Task.Run(() => GetAsync(localIdentifiers, sortby)).Result;
+            return Task.Run(() => GetAsync(localIdentifiers, sortby)).GetAwaiter().GetResult();
         }
 
         public async Task<Entry> GetAsync(IKey key)

--- a/src/Spark.Engine/Service/FhirServiceExtensions/SearchService.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/SearchService.cs
@@ -31,31 +31,31 @@ namespace Spark.Engine.Service.FhirServiceExtensions
         [Obsolete("Use Async method version instead")]
         public Snapshot GetSnapshot(string type, SearchParams searchCommand)
         {
-            return Task.Run(() => GetSnapshotAsync(type, searchCommand)).Result;
+            return Task.Run(() => GetSnapshotAsync(type, searchCommand)).GetAwaiter().GetResult();
         }
 
         [Obsolete("Use Async method version instead")]
         public Snapshot GetSnapshotForEverything(IKey key)
         {
-            return Task.Run(() => GetSnapshotForEverythingAsync(key)).Result;
+            return Task.Run(() => GetSnapshotForEverythingAsync(key)).GetAwaiter().GetResult();
         }
 
         [Obsolete("Use Async method version instead")]
         public IKey FindSingle(string type, SearchParams searchCommand)
         {
-            return Task.Run(() => FindSingleAsync(type, searchCommand)).Result;
+            return Task.Run(() => FindSingleAsync(type, searchCommand)).GetAwaiter().GetResult();
         }
 
         [Obsolete("Use Async method version instead")]
         public IKey FindSingleOrDefault(string type, SearchParams searchCommand)
         {
-            return Task.Run(() => FindSingleOrDefaultAsync(type, searchCommand)).Result;
+            return Task.Run(() => FindSingleOrDefaultAsync(type, searchCommand)).GetAwaiter().GetResult();
         }
 
         [Obsolete("Use Async method version instead")]
         public SearchResults GetSearchResults(string type, SearchParams searchCommand)
         {
-            return Task.Run(() => GetSearchResultsAsync(type, searchCommand)).Result;
+            return Task.Run(() => GetSearchResultsAsync(type, searchCommand)).GetAwaiter().GetResult();
         }
 
         public async Task<Snapshot> GetSnapshotAsync(string type, SearchParams searchCommand)

--- a/src/Spark.Engine/Service/FhirServiceExtensions/SearchService.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/SearchService.cs
@@ -2,12 +2,14 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Threading.Tasks;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Rest;
 using Spark.Core;
 using Spark.Engine.Core;
 using Spark.Engine.Extensions;
 using Spark.Service;
+using Task = System.Threading.Tasks.Task;
 
 namespace Spark.Engine.Service.FhirServiceExtensions
 {
@@ -26,10 +28,40 @@ namespace Spark.Engine.Service.FhirServiceExtensions
             this.fhirIndex = fhirIndex;
         }
 
+        [Obsolete("Use Async method version instead")]
         public Snapshot GetSnapshot(string type, SearchParams searchCommand)
         {
+            return Task.Run(() => GetSnapshotAsync(type, searchCommand)).Result;
+        }
+
+        [Obsolete("Use Async method version instead")]
+        public Snapshot GetSnapshotForEverything(IKey key)
+        {
+            return Task.Run(() => GetSnapshotForEverythingAsync(key)).Result;
+        }
+
+        [Obsolete("Use Async method version instead")]
+        public IKey FindSingle(string type, SearchParams searchCommand)
+        {
+            return Task.Run(() => FindSingleAsync(type, searchCommand)).Result;
+        }
+
+        [Obsolete("Use Async method version instead")]
+        public IKey FindSingleOrDefault(string type, SearchParams searchCommand)
+        {
+            return Task.Run(() => FindSingleOrDefaultAsync(type, searchCommand)).Result;
+        }
+
+        [Obsolete("Use Async method version instead")]
+        public SearchResults GetSearchResults(string type, SearchParams searchCommand)
+        {
+            return Task.Run(() => GetSearchResultsAsync(type, searchCommand)).Result;
+        }
+
+        public async Task<Snapshot> GetSnapshotAsync(string type, SearchParams searchCommand)
+        {
             Validate.TypeName(type);
-            SearchResults results =   fhirIndex.Search(type, searchCommand);
+            SearchResults results = await fhirIndex.SearchAsync(type, searchCommand).ConfigureAwait(false);
 
             if (results.HasErrors)
             {
@@ -40,11 +72,10 @@ namespace Spark.Engine.Service.FhirServiceExtensions
             builder.Query = results.UsedParameters;
             Uri link = builder.Uri;
 
-            Snapshot snapshot = CreateSnapshot(link, results, searchCommand);
-            return snapshot;
+            return CreateSnapshot(link, results, searchCommand);
         }
 
-        public Snapshot GetSnapshotForEverything(IKey key)
+        public async Task<Snapshot> GetSnapshotForEverythingAsync(IKey key)
         {
             var searchCommand = new SearchParams();
             if (string.IsNullOrEmpty(key.ResourceId) == false)
@@ -60,7 +91,7 @@ namespace Spark.Engine.Service.FhirServiceExtensions
                 }
             }
 
-            return GetSnapshot(key.TypeName, searchCommand);
+            return await GetSnapshotAsync(key.TypeName, searchCommand).ConfigureAwait(false);
         }
 
         private Snapshot CreateSnapshot(Uri selflink, IEnumerable<string> keys, SearchParams searchCommand)
@@ -108,21 +139,21 @@ namespace Spark.Engine.Service.FhirServiceExtensions
             return firstSort;
         }
 
-        public IKey FindSingle(string type, SearchParams searchCommand)
+        public async Task<IKey> FindSingleAsync(string type, SearchParams searchCommand)
         {
-            return Key.ParseOperationPath(GetSearchResults(type, searchCommand).Single());
+            return Key.ParseOperationPath((await GetSearchResultsAsync(type, searchCommand).ConfigureAwait(false)).Single());
         }
 
-        public IKey FindSingleOrDefault(string type, SearchParams searchCommand)
+        public async Task<IKey> FindSingleOrDefaultAsync(string type, SearchParams searchCommand)
         {
-            string value = GetSearchResults(type, searchCommand).SingleOrDefault();
+            string value = (await GetSearchResultsAsync(type, searchCommand).ConfigureAwait(false)).SingleOrDefault();
             return  value != null? Key.ParseOperationPath(value) : null;
         }
 
-        public SearchResults GetSearchResults(string type, SearchParams searchCommand)
+        public async Task<SearchResults> GetSearchResultsAsync(string type, SearchParams searchCommand)
         {
             Validate.TypeName(type);
-            SearchResults results = fhirIndex.Search(type, searchCommand);
+            SearchResults results = await fhirIndex.SearchAsync(type, searchCommand).ConfigureAwait(false);
 
             if (results.HasErrors)
             {
@@ -137,6 +168,9 @@ namespace Spark.Engine.Service.FhirServiceExtensions
             indexService.Process(interaction);
         }
 
+        public async Task InformAsync(Uri location, Entry interaction)
+        {
+            await indexService.ProcessAsync(interaction).ConfigureAwait(false);
+        }
     }
- 
 }

--- a/src/Spark.Engine/Service/FhirServiceExtensions/SnapshotPaginationProvider.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/SnapshotPaginationProvider.cs
@@ -1,12 +1,14 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Hl7.Fhir.Model;
 using Spark.Core;
 using Spark.Engine.Core;
 using Spark.Engine.Extensions;
 using Spark.Engine.Store.Interfaces;
 using Spark.Service;
+using Task = System.Threading.Tasks.Task;
 
 namespace Spark.Engine.Service.FhirServiceExtensions
 {
@@ -34,6 +36,11 @@ namespace Spark.Engine.Service.FhirServiceExtensions
 
         public Bundle GetPage(int? index = null, Action<Entry> transformElement = null)
         {
+            return Task.Run(() => GetPageAsync(index, transformElement)).Result;
+        }
+
+        public async Task<Bundle> GetPageAsync(int? index = null, Action<Entry> transformElement = null)
+        {
             if (snapshot == null)
                 throw Error.NotFound("There is no paged snapshot");
 
@@ -44,10 +51,10 @@ namespace Spark.Engine.Service.FhirServiceExtensions
                     snapshot.Keys.Count(), snapshot.Id);
             }
 
-            return this.CreateBundle(index);
+            return await CreateBundleAsync(index);
         }
 
-        private Bundle CreateBundle(int? start = null)
+        private async Task<Bundle> CreateBundleAsync(int? start = null)
         {
             Bundle bundle = new Bundle();
             bundle.Type = snapshot.Type;
@@ -55,14 +62,14 @@ namespace Spark.Engine.Service.FhirServiceExtensions
             bundle.Id = Guid.NewGuid().ToString();
 
             List<IKey> keys = _snapshotPaginationCalculator.GetKeysForPage(snapshot, start).ToList();
-            IList<Entry> entries = fhirStore.Get(keys).ToList();
+            var entries = (await fhirStore.GetAsync(keys).ConfigureAwait(false)).ToList();
             if (snapshot.SortBy != null)
             {
                 entries = entries.Select(e => new {Entry = e, Index = keys.IndexOf(e.Key)})
                     .OrderBy(e => e.Index)
                     .Select(e => e.Entry).ToList();
             }
-            IList<Entry> included = GetIncludesRecursiveFor(entries, snapshot.Includes);
+            IList<Entry> included = await GetIncludesRecursiveForAsync(entries, snapshot.Includes).ConfigureAwait(false);
             entries.Append(included);
 
             transfer.Externalize(entries);
@@ -73,29 +80,30 @@ namespace Spark.Engine.Service.FhirServiceExtensions
         }
 
 
-        private IList<Entry> GetIncludesRecursiveFor(IList<Entry> entries, IEnumerable<string> includes)
+        private async Task<IList<Entry>> GetIncludesRecursiveForAsync(IList<Entry> entries, IEnumerable<string> includes)
         {
             IList<Entry> included = new List<Entry>();
 
-            var latest = GetIncludesFor(entries, includes);
+            var latest = await GetIncludesForAsync(entries, includes).ConfigureAwait(false);
             int previouscount;
             do
             {
                 previouscount = included.Count;
                 included.AppendDistinct(latest);
-                latest = GetIncludesFor(latest, includes);
+                latest = await GetIncludesForAsync(latest, includes).ConfigureAwait(false);
             }
             while (included.Count > previouscount);
             return included;
         }
-        private IList<Entry> GetIncludesFor(IList<Entry> entries, IEnumerable<string> includes)
+
+        private async Task<IList<Entry>> GetIncludesForAsync(IList<Entry> entries, IEnumerable<string> includes)
         {
             if (includes == null) return new List<Entry>();
 
             IEnumerable<string> paths = includes.SelectMany(i => IncludeToPath(i));
             IList<IKey> identifiers = entries.GetResources().GetReferences(paths).Distinct().Select(k => (IKey)Key.ParseOperationPath(k)).ToList();
 
-            IList<Entry> result = fhirStore.Get(identifiers).ToList();
+            IList<Entry> result = (await fhirStore.GetAsync(identifiers).ConfigureAwait(false)).ToList();
 
             return result;
         }

--- a/src/Spark.Engine/Service/FhirServiceExtensions/SnapshotPaginationProvider.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/SnapshotPaginationProvider.cs
@@ -36,7 +36,7 @@ namespace Spark.Engine.Service.FhirServiceExtensions
 
         public Bundle GetPage(int? index = null, Action<Entry> transformElement = null)
         {
-            return Task.Run(() => GetPageAsync(index, transformElement)).Result;
+            return Task.Run(() => GetPageAsync(index, transformElement)).GetAwaiter().GetResult();
         }
 
         public async Task<Bundle> GetPageAsync(int? index = null, Action<Entry> transformElement = null)

--- a/src/Spark.Engine/Service/FhirServiceExtensions/TransactionService.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/TransactionService.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Hl7.Fhir.Model;
 using Spark.Engine.Core;
 using Spark.Service;
+using Task = System.Threading.Tasks.Task;
 
 namespace Spark.Engine.Service.FhirServiceExtensions
 {
@@ -20,22 +22,40 @@ namespace Spark.Engine.Service.FhirServiceExtensions
             this.searchService = searchService;
         }
 
+        [Obsolete("Use Async method version instead")]
+        public FhirResponse HandleTransaction(ResourceManipulationOperation operation, IInteractionHandler interactionHandler)
+        {
+            return Task.Run(() => HandleTransactionAsync(operation, interactionHandler)).Result;
+        }
+
+        [Obsolete("Use Async method version instead")]
+        public IList<Tuple<Entry, FhirResponse>> HandleTransaction(Bundle bundle, IInteractionHandler interactionHandler)
+        {
+            return Task.Run(() => HandleTransactionAsync(bundle, interactionHandler)).Result;
+        }
+
+        [Obsolete("Use Async method version instead")]
         public IList<Tuple<Entry, FhirResponse>> HandleTransaction(IList<Entry> interactions, IInteractionHandler interactionHandler)
+        {
+            return Task.Run(() => HandleTransactionAsync(interactions, interactionHandler)).Result;
+        }
+
+        public async Task<IList<Tuple<Entry, FhirResponse>>> HandleTransactionAsync(IList<Entry> interactions, IInteractionHandler interactionHandler)
         {
             if (interactionHandler == null)
             {
                 throw new InvalidOperationException("Unable to run transaction operation");
             }
 
-            return HandleTransaction(interactions, interactionHandler, null);
+            return await HandleTransactionAsync(interactions, interactionHandler, null).ConfigureAwait(false);
         }
 
-        public FhirResponse HandleTransaction(ResourceManipulationOperation operation, IInteractionHandler interactionHandler)
+        public Task<FhirResponse> HandleTransactionAsync(ResourceManipulationOperation operation, IInteractionHandler interactionHandler)
         {
-            return HandleOperation(operation, interactionHandler);
+            return HandleOperationAsync(operation, interactionHandler);
         }
 
-        public FhirResponse HandleOperation(ResourceManipulationOperation operation, IInteractionHandler interactionHandler, Mapper<string, IKey> mapper = null)
+        public async Task<FhirResponse> HandleOperationAsync(ResourceManipulationOperation operation, IInteractionHandler interactionHandler, Mapper<string, IKey> mapper = null)
         {
             IList<Entry> interactions = operation.GetEntries().ToList();
             if(mapper != null)
@@ -44,7 +64,7 @@ namespace Spark.Engine.Service.FhirServiceExtensions
             FhirResponse response = null;
             foreach (Entry interaction in interactions)
             {
-                response = MergeFhirResponse(response, interactionHandler.HandleInteraction(interaction));
+                response = MergeFhirResponse(response, await interactionHandler.HandleInteractionAsync(interaction).ConfigureAwait(false));
                 if (!response.IsValid) throw new Exception();
                 interaction.Resource = response.Resource;
             }
@@ -92,7 +112,7 @@ namespace Spark.Engine.Service.FhirServiceExtensions
             }
         }
 
-        public IList<Tuple<Entry, FhirResponse>> HandleTransaction(Bundle bundle, IInteractionHandler interactionHandler)
+        public async Task<IList<Tuple<Entry, FhirResponse>>> HandleTransactionAsync(Bundle bundle, IInteractionHandler interactionHandler)
         {
             if (interactionHandler == null)
             {
@@ -102,17 +122,18 @@ namespace Spark.Engine.Service.FhirServiceExtensions
             var entries = new List<Entry>();
             Mapper<string, IKey> mapper = new Mapper<string, IKey>();
 
-            foreach (var operation in bundle.Entry.Select(e => ResourceManipulationOperationFactory.GetManipulationOperation(e, localhost, searchService)))
+            foreach (var task in bundle.Entry.Select(e => ResourceManipulationOperationFactory.GetManipulationOperationAsync(e, localhost, searchService)))
             {
+                var operation = await task.ConfigureAwait(false);
                 IList<Entry> atomicOperations = operation.GetEntries().ToList();
                 AddMappingsForOperation(mapper, operation, atomicOperations);
                 entries.AddRange(atomicOperations);
             }
 
-            return HandleTransaction(entries, interactionHandler, mapper);
+            return await HandleTransactionAsync(entries, interactionHandler, mapper).ConfigureAwait(false);
         }
 
-        private IList<Tuple<Entry, FhirResponse>> HandleTransaction(IList<Entry> interactions, IInteractionHandler interactionHandler, Mapper<string, IKey> mapper)
+        private async Task<IList<Tuple<Entry, FhirResponse>>> HandleTransactionAsync(IList<Entry> interactions, IInteractionHandler interactionHandler, Mapper<string, IKey> mapper)
         {
             List<Tuple<Entry, FhirResponse>> responses = new List<Tuple<Entry, FhirResponse>>();
 
@@ -120,7 +141,7 @@ namespace Spark.Engine.Service.FhirServiceExtensions
 
             foreach (Entry interaction in interactions)
             {
-                FhirResponse response = interactionHandler.HandleInteraction(interaction);
+                FhirResponse response = await interactionHandler.HandleInteractionAsync(interaction).ConfigureAwait(false);
                 if (!response.IsValid) throw new Exception();
                 interaction.Resource = response.Resource;
                 response.Resource = null;

--- a/src/Spark.Engine/Service/FhirServiceExtensions/TransactionService.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/TransactionService.cs
@@ -25,19 +25,19 @@ namespace Spark.Engine.Service.FhirServiceExtensions
         [Obsolete("Use Async method version instead")]
         public FhirResponse HandleTransaction(ResourceManipulationOperation operation, IInteractionHandler interactionHandler)
         {
-            return Task.Run(() => HandleTransactionAsync(operation, interactionHandler)).Result;
+            return Task.Run(() => HandleTransactionAsync(operation, interactionHandler)).GetAwaiter().GetResult();
         }
 
         [Obsolete("Use Async method version instead")]
         public IList<Tuple<Entry, FhirResponse>> HandleTransaction(Bundle bundle, IInteractionHandler interactionHandler)
         {
-            return Task.Run(() => HandleTransactionAsync(bundle, interactionHandler)).Result;
+            return Task.Run(() => HandleTransactionAsync(bundle, interactionHandler)).GetAwaiter().GetResult();
         }
 
         [Obsolete("Use Async method version instead")]
         public IList<Tuple<Entry, FhirResponse>> HandleTransaction(IList<Entry> interactions, IInteractionHandler interactionHandler)
         {
-            return Task.Run(() => HandleTransactionAsync(interactions, interactionHandler)).Result;
+            return Task.Run(() => HandleTransactionAsync(interactions, interactionHandler)).GetAwaiter().GetResult();
         }
 
         public async Task<IList<Tuple<Entry, FhirResponse>>> HandleTransactionAsync(IList<Entry> interactions, IInteractionHandler interactionHandler)

--- a/src/Spark.Engine/Service/IAsyncFhirService.cs
+++ b/src/Spark.Engine/Service/IAsyncFhirService.cs
@@ -1,0 +1,40 @@
+﻿using Hl7.Fhir.Model;
+using Hl7.Fhir.Rest;
+using Spark.Engine.Core;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Spark.Engine.Service
+{
+    public interface IAsyncFhirService
+    {
+        Task<FhirResponse> AddMetaAsync(IKey key, Parameters parameters);
+        Task<FhirResponse> ConditionalCreateAsync(IKey key, Resource resource, IEnumerable<Tuple<string, string>> parameters);
+        Task<FhirResponse> ConditionalCreateAsync(IKey key, Resource resource, SearchParams parameters);
+        Task<FhirResponse> ConditionalDeleteAsync(IKey key, IEnumerable<Tuple<string, string>> parameters);
+        Task<FhirResponse> ConditionalUpdateAsync(IKey key, Resource resource, SearchParams parameters);
+        Task<FhirResponse> CapabilityStatementAsync(string sparkVersion);
+        Task<FhirResponse> CreateAsync(IKey key, Resource resource);
+        Task<FhirResponse> DeleteAsync(IKey key);
+        Task<FhirResponse> DeleteAsync(Entry entry);
+        Task<FhirResponse> GetPageAsync(string snapshotKey, int index);
+        Task<FhirResponse> HistoryAsync(HistoryParameters parameters);
+        Task<FhirResponse> HistoryAsync(string type, HistoryParameters parameters);
+        Task<FhirResponse> HistoryAsync(IKey key, HistoryParameters parameters);
+        Task<FhirResponse> MailboxAsync(Bundle bundle, Binary body);
+        Task<FhirResponse> PutAsync(IKey key, Resource resource);
+        Task<FhirResponse> PutAsync(Entry entry);
+        Task<FhirResponse> ReadAsync(IKey key, ConditionalHeaderParameters parameters = null);
+        Task<FhirResponse> ReadMetaAsync(IKey key);
+        Task<FhirResponse> SearchAsync(string type, SearchParams searchCommand, int pageIndex = 0);
+        Task<FhirResponse> TransactionAsync(IList<Entry> interactions);
+        Task<FhirResponse> TransactionAsync(Bundle bundle);
+        Task<FhirResponse> UpdateAsync(IKey key, Resource resource);
+        Task<FhirResponse> ValidateOperationAsync(IKey key, Resource resource);
+        Task<FhirResponse> VersionReadAsync(IKey key);
+        Task<FhirResponse> VersionSpecificUpdateAsync(IKey versionedKey, Resource resource);
+        Task<FhirResponse> EverythingAsync(IKey key);
+        Task<FhirResponse> DocumentAsync(IKey key);
+    }
+}

--- a/src/Spark.Engine/Service/IFhirService.cs
+++ b/src/Spark.Engine/Service/IFhirService.cs
@@ -6,6 +6,7 @@ using Spark.Engine.Core;
 
 namespace Spark.Service
 {
+    [Obsolete("Use IAsyncFhirService instead")]
     public interface IFhirService
     {
         FhirResponse AddMeta(IKey key, Parameters parameters);

--- a/src/Spark.Engine/Service/IServiceListener.cs
+++ b/src/Spark.Engine/Service/IServiceListener.cs
@@ -1,11 +1,15 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Spark.Engine.Core;
 
 namespace Spark.Service
 {
     public interface IServiceListener
     {
+        [Obsolete("Use Async method version instead")]
         void Inform(Uri location, Entry interaction);
+
+        Task InformAsync(Uri location, Entry interaction);
     }
 
 }

--- a/src/Spark.Engine/Service/ServiceListener.cs
+++ b/src/Spark.Engine/Service/ServiceListener.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Spark.Engine.Core;
 using Spark.Engine.Service;
 
@@ -47,9 +48,17 @@ namespace Spark.Service
 
         public void Inform(Uri location, Entry entry)
         {
-            foreach(IServiceListener listener in listeners)
+            foreach (IServiceListener listener in listeners)
             {
                 Inform(listener, location, entry);
+            }
+        }
+
+        public async Task InformAsync(Uri location, Entry interaction)
+        {
+            foreach (var listener in listeners)
+            {
+                await listener.InformAsync(location, interaction).ConfigureAwait(false);
             }
         }
     }

--- a/src/Spark.Engine/Spark.Engine.csproj
+++ b/src/Spark.Engine/Spark.Engine.csproj
@@ -10,6 +10,7 @@
         <Product>Spark.Engine.R4</Product>
         <Description>FHIR Server Engine - handling REST calls and service layer</Description>
         <PackageLicenseFile>LICENSE</PackageLicenseFile>
+        <LangVersion>8.0</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Spark.Engine/Store/Interfaces/IFhirStore.cs
+++ b/src/Spark.Engine/Store/Interfaces/IFhirStore.cs
@@ -1,13 +1,25 @@
+using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Spark.Engine.Core;
 
 namespace Spark.Engine.Store.Interfaces
 {
     public interface IFhirStore
     {
+        [Obsolete("Use Async method version instead")]
         void Add(Entry entry);
+
+        [Obsolete("Use Async method version instead")]
         Entry Get(IKey key);
+
+        [Obsolete("Use Async method version instead")]
         IList<Entry> Get(IEnumerable<IKey> localIdentifiers);
+
+        Task AddAsync(Entry entry);
+
+        Task<Entry> GetAsync(IKey key);
+
+        Task<IList<Entry>> GetAsync(IEnumerable<IKey> localIdentifiers);
     }
-   
 }

--- a/src/Spark.Engine/Store/Interfaces/IHistoryExtension.cs
+++ b/src/Spark.Engine/Store/Interfaces/IHistoryExtension.cs
@@ -1,11 +1,24 @@
+using System;
+using System.Threading.Tasks;
 using Spark.Engine.Core;
 
 namespace Spark.Engine.Store.Interfaces
 {
     public interface IHistoryStore
     {
+        [Obsolete("Use Async method version instead")]
         Snapshot History(string typename, HistoryParameters parameters);
+
+        [Obsolete("Use Async method version instead")]
         Snapshot History(IKey key, HistoryParameters parameters);
+
+        [Obsolete("Use Async method version instead")]
         Snapshot History(HistoryParameters parameters);
+
+        Task<Snapshot> HistoryAsync(string typename, HistoryParameters parameters);
+
+        Task<Snapshot> HistoryAsync(IKey key, HistoryParameters parameters);
+
+        Task<Snapshot> HistoryAsync(HistoryParameters parameters);
     }
 }

--- a/src/Spark.Engine/Store/Interfaces/IIndexStore.cs
+++ b/src/Spark.Engine/Store/Interfaces/IIndexStore.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Threading.Tasks;
 using Spark.Engine.Core;
 using Spark.Engine.Model;
 
@@ -5,10 +7,19 @@ namespace Spark.Engine.Store.Interfaces
 {
     public interface IIndexStore
     {
+        [Obsolete("Use Async method version instead")]
         void Save(IndexValue indexValue);
 
+        [Obsolete("Use Async method version instead")]
         void Delete(Entry entry);
 
+        [Obsolete("Use Async method version instead")]
         void Clean();
+
+        Task SaveAsync(IndexValue indexValue);
+
+        Task DeleteAsync(Entry entry);
+
+        Task CleanAsync();
     }
 }

--- a/src/Spark.Engine/Store/Interfaces/ISnapshotStore.cs
+++ b/src/Spark.Engine/Store/Interfaces/ISnapshotStore.cs
@@ -1,10 +1,19 @@
+using System;
+using System.Threading.Tasks;
 using Spark.Engine.Core;
 
 namespace Spark.Engine.Store.Interfaces
 {
     public interface ISnapshotStore
     {
+        [Obsolete("Use Async method version instead")]
         void AddSnapshot(Snapshot snapshot);
+
+        [Obsolete("Use Async method version instead")]
         Snapshot GetSnapshot(string snapshotid);
+
+        Task AddSnapshotAsync(Snapshot snapshot);
+
+        Task<Snapshot> GetSnapshotAsync(string snapshotId);
     }
 }

--- a/src/Spark.Mongo/Search/Infrastructure/MongoFhirIndex.cs
+++ b/src/Spark.Mongo/Search/Infrastructure/MongoFhirIndex.cs
@@ -6,8 +6,11 @@
  * available at https://raw.github.com/furore-fhir/spark/master/LICENSE
  */
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Spark.Core;
 using Hl7.Fhir.Rest;
 using Spark.Engine;
@@ -31,26 +34,55 @@ namespace Spark.Mongo.Search.Common
             _searchSettings = sparkSettings?.Search ?? new SearchSettings();
         }
 
-        private object transaction = new object();
-       
+        private readonly SemaphoreSlim _transaction = new SemaphoreSlim(1, 1);
+
+        [Obsolete("Use Async method version instead")]
         public void Clean()
         {
-            lock (transaction)
+            Task.Run(() => CleanAsync()).Wait();
+        }
+
+        [Obsolete("Use Async method version instead")]
+        public SearchResults Search(string resource, SearchParams searchCommand)
+        {
+            return Task.Run(() => SearchAsync(resource, searchCommand)).Result;
+        }
+
+        [Obsolete("Use Async method version instead")]
+        public Key FindSingle(string resource, SearchParams searchCommand)
+        {
+            return Task.Run(() => FindSingleAsync(resource, searchCommand)).Result;
+        }
+
+        [Obsolete("Use Async method version instead")]
+        public SearchResults GetReverseIncludes(IList<IKey> keys, IList<string> revIncludes)
+        {
+            return Task.Run(() => GetReverseIncludesAsync(keys, revIncludes)).Result;
+        }
+
+        public async Task CleanAsync()
+        {
+            await _transaction.WaitAsync().ConfigureAwait(false);
+            try
             {
-                _indexStore.Clean();
+                await _indexStore.CleanAsync().ConfigureAwait(false);
+            }
+            finally
+            {
+                _transaction.Release();
             }
         }
 
-        public SearchResults Search(string resource, SearchParams searchCommand)
+        public async Task<SearchResults> SearchAsync(string resource, SearchParams searchCommand)
         {
-            return _searcher.Search(resource, searchCommand, _searchSettings);
+            return await _searcher.SearchAsync(resource, searchCommand, _searchSettings).ConfigureAwait(false);
         }
 
-        public Key FindSingle(string resource, SearchParams searchCommand)
+        public async Task<Key> FindSingleAsync(string resource, SearchParams searchCommand)
         {
             // todo: this needs optimization
 
-            SearchResults results = _searcher.Search(resource, searchCommand, _searchSettings);
+            var results = await _searcher.SearchAsync(resource, searchCommand, _searchSettings).ConfigureAwait(false);
             if (results.Count > 1)
             {
                 throw Error.BadRequest("The search for a single resource yielded more than one.");
@@ -65,10 +97,10 @@ namespace Spark.Mongo.Search.Common
                 return Key.ParseOperationPath(location);
             }
         }
-        public SearchResults GetReverseIncludes(IList<IKey> keys, IList<string> revIncludes)
-        {
-            return _searcher.GetReverseIncludes(keys, revIncludes);
-        }
 
+        public async Task<SearchResults> GetReverseIncludesAsync(IList<IKey> keys, IList<string> revIncludes)
+        {
+            return await _searcher.GetReverseIncludesAsync(keys, revIncludes).ConfigureAwait(false);
+        }
     }
 }

--- a/src/Spark.Mongo/Search/Infrastructure/MongoFhirIndex.cs
+++ b/src/Spark.Mongo/Search/Infrastructure/MongoFhirIndex.cs
@@ -39,25 +39,25 @@ namespace Spark.Mongo.Search.Common
         [Obsolete("Use Async method version instead")]
         public void Clean()
         {
-            Task.Run(() => CleanAsync()).Wait();
+            Task.Run(() => CleanAsync()).GetAwaiter().GetResult();
         }
 
         [Obsolete("Use Async method version instead")]
         public SearchResults Search(string resource, SearchParams searchCommand)
         {
-            return Task.Run(() => SearchAsync(resource, searchCommand)).Result;
+            return Task.Run(() => SearchAsync(resource, searchCommand)).GetAwaiter().GetResult();
         }
 
         [Obsolete("Use Async method version instead")]
         public Key FindSingle(string resource, SearchParams searchCommand)
         {
-            return Task.Run(() => FindSingleAsync(resource, searchCommand)).Result;
+            return Task.Run(() => FindSingleAsync(resource, searchCommand)).GetAwaiter().GetResult();
         }
 
         [Obsolete("Use Async method version instead")]
         public SearchResults GetReverseIncludes(IList<IKey> keys, IList<string> revIncludes)
         {
-            return Task.Run(() => GetReverseIncludesAsync(keys, revIncludes)).Result;
+            return Task.Run(() => GetReverseIncludesAsync(keys, revIncludes)).GetAwaiter().GetResult();
         }
 
         public async Task CleanAsync()

--- a/src/Spark.Mongo/Search/Infrastructure/MongoIndexStore.cs
+++ b/src/Spark.Mongo/Search/Infrastructure/MongoIndexStore.cs
@@ -26,19 +26,19 @@ namespace Spark.Mongo.Search.Common
         [Obsolete("Use Async method version instead")]
         public void Save(IndexValue indexValue)
         {
-            Task.Run(() => SaveAsync(indexValue)).Wait();
+            Task.Run(() => SaveAsync(indexValue)).GetAwaiter().GetResult();
         }
 
         [Obsolete("Use Async method version instead")]
         public void Delete(Entry entry)
         {
-            Task.Run(() => DeleteAsync(entry)).Wait();
+            Task.Run(() => DeleteAsync(entry)).GetAwaiter().GetResult();
         }
 
         [Obsolete("Use Async method version instead")]
         public void Clean()
         {
-            Task.Run(() => CleanAsync()).Wait();
+            Task.Run(() => CleanAsync()).GetAwaiter().GetResult();
         }
 
         public async Task SaveAsync(IndexValue indexValue)

--- a/src/Spark.Mongo/Search/Infrastructure/MongoIndexStore.cs
+++ b/src/Spark.Mongo/Search/Infrastructure/MongoIndexStore.cs
@@ -1,7 +1,8 @@
-﻿using MongoDB.Bson;
+﻿using System;
+using MongoDB.Bson;
 using MongoDB.Driver;
 using Spark.Engine.Core;
-using System;
+using System.Threading.Tasks;
 using Spark.Store.Mongo;
 using Spark.Engine.Model;
 using Spark.Mongo.Search.Indexer;
@@ -22,44 +23,54 @@ namespace Spark.Mongo.Search.Common
             Collection = _database.GetCollection<BsonDocument>(Config.MONGOINDEXCOLLECTION);
         }
 
+        [Obsolete("Use Async method version instead")]
         public void Save(IndexValue indexValue)
+        {
+            Task.Run(() => SaveAsync(indexValue)).Wait();
+        }
+
+        [Obsolete("Use Async method version instead")]
+        public void Delete(Entry entry)
+        {
+            Task.Run(() => DeleteAsync(entry)).Wait();
+        }
+
+        [Obsolete("Use Async method version instead")]
+        public void Clean()
+        {
+            Task.Run(() => CleanAsync()).Wait();
+        }
+
+        public async Task SaveAsync(IndexValue indexValue)
         {
             var result = _indexMapper.MapEntry(indexValue);
 
             foreach (var doc in result)
             {
-                Save(doc);
+                await SaveAsync(doc).ConfigureAwait(false);
             }
         }
 
-        public void Save(BsonDocument document)
+        public async Task SaveAsync(BsonDocument document)
         {
-            try
-            {
-                string keyvalue = document.GetValue(InternalField.ID).ToString();
-                var query = Builders<BsonDocument>.Filter.Eq(InternalField.ID, keyvalue);
+            string keyvalue = document.GetValue(InternalField.ID).ToString();
+            var query = Builders<BsonDocument>.Filter.Eq(InternalField.ID, keyvalue);
 
-                // todo: should use Update: collection.Update();
-                Collection.DeleteMany(query);
-                Collection.InsertOne(document);
-            }
-            catch (Exception exception)
-            {
-                throw exception;
-            }
+            // todo: should use Update: collection.Update();
+            await Collection.DeleteManyAsync(query).ConfigureAwait(false);
+            await Collection.InsertOneAsync(document).ConfigureAwait(false);
         }
 
-        public void Delete(Entry entry)
+        public async Task DeleteAsync(Entry entry)
         {
             string id = entry.Key.WithoutVersion().ToOperationPath();
             var query = Builders<BsonDocument>.Filter.Eq(InternalField.ID, id);
-            Collection.DeleteMany(query);
+            await Collection.DeleteManyAsync(query).ConfigureAwait(false);
         }
 
-        public void Clean()
+        public async Task CleanAsync()
         {
-            Collection.DeleteMany(Builders<BsonDocument>.Filter.Empty);
+            await Collection.DeleteManyAsync(Builders<BsonDocument>.Filter.Empty).ConfigureAwait(false);
         }
-
     }
 }

--- a/src/Spark.Mongo/Search/Searcher/MongoSearcher.cs
+++ b/src/Spark.Mongo/Search/Searcher/MongoSearcher.cs
@@ -387,7 +387,7 @@ namespace Spark.Search.Mongo
             SearchParams searchCommand,
             SearchSettings searchSettings = null)
         {
-            return Task.Run(() => SearchAsync(resourceType, searchCommand, searchSettings)).Result;
+            return Task.Run(() => SearchAsync(resourceType, searchCommand, searchSettings)).GetAwaiter().GetResult();
         }
 
         public async Task<SearchResults> SearchAsync(string resourceType, SearchParams searchCommand, SearchSettings searchSettings = null)

--- a/src/Spark.Mongo/Search/Searcher/MongoSearcher.cs
+++ b/src/Spark.Mongo/Search/Searcher/MongoSearcher.cs
@@ -9,19 +9,19 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 
 //using Hl7.Fhir.Support;
 using MongoDB.Bson;
 using MongoDB.Driver;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Rest;
-using MongoDB.Bson.Serialization.Serializers;
-using MongoDB.Driver.Core.Configuration;
 using Spark.Engine.Core;
 using Spark.Mongo.Search.Common;
 using Spark.Engine.Extensions;
 using Spark.Engine.Search;
 using SM = Spark.Engine.Search.Model;
+using Task = System.Threading.Tasks.Task;
 
 namespace Spark.Search.Mongo
 {
@@ -42,38 +42,45 @@ namespace Spark.Search.Mongo
             _referenceNormalizationService = referenceNormalizationService;
         }
 
-        private List<BsonValue> CollectKeys(FilterDefinition<BsonDocument> query)
+        private async Task<List<BsonValue>> CollectKeysAsync(FilterDefinition<BsonDocument> query)
         {
-            var cursor = _collection.Find(query)
-                .Project(Builders<BsonDocument>.Projection.Include(InternalField.ID))
-                .ToEnumerable();
-            if (cursor.Count() > 0)
-                return cursor.Select(doc => doc.GetValue(InternalField.ID)).ToList();
-            return new List<BsonValue>();
+            var cursor = await _collection.FindAsync(query, new FindOptions<BsonDocument>
+            {
+                Projection = Builders<BsonDocument>.Projection.Include(InternalField.ID)
+            }).ConfigureAwait(false);
+
+            return cursor
+                .ToEnumerable()
+                .Select(doc => doc.GetValue(InternalField.ID))
+                .ToList();
         }
 
-        private List<BsonValue> CollectSelfLinks(FilterDefinition<BsonDocument> query, SortDefinition<BsonDocument> sortBy)
+        private async Task<List<BsonValue>> CollectSelfLinks(FilterDefinition<BsonDocument> query, SortDefinition<BsonDocument> sortBy)
         {
-            var cursor = _collection.Find(query);
-
+            var findOptions = new FindOptions<BsonDocument>
+            {
+                Projection = Builders<BsonDocument>.Projection.Include(InternalField.SELFLINK)
+            };
             if (sortBy != null)
             {
-                cursor.Sort(sortBy);
+                findOptions.Sort = sortBy;
             }
-
-            cursor = cursor.Project(Builders<BsonDocument>.Projection.Include(InternalField.SELFLINK));
-
+            var cursor = await _collection.FindAsync(query, findOptions);
             return cursor.ToEnumerable().Select(doc => doc.GetValue(InternalField.SELFLINK)).ToList();
         }
 
-        private SearchResults KeysToSearchResults(IEnumerable<BsonValue> keys)
+        private async Task<SearchResults> KeysToSearchResultsAsync(IEnumerable<BsonValue> keys)
         {
             var results = new SearchResults();
 
             if (keys.Count() > 0)
             {
-                var cursor = _collection.Find(Builders<BsonDocument>.Filter.In(InternalField.ID, keys))
-                    .Project(Builders<BsonDocument>.Projection.Include(InternalField.SELFLINK))
+                var cursor = (await _collection.FindAsync(
+                        Builders<BsonDocument>.Filter.In(InternalField.ID, keys),
+                        new FindOptions<BsonDocument>
+                        {
+                            Projection = Builders<BsonDocument>.Projection.Include(InternalField.SELFLINK)
+                        }).ConfigureAwait(false))
                     .ToEnumerable();
 
                 foreach (BsonDocument document in cursor)
@@ -87,29 +94,29 @@ namespace Spark.Search.Mongo
             return results;
         }
 
-        private List<BsonValue> CollectKeys(string resourceType, IEnumerable<Criterium> criteria, int level = 0)
+        private async Task<List<BsonValue>> CollectKeysAsync(string resourceType, IEnumerable<Criterium> criteria, int level = 0)
         {
-            return CollectKeys(resourceType, criteria, null, level);
+            return await CollectKeysAsync(resourceType, criteria, null, level).ConfigureAwait(false);
         }
 
-        private List<BsonValue> CollectKeys(string resourceType, IEnumerable<Criterium> criteria, SearchResults results, int level)
+        private async Task<List<BsonValue>> CollectKeysAsync(string resourceType, IEnumerable<Criterium> criteria, SearchResults results, int level)
         {
-            Dictionary<Criterium, Criterium> closedCriteria = CloseChainedCriteria(resourceType, criteria, results, level);
+            Dictionary<Criterium, Criterium> closedCriteria = await CloseChainedCriteria(resourceType, criteria, results, level).ConfigureAwait(false);
 
             //All chained criteria are 'closed' or 'rolled up' to something like subject IN (id1, id2, id3), so now we AND them with the rest of the criteria.
             FilterDefinition<BsonDocument> resultQuery = CreateMongoQuery(resourceType, results, level, closedCriteria);
 
-            return CollectKeys(resultQuery);
+            return await CollectKeysAsync(resultQuery).ConfigureAwait(false);
         }
 
-        private List<BsonValue> CollectSelfLinks(string resourceType, IEnumerable<Criterium> criteria, SearchResults results, int level, IList<(string, SortOrder)> sortItems )
+        private async Task<List<BsonValue>> CollectSelfLinksAsync(string resourceType, IEnumerable<Criterium> criteria, SearchResults results, int level, IList<(string, SortOrder)> sortItems )
         {
-            Dictionary<Criterium, Criterium> closedCriteria = CloseChainedCriteria(resourceType, criteria, results, level);
+            Dictionary<Criterium, Criterium> closedCriteria = await CloseChainedCriteria(resourceType, criteria, results, level).ConfigureAwait(false);
 
             //All chained criteria are 'closed' or 'rolled up' to something like subject IN (id1, id2, id3), so now we AND them with the rest of the criteria.
             FilterDefinition<BsonDocument> resultQuery = CreateMongoQuery(resourceType, results, level, closedCriteria);
             SortDefinition<BsonDocument> sortBy = CreateSortBy(sortItems);
-            return CollectSelfLinks(resultQuery, sortBy);
+            return await CollectSelfLinks(resultQuery, sortBy).ConfigureAwait(false);
         }
 
         private static SortDefinition<BsonDocument> CreateSortBy(IList<(string, SortOrder)> sortItems)
@@ -175,7 +182,7 @@ namespace Spark.Search.Mongo
             return resultQuery;
         }
 
-        private Dictionary<Criterium, Criterium> CloseChainedCriteria(string resourceType, IEnumerable<Criterium> criteria, SearchResults results, int level)
+        private async Task<Dictionary<Criterium, Criterium>> CloseChainedCriteria(string resourceType, IEnumerable<Criterium> criteria, SearchResults results, int level)
         {
             //Mapping of original criterium and closed criterium, the former to be able to exclude it if it errors later on.
             var closedCriteria = new Dictionary<Criterium, Criterium>();
@@ -185,7 +192,7 @@ namespace Spark.Search.Mongo
                 {
                     try
                     {
-                        closedCriteria.Add(c.Clone(), CloseCriterium(c, resourceType, level));
+                        closedCriteria.Add(c.Clone(), await CloseCriteriumAsync(c, resourceType, level).ConfigureAwait(false));
                         //CK: We don't pass the SearchResults on to the (recursive) CloseCriterium. We catch any exceptions only on the highest level.
                     }
                     catch (ArgumentException ex)
@@ -211,7 +218,7 @@ namespace Spark.Search.Mongo
         /// <param name="resourceType"></param>
         /// <param name="crit"></param>
         /// <returns></returns>
-        private Criterium CloseCriterium(Criterium crit, string resourceType, int level)
+        private async Task<Criterium> CloseCriteriumAsync(Criterium crit, string resourceType, int level)
         {
 
             List<string> targeted = crit.GetTargetedReferenceTypes(resourceType);
@@ -222,7 +229,7 @@ namespace Spark.Search.Mongo
                 try
                 {
                     Criterium innerCriterium = (Criterium)crit.Operand;
-                    var keys = CollectKeys(target, new List<Criterium> { innerCriterium }, ++level);               //Recursive call to CollectKeys!
+                    var keys = await CollectKeysAsync(target, new List<Criterium> { innerCriterium }, ++level).ConfigureAwait(false);               //Recursive call to CollectKeys!
                     allKeys.AddRange(keys.Select(k => k.ToString()));
                 }
                 catch (Exception ex)
@@ -374,7 +381,16 @@ namespace Spark.Search.Mongo
             return result;
         }
 
-        public SearchResults Search(string resourceType, SearchParams searchCommand, SearchSettings searchSettings = null)
+        [Obsolete("Use Async method version instead")]
+        public SearchResults Search(
+            string resourceType,
+            SearchParams searchCommand,
+            SearchSettings searchSettings = null)
+        {
+            return Task.Run(() => SearchAsync(resourceType, searchCommand, searchSettings)).Result;
+        }
+
+        public async Task<SearchResults> SearchAsync(string resourceType, SearchParams searchCommand, SearchSettings searchSettings = null)
         {
             if (searchSettings == null)
             {
@@ -395,7 +411,7 @@ namespace Spark.Search.Mongo
                 var normalizedCriteria = NormalizeNonChainedReferenceCriteria(criteria, resourceType, searchSettings);
                 var normalizeSortCriteria = NormalizeSortItems(resourceType, searchCommand);
 
-                List<BsonValue> selfLinks = CollectSelfLinks(resourceType, normalizedCriteria, results, 0, normalizeSortCriteria);
+                List<BsonValue> selfLinks = await CollectSelfLinksAsync(resourceType, normalizedCriteria, results, 0, normalizeSortCriteria).ConfigureAwait(false);
 
                 foreach (BsonValue selfLink in selfLinks)
                 {
@@ -434,7 +450,7 @@ namespace Spark.Search.Mongo
             return sortItem;
         }
 
-        public SearchResults GetReverseIncludes(IList<IKey> keys, IList<string> revIncludes)
+        public async Task<SearchResults> GetReverseIncludesAsync(IList<IKey> keys, IList<string> revIncludes)
         {
             BsonValue[] internal_ids = keys.Select(k => BsonString.Create(String.Format("{0}/{1}", k.TypeName, k.ResourceId))).ToArray();
 
@@ -459,8 +475,8 @@ namespace Spark.Search.Mongo
                 if (riQueries.Count > 0)
                 {
                     var revIncludeQuery = Builders<BsonDocument>.Filter.Or(riQueries);
-                    var resultKeys = CollectKeys(revIncludeQuery);
-                    results = KeysToSearchResults(resultKeys);
+                    var resultKeys = await CollectKeysAsync(revIncludeQuery).ConfigureAwait(false);
+                    results = await KeysToSearchResultsAsync(resultKeys).ConfigureAwait(false);
                 }
             }
             return results;

--- a/src/Spark.Mongo/Store/Extensions/HistoryExtension.cs
+++ b/src/Spark.Mongo/Store/Extensions/HistoryExtension.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Hl7.Fhir.Model;
 using MongoDB.Bson;
 using MongoDB.Driver;
@@ -8,6 +9,7 @@ using Spark.Engine.Auxiliary;
 using Spark.Engine.Core;
 using Spark.Engine.Store.Interfaces;
 using Spark.Store.Mongo;
+using Task = System.Threading.Tasks.Task;
 
 namespace Spark.Mongo.Store.Extensions
 {
@@ -20,8 +22,26 @@ namespace Spark.Mongo.Store.Extensions
             this.database = MongoDatabaseFactory.GetMongoDatabase(mongoUrl);
             this.collection = database.GetCollection<BsonDocument>(Collection.RESOURCE);
         }
-   
-        public Snapshot History(string resource, HistoryParameters parameters)
+
+        [Obsolete("Use Async method version instead")]
+        public Snapshot History(string typename, HistoryParameters parameters)
+        {
+            return Task.Run(() => HistoryAsync(typename, parameters)).Result;
+        }
+
+        [Obsolete("Use Async method version instead")]
+        public Snapshot History(IKey key, HistoryParameters parameters)
+        {
+            return Task.Run(() => HistoryAsync(key, parameters)).Result;
+        }
+
+        [Obsolete("Use Async method version instead")]
+        public Snapshot History(HistoryParameters parameters)
+        {
+            return Task.Run(() => HistoryAsync(parameters)).Result;
+        }
+
+        public async Task<Snapshot> HistoryAsync(string resource, HistoryParameters parameters)
         {
             var clauses = new List<FilterDefinition<BsonDocument>>();
 
@@ -29,10 +49,10 @@ namespace Spark.Mongo.Store.Extensions
             if (parameters.Since != null)
                 clauses.Add(Builders<BsonDocument>.Filter.Gt(Field.WHEN, BsonDateTime.Create(parameters.Since)));
 
-            return CreateSnapshot(FetchPrimaryKeys(clauses), parameters.Count);
+            return CreateSnapshot(await FetchPrimaryKeysAsync(clauses).ConfigureAwait(false), parameters.Count);
         }
 
-        public Snapshot History(IKey key, HistoryParameters parameters)
+        public async Task<Snapshot> HistoryAsync(IKey key, HistoryParameters parameters)
         {
             var clauses = new List<FilterDefinition<BsonDocument>>();
 
@@ -41,39 +61,39 @@ namespace Spark.Mongo.Store.Extensions
             if (parameters.Since != null)
                 clauses.Add(Builders<BsonDocument>.Filter.Gt(Field.WHEN, BsonDateTime.Create(parameters.Since)));
 
-            return CreateSnapshot(FetchPrimaryKeys(clauses), parameters.Count);
+            return CreateSnapshot(await FetchPrimaryKeysAsync(clauses).ConfigureAwait(false), parameters.Count);
         }
 
-        public Snapshot History(HistoryParameters parameters)
+        public async Task<Snapshot> HistoryAsync(HistoryParameters parameters)
         {
             var clauses = new List<FilterDefinition<BsonDocument>>();
             if (parameters.Since != null)
                 clauses.Add(Builders<BsonDocument>.Filter.Gt(Field.WHEN, BsonDateTime.Create(parameters.Since)));
 
-            return CreateSnapshot(FetchPrimaryKeys(clauses), parameters.Count);
+            return CreateSnapshot(await FetchPrimaryKeysAsync(clauses).ConfigureAwait(false), parameters.Count);
         }
 
-        public IList<string> FetchPrimaryKeys(FilterDefinition<BsonDocument> query)
+        private async Task<IList<string>> FetchPrimaryKeysAsync(IList<FilterDefinition<BsonDocument>> clauses)
         {
-            return collection.Find(query)
-                .Sort(Builders<BsonDocument>.Sort.Descending(Field.WHEN))
-                .Project(Builders<BsonDocument>.Projection.Include(Field.PRIMARYKEY))
-                .ToEnumerable()
-                .Select(doc => doc.GetValue(Field.PRIMARYKEY).AsString).ToList();
+            var query = clauses.Any()
+                ? Builders<BsonDocument>.Filter.And(clauses)
+                : Builders<BsonDocument>.Filter.Empty;
+
+            var cursor = await collection.FindAsync(query, new FindOptions<BsonDocument>
+            {
+                Sort = Builders<BsonDocument>.Sort.Descending(Field.WHEN),
+                Projection = Builders<BsonDocument>.Projection.Include(Field.PRIMARYKEY)
+            }).ConfigureAwait(false);
+
+            return cursor.ToEnumerable().Select(doc => doc.GetValue(Field.PRIMARYKEY).AsString).ToList();
         }
 
-        public IList<string> FetchPrimaryKeys(IEnumerable<FilterDefinition<BsonDocument>> clauses)
+        private static Snapshot CreateSnapshot(IEnumerable<string> keys, int? count = null, IList<string> includes = null, IList<string> reverseIncludes = null)
         {
-            FilterDefinition<BsonDocument> query = clauses.Any() ? Builders<BsonDocument>.Filter.And(clauses) : Builders<BsonDocument>.Filter.Empty;
-            return FetchPrimaryKeys(query);
-        }
-
-        private Snapshot CreateSnapshot(IEnumerable<string> keys, int? count = null, IList<string> includes = null, IList<string> reverseIncludes = null)
-        {
-            Uri link =  new Uri(RestOperation.HISTORY, UriKind.Relative);
-            Snapshot snapshot = Snapshot.Create(Bundle.BundleType.History, link, keys, "history" , count, includes, reverseIncludes);
+            var link = new Uri(RestOperation.HISTORY, UriKind.Relative);
+            var snapshot = Snapshot.Create(Bundle.BundleType.History, link, keys, "history", count, includes, reverseIncludes);
             return snapshot;
         }
-     
+
     }
 }

--- a/src/Spark.Mongo/Store/Extensions/HistoryExtension.cs
+++ b/src/Spark.Mongo/Store/Extensions/HistoryExtension.cs
@@ -26,19 +26,19 @@ namespace Spark.Mongo.Store.Extensions
         [Obsolete("Use Async method version instead")]
         public Snapshot History(string typename, HistoryParameters parameters)
         {
-            return Task.Run(() => HistoryAsync(typename, parameters)).Result;
+            return Task.Run(() => HistoryAsync(typename, parameters)).GetAwaiter().GetResult();
         }
 
         [Obsolete("Use Async method version instead")]
         public Snapshot History(IKey key, HistoryParameters parameters)
         {
-            return Task.Run(() => HistoryAsync(key, parameters)).Result;
+            return Task.Run(() => HistoryAsync(key, parameters)).GetAwaiter().GetResult();
         }
 
         [Obsolete("Use Async method version instead")]
         public Snapshot History(HistoryParameters parameters)
         {
-            return Task.Run(() => HistoryAsync(parameters)).Result;
+            return Task.Run(() => HistoryAsync(parameters)).GetAwaiter().GetResult();
         }
 
         public async Task<Snapshot> HistoryAsync(string resource, HistoryParameters parameters)

--- a/src/Spark.Mongo/Store/MongoFhirStore.cs
+++ b/src/Spark.Mongo/Store/MongoFhirStore.cs
@@ -9,7 +9,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-
+using System.Threading.Tasks;
 using MongoDB.Bson;
 using MongoDB.Driver;
 using Spark.Engine.Core;
@@ -31,14 +31,32 @@ namespace Spark.Store.Mongo
             //this.transaction = new MongoSimpleTransaction(collection);
         }
 
+        [Obsolete("Use Async method version instead")]
         public void Add(Entry entry)
         {
-            BsonDocument document = SparkBsonHelper.ToBsonDocument(entry);
-            Supercede(entry.Key);
-            collection.InsertOne(document);
+            Task.Run(() => AddAsync(entry)).Wait();
         }
 
-        public  Entry Get(IKey key)
+        [Obsolete("Use Async method version instead")]
+        public Entry Get(IKey key)
+        {
+            return Task.Run(() => GetAsync(key)).Result;
+        }
+
+        [Obsolete("Use Async method version instead")]
+        public IList<Entry> Get(IEnumerable<IKey> localIdentifiers)
+        {
+            return Task.Run(() => GetAsync(localIdentifiers)).Result;
+        }
+
+        public async Task AddAsync(Entry entry)
+        {
+            BsonDocument document = SparkBsonHelper.ToBsonDocument(entry);
+            await SupercedeAsync(entry.Key).ConfigureAwait(false);
+            await collection.InsertOneAsync(document).ConfigureAwait(false);
+        }
+
+        public async Task<Entry> GetAsync(IKey key)
         {
             var clauses = new List<FilterDefinition<BsonDocument>>();
 
@@ -56,12 +74,12 @@ namespace Spark.Store.Mongo
 
             FilterDefinition<BsonDocument> query = Builders<BsonDocument>.Filter.And(clauses);
 
-            BsonDocument document = collection.Find(query).FirstOrDefault();
+            BsonDocument document = (await collection.FindAsync(query).ConfigureAwait(false)).FirstOrDefault();
             return document.ToEntry();
 
         }
 
-        public  IList<Entry> Get(IEnumerable<IKey> identifiers)
+        public async Task<IList<Entry>> GetAsync(IEnumerable<IKey> identifiers)
         {
             if (!identifiers.Any())
                 return new List<Entry>();
@@ -77,7 +95,7 @@ namespace Spark.Store.Mongo
                 queries.Add(GetCurrentVersionQuery(unversionedIdentifiers));
             FilterDefinition<BsonDocument> query = Builders<BsonDocument>.Filter.Or(queries);
 
-            IEnumerable<BsonDocument> cursor = collection.Find(query).ToEnumerable();
+            IEnumerable<BsonDocument> cursor = (await collection.FindAsync(query).ConfigureAwait(false)).ToEnumerable();
 
             return cursor.ToEntries().ToList();
         }
@@ -104,7 +122,7 @@ namespace Spark.Store.Mongo
             return Builders<BsonDocument>.Filter.And(clauses);
         }
 
-        private void Supercede(IKey key)
+        private async Task SupercedeAsync(IKey key)
         {
             var pk = key.ToBsonReferenceKey();
             FilterDefinition<BsonDocument> query = Builders<BsonDocument>.Filter.And(
@@ -114,7 +132,7 @@ namespace Spark.Store.Mongo
 
             UpdateDefinition<BsonDocument> update = Builders<BsonDocument>.Update.Set(Field.STATE, Value.SUPERCEDED);
             // A single delete on a sharded collection must contain an exact match on _id (and have the collection default collation) or contain the shard key (and have the simple collation). 
-            collection.UpdateMany(query, update);
+            await collection.UpdateManyAsync(query, update);
         }
 
     }

--- a/src/Spark.Mongo/Store/MongoFhirStore.cs
+++ b/src/Spark.Mongo/Store/MongoFhirStore.cs
@@ -34,19 +34,19 @@ namespace Spark.Store.Mongo
         [Obsolete("Use Async method version instead")]
         public void Add(Entry entry)
         {
-            Task.Run(() => AddAsync(entry)).Wait();
+            Task.Run(() => AddAsync(entry)).GetAwaiter().GetResult();
         }
 
         [Obsolete("Use Async method version instead")]
         public Entry Get(IKey key)
         {
-            return Task.Run(() => GetAsync(key)).Result;
+            return Task.Run(() => GetAsync(key)).GetAwaiter().GetResult();
         }
 
         [Obsolete("Use Async method version instead")]
         public IList<Entry> Get(IEnumerable<IKey> localIdentifiers)
         {
-            return Task.Run(() => GetAsync(localIdentifiers)).Result;
+            return Task.Run(() => GetAsync(localIdentifiers)).GetAwaiter().GetResult();
         }
 
         public async Task AddAsync(Entry entry)

--- a/src/Spark.Mongo/Store/MongoFhirStoreOther.cs
+++ b/src/Spark.Mongo/Store/MongoFhirStoreOther.cs
@@ -10,6 +10,7 @@ using Spark.Engine.Store.Interfaces;
 namespace Spark.Store.Mongo
 {
     //TODO: decide if we still need this
+    [Obsolete("Don't use it at all")]
     public class MongoFhirStoreOther
     {
         private readonly IFhirStore _mongoFhirStoreOther;

--- a/src/Spark.Mongo/Store/MongoSnapshotStore.cs
+++ b/src/Spark.Mongo/Store/MongoSnapshotStore.cs
@@ -17,12 +17,12 @@ namespace Spark.Mongo.Store
 
         public void AddSnapshot(Snapshot snapshot)
         {
-            Task.Run(() => AddSnapshotAsync(snapshot)).Wait();
+            Task.Run(() => AddSnapshotAsync(snapshot)).GetAwaiter().GetResult();
         }
 
         public Snapshot GetSnapshot(string snapshotid)
         {
-            return Task.Run(() => GetSnapshotAsync(snapshotid)).Result;
+            return Task.Run(() => GetSnapshotAsync(snapshotid)).GetAwaiter().GetResult();
         }
 
         public async Task AddSnapshotAsync(Snapshot snapshot)

--- a/src/Spark.Mongo/Store/MongoSnapshotStore.cs
+++ b/src/Spark.Mongo/Store/MongoSnapshotStore.cs
@@ -1,4 +1,5 @@
-﻿using MongoDB.Driver;
+﻿using System.Threading.Tasks;
+using MongoDB.Driver;
 using Spark.Engine.Core;
 using Spark.Engine.Store.Interfaces;
 using Spark.Store.Mongo;
@@ -8,20 +9,33 @@ namespace Spark.Mongo.Store
     public class MongoSnapshotStore : ISnapshotStore
     {
         IMongoDatabase database;
+
         public MongoSnapshotStore(string mongoUrl)
         {
             this.database = MongoDatabaseFactory.GetMongoDatabase(mongoUrl);
         }
+
         public void AddSnapshot(Snapshot snapshot)
         {
-            var collection = database.GetCollection<Snapshot>(Collection.SNAPSHOT);
-            collection.InsertOne(snapshot);
+            Task.Run(() => AddSnapshotAsync(snapshot)).Wait();
         }
 
         public Snapshot GetSnapshot(string snapshotid)
         {
+            return Task.Run(() => GetSnapshotAsync(snapshotid)).Result;
+        }
+
+        public async Task AddSnapshotAsync(Snapshot snapshot)
+        {
             var collection = database.GetCollection<Snapshot>(Collection.SNAPSHOT);
-            return collection.Find(s => s.Id == snapshotid).FirstOrDefault();
+            await collection.InsertOneAsync(snapshot).ConfigureAwait(false);
+        }
+
+        public async Task<Snapshot> GetSnapshotAsync(string snapshotId)
+        {
+            var collection = database.GetCollection<Snapshot>(Collection.SNAPSHOT);
+            return (await collection.FindAsync(s => s.Id == snapshotId).ConfigureAwait(false))
+                .FirstOrDefault();
         }
     }
 }

--- a/src/Spark.Mongo/Store/MongoStoreAdministration.cs
+++ b/src/Spark.Mongo/Store/MongoStoreAdministration.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using MongoDB.Bson;
 using MongoDB.Driver;
 using Spark.Engine.Interfaces;
@@ -16,19 +18,26 @@ namespace Spark.Mongo.Store
             this.database = MongoDatabaseFactory.GetMongoDatabase(mongoUrl);
             this.collection = database.GetCollection<BsonDocument>(Collection.RESOURCE);
         }
+
+        [Obsolete("Use Async method version instead")]
         public void Clean()
         {
-            EraseData();
-            EnsureIndices();
+            Task.Run(CleanAsync).Wait();
+        }
+
+        public async Task CleanAsync()
+        {
+            await EraseDataAsync().ConfigureAwait(false);
+            await EnsureIndicesAsync().ConfigureAwait(false);
         }
 
         // Drops all collections, including the special 'counters' collection for generating ids,
         // AND the binaries stored at Amazon S3
-        private void EraseData()
+        private async Task EraseDataAsync()
         {
             // Don't try this at home
             var collectionsToDrop = new string[] { Collection.RESOURCE, Collection.COUNTERS, Collection.SNAPSHOT };
-            DropCollections(collectionsToDrop);
+            await DropCollectionsAsync(collectionsToDrop).ConfigureAwait(false);
 
             /*
             // When using Amazon S3, remove blobs from there as well
@@ -46,17 +55,17 @@ namespace Spark.Mongo.Store
             }
             */
         }
-        private void DropCollections(IEnumerable<string> collections)
+        private async Task DropCollectionsAsync(IEnumerable<string> collections)
         {
             foreach (var name in collections)
             {
-                TryDropCollection(name);
+                await TryDropCollectionAsync(name).ConfigureAwait(false);
             }
         }
 
 
 
-        private void EnsureIndices()
+        private async Task EnsureIndicesAsync()
         {
             var indices = new List<CreateIndexModel<BsonDocument>>
             {
@@ -64,14 +73,14 @@ namespace Spark.Mongo.Store
                 new CreateIndexModel<BsonDocument>(Builders<BsonDocument>.IndexKeys.Ascending(Field.PRIMARYKEY).Ascending(Field.STATE)),
                 new CreateIndexModel<BsonDocument>(Builders<BsonDocument>.IndexKeys.Descending(Field.WHEN).Ascending(Field.TYPENAME)),
             };
-            collection.Indexes.CreateMany(indices);
+            await collection.Indexes.CreateManyAsync(indices).ConfigureAwait(false);
         }
 
-        private void TryDropCollection(string name)
+        private async Task TryDropCollectionAsync(string name)
         {
             try
             {
-                database.DropCollection(name);
+                await database.DropCollectionAsync(name).ConfigureAwait(false);
             }
             catch
             {

--- a/src/Spark.Mongo/Store/MongoStoreAdministration.cs
+++ b/src/Spark.Mongo/Store/MongoStoreAdministration.cs
@@ -22,7 +22,7 @@ namespace Spark.Mongo.Store
         [Obsolete("Use Async method version instead")]
         public void Clean()
         {
-            Task.Run(CleanAsync).Wait();
+            Task.Run(CleanAsync).GetAwaiter().GetResult();
         }
 
         public async Task CleanAsync()

--- a/src/Spark.Web/Controllers/FhirController.cs
+++ b/src/Spark.Web/Controllers/FhirController.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
 using System.Net;
+using System.Threading.Tasks;
 using System.Web;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Rest;
@@ -12,40 +13,41 @@ using Microsoft.AspNetCore.Mvc;
 using Spark.Engine;
 using Spark.Engine.Core;
 using Spark.Engine.Extensions;
+using Spark.Engine.Service;
 using Spark.Engine.Utility;
-using Spark.Service;
 
 namespace Spark.Web.Controllers
 {
     [Route("fhir"), ApiController, EnableCors]
     public class FhirController : ControllerBase
     {
-        private readonly IFhirService _fhirService;
+        private readonly IAsyncFhirService _fhirService;
         private readonly SparkSettings _settings;
 
-        public FhirController(IFhirService fhirService, SparkSettings settings)
+        public FhirController(IAsyncFhirService fhirService, SparkSettings settings)
         {
             _fhirService = fhirService ?? throw new ArgumentNullException(nameof(fhirService));
             _settings = settings ?? throw new ArgumentNullException(nameof(settings));
         }
 
         [HttpGet("{type}/{id}")]
-        public ActionResult<FhirResponse> Read(string type, string id)
+        public async Task<ActionResult<FhirResponse>> Read(string type, string id)
         {
             ConditionalHeaderParameters parameters = new ConditionalHeaderParameters(Request);
             Key key = Key.Create(type, id);
-            return new ActionResult<FhirResponse>(_fhirService.Read(key, parameters));
+            var response = await _fhirService.ReadAsync(key, parameters).ConfigureAwait(false);
+            return new ActionResult<FhirResponse>(response);
         }
 
         [HttpGet("{type}/{id}/_history/{vid}")]
-        public FhirResponse VRead(string type, string id, string vid)
+        public async Task<FhirResponse> VRead(string type, string id, string vid)
         {
             Key key = Key.Create(type, id, vid);
-            return _fhirService.VersionRead(key);
+            return await _fhirService.VersionReadAsync(key).ConfigureAwait(false);
         }
 
         [HttpPut("{type}/{id?}")]
-        public ActionResult<FhirResponse> Update(string type, Resource resource, string id = null)
+        public async Task<ActionResult<FhirResponse>> Update(string type, Resource resource, string id = null)
         {
             string versionId = Request.GetTypedHeaders().IfMatch?.FirstOrDefault()?.Tag.Buffer;
             Key key = Key.Create(type, id, versionId);
@@ -53,17 +55,17 @@ namespace Spark.Web.Controllers
             {
                 Request.TransferResourceIdIfRawBinary(resource, id);
 
-                return new ActionResult<FhirResponse>(_fhirService.Update(key, resource));
+                return new ActionResult<FhirResponse>(await _fhirService.UpdateAsync(key, resource).ConfigureAwait(false));
             }
             else
             {
-                return new ActionResult<FhirResponse>(_fhirService.ConditionalUpdate(key, resource,
-                    SearchParams.FromUriParamList(Request.TupledParameters())));
+                return new ActionResult<FhirResponse>(await _fhirService.ConditionalUpdateAsync(key, resource,
+                    SearchParams.FromUriParamList(Request.TupledParameters())).ConfigureAwait(false));
             }
         }
 
         [HttpPost("{type}")]
-        public FhirResponse Create(string type, Resource resource)
+        public async Task<FhirResponse> Create(string type, Resource resource)
         {
             Key key = Key.Create(type, resource?.Id);
 
@@ -74,99 +76,99 @@ namespace Spark.Web.Controllers
                     searchQueryString.Keys.Cast<string>()
                         .Select(k => new Tuple<string, string>(k, searchQueryString[k]));
 
-                return _fhirService.ConditionalCreate(key, resource, SearchParams.FromUriParamList(searchValues));
+                return await _fhirService.ConditionalCreateAsync(key, resource, SearchParams.FromUriParamList(searchValues)).ConfigureAwait(false);
             }
 
-            return _fhirService.Create(key, resource);
+            return await _fhirService.CreateAsync(key, resource).ConfigureAwait(false);
         }
 
         [HttpDelete("{type}/{id}")]
-        public FhirResponse Delete(string type, string id)
+        public async Task<FhirResponse> Delete(string type, string id)
         {
             Key key = Key.Create(type, id);
-            FhirResponse response = _fhirService.Delete(key);
+            FhirResponse response = await _fhirService.DeleteAsync(key).ConfigureAwait(false);
             return response;
         }
 
         [HttpDelete("{type}")]
-        public FhirResponse ConditionalDelete(string type)
+        public async Task<FhirResponse> ConditionalDelete(string type)
         {
             Key key = Key.Create(type);
-            return _fhirService.ConditionalDelete(key, Request.TupledParameters());
+            return await _fhirService.ConditionalDeleteAsync(key, Request.TupledParameters()).ConfigureAwait(false);
         }
 
         [HttpGet("{type}/{id}/_history")]
-        public FhirResponse History(string type, string id)
+        public async Task<FhirResponse> History(string type, string id)
         {
             Key key = Key.Create(type, id);
             var parameters = new HistoryParameters(Request);
-            return _fhirService.History(key, parameters);
+            return await _fhirService.HistoryAsync(key, parameters).ConfigureAwait(false);
         }
 
         // ============= Validate
 
         [HttpPost("{type}/{id}/$validate")]
-        public FhirResponse Validate(string type, string id, Resource resource)
+        public async Task<FhirResponse> Validate(string type, string id, Resource resource)
         {
             Key key = Key.Create(type, id);
-            return _fhirService.ValidateOperation(key, resource);
+            return await _fhirService.ValidateOperationAsync(key, resource).ConfigureAwait(false);
         }
 
         [HttpPost("{type}/$validate")]
-        public FhirResponse Validate(string type, Resource resource)
+        public async Task<FhirResponse> Validate(string type, Resource resource)
         {
             Key key = Key.Create(type);
-            return _fhirService.ValidateOperation(key, resource);
+            return await _fhirService.ValidateOperationAsync(key, resource).ConfigureAwait(false);
         }
 
         // ============= Type Level Interactions
 
         [HttpGet("{type}")]
-        public FhirResponse Search(string type)
+        public async Task<FhirResponse> Search(string type)
         {
             int start = FhirParameterParser.ParseIntParameter(Request.GetParameter(FhirParameter.SNAPSHOT_INDEX)) ?? 0;
             var searchparams = Request.GetSearchParams();
             //int pagesize = Request.GetIntParameter(FhirParameter.COUNT) ?? Const.DEFAULT_PAGE_SIZE;
             //string sortby = Request.GetParameter(FhirParameter.SORT);
 
-            return _fhirService.Search(type, searchparams, start);
+            return await _fhirService.SearchAsync(type, searchparams, start).ConfigureAwait(false);
         }
 
         [HttpPost("{type}/_search")]
-        public FhirResponse SearchWithOperator(string type)
+        public async Task<FhirResponse> SearchWithOperator(string type)
         {
             // TODO: start index should be retrieved from the body.
             int start = FhirParameterParser.ParseIntParameter(Request.GetParameter(FhirParameter.SNAPSHOT_INDEX)) ?? 0;
             SearchParams searchparams = Request.GetSearchParamsFromBody();
 
-            return _fhirService.Search(type, searchparams, start);
+            return await _fhirService.SearchAsync(type, searchparams, start).ConfigureAwait(false);
         }
 
         [HttpGet("{type}/_history")]
-        public FhirResponse History(string type)
+        public async Task<FhirResponse> History(string type)
         {
             var parameters = new HistoryParameters(Request);
-            return _fhirService.History(type, parameters);
+            return await _fhirService.HistoryAsync(type, parameters).ConfigureAwait(false);
         }
 
         // ============= Whole System Interactions
 
         [HttpGet, Route("metadata")]
-        public FhirResponse Metadata()
+        public async Task<FhirResponse> Metadata()
         {
-            return _fhirService.CapabilityStatement(_settings.Version);
+            return await _fhirService.CapabilityStatementAsync(_settings.Version).ConfigureAwait(false);
         }
 
         [HttpOptions, Route("")]
-        public FhirResponse Options()
+        public async Task<FhirResponse> Options()
         {
-            return _fhirService.CapabilityStatement(_settings.Version);
+            return await _fhirService.CapabilityStatementAsync(_settings.Version).ConfigureAwait(false);
         }
 
         [HttpPost, Route("")]
-        public FhirResponse Transaction(Bundle bundle)
+        public async Task<FhirResponse> Transaction(Bundle bundle)
         {
-            return _fhirService.Transaction(bundle);
+            return await _fhirService.TransactionAsync(bundle).ConfigureAwait(false);
         }
 
         //[HttpPost, Route("Mailbox")]
@@ -177,18 +179,18 @@ namespace Spark.Web.Controllers
         //}
 
         [HttpGet, Route("_history")]
-        public FhirResponse History()
+        public async Task<FhirResponse> History()
         {
             var parameters = new HistoryParameters(Request);
-            return _fhirService.History(parameters);
+            return await _fhirService.HistoryAsync(parameters).ConfigureAwait(false);
         }
 
         [HttpGet, Route("_snapshot")]
-        public FhirResponse Snapshot()
+        public async Task<FhirResponse> Snapshot()
         {
             string snapshot = Request.GetParameter(FhirParameter.SNAPSHOT_ID);
             int start = FhirParameterParser.ParseIntParameter(Request.GetParameter(FhirParameter.SNAPSHOT_INDEX)) ?? 0;
-            return _fhirService.GetPage(snapshot, start);
+            return await _fhirService.GetPageAsync(snapshot, start).ConfigureAwait(false);
         }
 
         // Operations
@@ -204,13 +206,13 @@ namespace Spark.Web.Controllers
         }
 
         [HttpPost, Route("{type}/{id}/${operation}")]
-        public FhirResponse InstanceOperation(string type, string id, string operation, Parameters parameters)
+        public async Task<FhirResponse> InstanceOperation(string type, string id, string operation, Parameters parameters)
         {
             Key key = Key.Create(type, id);
             switch (operation.ToLower())
             {
-                case "meta": return _fhirService.ReadMeta(key);
-                case "meta-add": return _fhirService.AddMeta(key, parameters);
+                case "meta": return await _fhirService.ReadMetaAsync(key).ConfigureAwait(false);
+                case "meta-add": return await _fhirService.AddMetaAsync(key, parameters).ConfigureAwait(false);
                 case "meta-delete":
 
                 default: return Respond.WithError(HttpStatusCode.NotFound, "Unknown operation");
@@ -218,24 +220,24 @@ namespace Spark.Web.Controllers
         }
 
         [HttpPost, HttpGet, Route("{type}/{id}/$everything")]
-        public FhirResponse Everything(string type, string id = null)
+        public async Task<FhirResponse> Everything(string type, string id = null)
         {
             Key key = Key.Create(type, id);
-            return _fhirService.Everything(key);
+            return await _fhirService.EverythingAsync(key).ConfigureAwait(false);
         }
 
         [HttpPost, HttpGet, Route("{type}/$everything")]
-        public FhirResponse Everything(string type)
+        public async Task<FhirResponse> Everything(string type)
         {
             Key key = Key.Create(type);
-            return _fhirService.Everything(key);
+            return await _fhirService.EverythingAsync(key).ConfigureAwait(false);
         }
 
         [HttpPost, HttpGet, Route("Composition/{id}/$document")]
-        public FhirResponse Document(string id)
+        public async Task<FhirResponse> Document(string id)
         {
             Key key = Key.Create("Composition", id);
-            return _fhirService.Document(key);
+            return await _fhirService.DocumentAsync(key).ConfigureAwait(false);
         }
     }
 }

--- a/src/Spark.Web/Hubs/MaintenanceHub.cs
+++ b/src/Spark.Web/Hubs/MaintenanceHub.cs
@@ -1,7 +1,6 @@
 using Hl7.Fhir.Model;
 using Spark.Core;
 using Spark.Engine.Core;
-using Spark.Service;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -13,6 +12,7 @@ using Spark.Web.Utilities;
 using System.IO;
 using Tasks = System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Spark.Engine.Service;
 using Spark.Engine.Service.FhirServiceExtensions;
 
 namespace Spark.Web.Hubs
@@ -22,7 +22,7 @@ namespace Spark.Web.Hubs
     {
         private List<Resource> _resources = null;
 
-        private IFhirService _fhirService;
+        private IAsyncFhirService _fhirService;
         private ILocalhost _localhost;
         private IFhirStoreAdministration _fhirStoreAdministration;
         private IFhirIndex _fhirIndex;
@@ -34,7 +34,7 @@ namespace Spark.Web.Hubs
         private int _resourceCount;
 
         public MaintenanceHub(
-            IFhirService fhirService,
+            IAsyncFhirService fhirService,
             ILocalhost localhost,
             IFhirStoreAdministration fhirStoreAdministration,
             IFhirIndex fhirIndex,
@@ -90,8 +90,8 @@ namespace Spark.Web.Hubs
             try
             {
                 await notifier.SendProgressUpdate(0, "Clearing the database...");
-                _fhirStoreAdministration.Clean();
-                _fhirIndex.Clean();
+                await _fhirStoreAdministration.CleanAsync().ConfigureAwait(false);
+                await _fhirIndex.CleanAsync().ConfigureAwait(false);
                 await notifier.SendProgressUpdate(100, "Database cleared");
             }
             catch (Exception e)
@@ -118,7 +118,7 @@ namespace Spark.Web.Hubs
             }
         }
 
-        public async void LoadExamplesToStore()
+        public async Tasks.Task LoadExamplesToStore()
         {
             var messages = new StringBuilder();
             var notifier = new HubContextProgressNotifier(_hubContext, _logger);
@@ -143,11 +143,11 @@ namespace Spark.Web.Hubs
 
                         if (res.Id != null && res.Id != "")
                         {
-                            _fhirService.Put(key, res);
+                            await _fhirService.PutAsync(key, res).ConfigureAwait(false);
                         }
                         else
                         {
-                            _fhirService.Create(key, res);
+                            await _fhirService.CreateAsync(key, res).ConfigureAwait(false);
                         }
                     }
                     catch (Exception e)

--- a/src/Spark/App_Start/UnityConfig.cs
+++ b/src/Spark/App_Start/UnityConfig.cs
@@ -103,6 +103,7 @@ namespace Spark
             container.RegisterType<InitializerHub>(new HierarchicalLifetimeManager());
             container.RegisterType<IHistoryStore, HistoryStore>(new InjectionConstructor(Settings.MongoUrl));
             container.RegisterType<IFhirService, FhirService>(new ContainerControlledLifetimeManager());
+            container.RegisterType<IAsyncFhirService, AsyncFhirService>(new ContainerControlledLifetimeManager());
             container.RegisterType<IIndexRebuildService, IndexRebuildService>(new ContainerControlledLifetimeManager(),
                 new InjectionConstructor(
                     container.Resolve<IIndexStore>(),

--- a/src/Spark/Controllers/FhirController.cs
+++ b/src/Spark/Controllers/FhirController.cs
@@ -8,11 +8,13 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
 using System.Net;
+using System.Threading.Tasks;
 using System.Web;
 using System.Web.Http;
 using System.Web.Http.Cors;
 using Hl7.Fhir.Rest;
 using Spark.Core;
+using Spark.Engine.Service;
 using Spark.Infrastructure;
 using Spark.Engine.Utility;
 
@@ -22,34 +24,34 @@ namespace Spark.Controllers
     [RouteDataValuesOnly]
     public class FhirController : ApiController
     {
-        readonly IFhirService _fhirService;
+        readonly IAsyncFhirService _fhirService;
 
         [InjectionConstructor]
-        public FhirController(IFhirService fhirService)
+        public FhirController(IAsyncFhirService fhirService)
         {
             // This will be a (injected) constructor parameter in ASP.vNext.
             _fhirService = fhirService;
         }
 
         [HttpGet, Route("{type}/{id}")]
-        public FhirResponse Read(string type, string id)
+        public async Task<FhirResponse> Read(string type, string id)
         {
             ConditionalHeaderParameters parameters = new ConditionalHeaderParameters(Request);
             Key key = Key.Create(type, id);
-            FhirResponse response = _fhirService.Read(key, parameters);
+            FhirResponse response = await _fhirService.ReadAsync(key, parameters).ConfigureAwait(false);
 
             return response;
         }
 
         [HttpGet, Route("{type}/{id}/_history/{vid}")]
-        public FhirResponse VRead(string type, string id, string vid)
+        public async Task<FhirResponse> VRead(string type, string id, string vid)
         {
             Key key = Key.Create(type, id, vid);
-            return _fhirService.VersionRead(key);
+            return await _fhirService.VersionReadAsync(key).ConfigureAwait(false);
         }
 
         [HttpPut, Route("{type}/{id?}")]
-        public FhirResponse Update(string type, Resource resource, string id = null)
+        public async Task<FhirResponse> Update(string type, Resource resource, string id = null)
         {
             string versionid = Request.IfMatchVersionId();
             Key key = Key.Create(type, id, versionid);
@@ -57,17 +59,17 @@ namespace Spark.Controllers
             {
                 Request.TransferResourceIdIfRawBinary(resource, id);
 
-                return _fhirService.Update(key, resource);
+                return await _fhirService.UpdateAsync(key, resource).ConfigureAwait(false);
             }
             else
             {
-                return _fhirService.ConditionalUpdate(key, resource,
-                    SearchParams.FromUriParamList(Request.TupledParameters()));
+                return await _fhirService.ConditionalUpdateAsync(key, resource,
+                    SearchParams.FromUriParamList(Request.TupledParameters())).ConfigureAwait(false);
             }
         }
 
         [HttpPost, Route("{type}")]
-        public FhirResponse Create(string type, Resource resource)
+        public async Task<FhirResponse> Create(string type, Resource resource)
         {
             Key key = Key.Create(type, resource?.Id);
 
@@ -81,103 +83,104 @@ namespace Spark.Controllers
                         .Select(k => new Tuple<string, string>(k, searchQueryString[k]));
 
 
-                return _fhirService.ConditionalCreate(key, resource, SearchParams.FromUriParamList(searchValues));
+                return await _fhirService.ConditionalCreateAsync(key, resource, SearchParams.FromUriParamList(searchValues))
+                    .ConfigureAwait(false);
             }
 
             //entry.Tags = Request.GetFhirTags(); // todo: move to model binder?
 
-            return _fhirService.Create(key, resource);
+            return await _fhirService.CreateAsync(key, resource).ConfigureAwait(false);
         }
 
         [HttpDelete, Route("{type}/{id}")]
-        public FhirResponse Delete(string type, string id)
+        public async Task<FhirResponse> Delete(string type, string id)
         {
             Key key = Key.Create(type, id);
-            FhirResponse response = _fhirService.Delete(key);
+            FhirResponse response = await _fhirService.DeleteAsync(key).ConfigureAwait(false);
             return response;
         }
 
         [HttpDelete, Route("{type}")]
-        public FhirResponse ConditionalDelete(string type)
+        public async Task<FhirResponse> ConditionalDelete(string type)
         {
             Key key = Key.Create(type);
-            return _fhirService.ConditionalDelete(key, Request.TupledParameters());
+            return await _fhirService.ConditionalDeleteAsync(key, Request.TupledParameters()).ConfigureAwait(false);
         }
 
         [HttpGet, Route("{type}/{id}/_history")]
-        public FhirResponse History(string type, string id)
+        public async Task<FhirResponse> History(string type, string id)
         {
             Key key = Key.Create(type, id);
             var parameters = new HistoryParameters(Request);
-            return _fhirService.History(key, parameters);
+            return await _fhirService.HistoryAsync(key, parameters).ConfigureAwait(false);
         }
 
         // ============= Validate
         [HttpPost, Route("{type}/{id}/$validate")]
-        public FhirResponse Validate(string type, string id, Resource resource)
+        public async Task<FhirResponse> Validate(string type, string id, Resource resource)
         {
             //entry.Tags = Request.GetFhirTags();
             Key key = Key.Create(type, id);
-            return _fhirService.ValidateOperation(key, resource);
+            return await _fhirService.ValidateOperationAsync(key, resource).ConfigureAwait(false);
         }
 
         [HttpPost, Route("{type}/$validate")]
-        public FhirResponse Validate(string type, Resource resource)
+        public async Task<FhirResponse> Validate(string type, Resource resource)
         {
             // DSTU2: tags
             //entry.Tags = Request.GetFhirTags();
             Key key = Key.Create(type);
-            return _fhirService.ValidateOperation(key, resource);
+            return await _fhirService.ValidateOperationAsync(key, resource).ConfigureAwait(false);
         }
 
         // ============= Type Level Interactions
 
         [HttpGet, Route("{type}")]
-        public FhirResponse Search(string type)
+        public async Task<FhirResponse> Search(string type)
         {
             int start = FhirParameterParser.ParseIntParameter(Request.GetParameter(FhirParameter.SNAPSHOT_INDEX)) ?? 0;
             var searchparams = Request.GetSearchParams();
             //int pagesize = Request.GetIntParameter(FhirParameter.COUNT) ?? Const.DEFAULT_PAGE_SIZE;
             //string sortby = Request.GetParameter(FhirParameter.SORT);
 
-            return _fhirService.Search(type, searchparams, start);
+            return await _fhirService.SearchAsync(type, searchparams, start).ConfigureAwait(false);
         }
 
         [HttpPost, Route("{type}/_search")]
-        public FhirResponse SearchWithOperator(string type)
+        public async Task<FhirResponse> SearchWithOperator(string type)
         {
             // TODO: start index should be retrieved from the body.
             int start = FhirParameterParser.ParseIntParameter(Request.GetParameter(FhirParameter.SNAPSHOT_INDEX)) ?? 0;
             SearchParams searchparams = Request.GetSearchParamsFromBody();
 
-            return _fhirService.Search(type, searchparams, start);
+            return await _fhirService.SearchAsync(type, searchparams, start).ConfigureAwait(false);
         }
 
         [HttpGet, Route("{type}/_history")]
-        public FhirResponse History(string type)
+        public async Task<FhirResponse> History(string type)
         {
             var parameters = new HistoryParameters(Request);
-            return _fhirService.History(type, parameters);
+            return await _fhirService.HistoryAsync(type, parameters).ConfigureAwait(false);
         }
 
         // ============= Whole System Interactions
 
         [HttpGet, Route("metadata")]
-        public FhirResponse Metadata()
+        public async Task<FhirResponse> Metadata()
         {
-            return _fhirService.CapabilityStatement(Settings.Version);
+            return await _fhirService.CapabilityStatementAsync(Settings.Version).ConfigureAwait(false);
         }
 
         [HttpOptions, Route("")]
-        public FhirResponse Options()
+        public async Task<FhirResponse> Options()
         {
-            return _fhirService.CapabilityStatement(Settings.Version);
+            return await _fhirService.CapabilityStatementAsync(Settings.Version).ConfigureAwait(false);
         }
 
         [HttpPost, Route("")]
-        public FhirResponse Transaction(Bundle bundle)
+        public async Task<FhirResponse> Transaction(Bundle bundle)
         {
-            return _fhirService.Transaction(bundle);
+            return await _fhirService.TransactionAsync(bundle).ConfigureAwait(false);
         }
 
         //[HttpPost, Route("Mailbox")]
@@ -188,18 +191,18 @@ namespace Spark.Controllers
         //}
 
         [HttpGet, Route("_history")]
-        public FhirResponse History()
+        public async Task<FhirResponse> History()
         {
             var parameters = new HistoryParameters(Request);
-            return _fhirService.History(parameters);
+            return await _fhirService.HistoryAsync(parameters).ConfigureAwait(false);
         }
 
         [HttpGet, Route("_snapshot")]
-        public FhirResponse Snapshot()
+        public async Task<FhirResponse> Snapshot()
         {
             string snapshot = Request.GetParameter(FhirParameter.SNAPSHOT_ID);
             int start = FhirParameterParser.ParseIntParameter(Request.GetParameter(FhirParameter.SNAPSHOT_INDEX)) ?? 0;
-            return _fhirService.GetPage(snapshot, start);
+            return await _fhirService.GetPageAsync(snapshot, start).ConfigureAwait(false);
         }
 
         // Operations
@@ -215,13 +218,13 @@ namespace Spark.Controllers
         }
 
         [HttpPost, Route("{type}/{id}/${operation}")]
-        public FhirResponse InstanceOperation(string type, string id, string operation, Parameters parameters)
+        public async Task<FhirResponse> InstanceOperation(string type, string id, string operation, Parameters parameters)
         {
             Key key = Key.Create(type, id);
             switch (operation.ToLower())
             {
-                case "meta": return _fhirService.ReadMeta(key);
-                case "meta-add": return _fhirService.AddMeta(key, parameters);
+                case "meta": return await _fhirService.ReadMetaAsync(key).ConfigureAwait(false);
+                case "meta-add": return await _fhirService.AddMetaAsync(key, parameters).ConfigureAwait(false);
                 case "meta-delete":
 
                 default: return Respond.WithError(HttpStatusCode.NotFound, "Unknown operation");
@@ -229,24 +232,24 @@ namespace Spark.Controllers
         }
 
         [HttpPost, HttpGet, Route("{type}/{id}/$everything")]
-        public FhirResponse Everything(string type, string id = null)
+        public async Task<FhirResponse> Everything(string type, string id = null)
         {
             Key key = Key.Create(type, id);
-            return _fhirService.Everything(key);
+            return await _fhirService.EverythingAsync(key).ConfigureAwait(false);
         }
 
         [HttpPost, HttpGet, Route("{type}/$everything")]
-        public FhirResponse Everything(string type)
+        public async Task<FhirResponse> Everything(string type)
         {
             Key key = Key.Create(type);
-            return _fhirService.Everything(key);
+            return await _fhirService.EverythingAsync(key).ConfigureAwait(false);
         }
 
         [HttpPost, HttpGet, Route("Composition/{id}/$document")]
-        public FhirResponse Document(string id)
+        public async Task<FhirResponse> Document(string id)
         {
             Key key = Key.Create("Composition", id);
-            return _fhirService.Document(key);
+            return await _fhirService.DocumentAsync(key).ConfigureAwait(false);
         }
 
         // ============= Tag Interactions

--- a/src/Spark/Controllers/MaintenanceApiController.cs
+++ b/src/Spark/Controllers/MaintenanceApiController.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Configuration;
+using System.Threading.Tasks;
 using System.Web.Http;
 using System.Web.Http.Cors;
 using Spark.Core;
@@ -20,13 +21,13 @@ namespace Spark.Controllers
         }
 
         [HttpDelete, Route("All")]
-        public void ClearAll(Guid access)
+        public async Task ClearAll(Guid access)
         {
             string code = ConfigurationManager.AppSettings.Get("clearAllCode");
             if (!string.IsNullOrEmpty(code) && access.ToString() == code)
             {
-                fhirStoreAdministration.Clean();
-                fhirIndex.Clean();
+                await fhirStoreAdministration.CleanAsync().ConfigureAwait(false);
+                await fhirIndex.CleanAsync().ConfigureAwait(false);
             }
         }
     }

--- a/src/Spark/Hubs/InitializerHub.cs
+++ b/src/Spark/Hubs/InitializerHub.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Text;
 using Tasks = System.Threading.Tasks;
 using Spark.Engine.Interfaces;
+using Spark.Engine.Service;
 using Spark.Engine.Service.FhirServiceExtensions;
 
 
@@ -27,7 +28,7 @@ namespace Spark.Import
 
         private List<Resource> resources;
 
-        private readonly IFhirService fhirService;
+        private readonly IAsyncFhirService fhirService;
         private readonly ILocalhost localhost;
         private readonly IFhirStoreAdministration fhirStoreAdministration;
         private readonly IFhirIndex fhirIndex;
@@ -36,7 +37,7 @@ namespace Spark.Import
         private int ResourceCount;
 
         public InitializerHub(
-            IFhirService fhirService, 
+            IAsyncFhirService fhirService, 
             ILocalhost localhost, 
             IFhirStoreAdministration fhirStoreAdministration, 
             IFhirIndex fhirIndex,
@@ -108,7 +109,7 @@ namespace Spark.Import
             };
             return msg;
         }
-        public void LoadData()
+        public async Tasks.Task LoadData()
         {
             var messages = new StringBuilder();
             messages.AppendLine("Import completed!");
@@ -116,8 +117,8 @@ namespace Spark.Import
             {
                 //cleans store and index
                 Progress("Clearing the database...", 0);
-                fhirStoreAdministration.Clean();
-                fhirIndex.Clean();
+                await fhirStoreAdministration.CleanAsync().ConfigureAwait(false);
+                await fhirIndex.CleanAsync().ConfigureAwait(false);
 
                 Progress("Loading examples data...", 5);
                 this.resources = GetExampleData();
@@ -140,11 +141,11 @@ namespace Spark.Import
                         if (res.Id != null && res.Id != "")
                         {
 
-                            fhirService.Put(key, res);
+                            await fhirService.PutAsync(key, res).ConfigureAwait(false);
                         }
                         else
                         {
-                            fhirService.Create(key, res);
+                            await fhirService.CreateAsync(key, res).ConfigureAwait(false);
                         }
                     }
                     catch (Exception e)

--- a/src/Spark/MetaStore/MaintenanceService.cs
+++ b/src/Spark/MetaStore/MaintenanceService.cs
@@ -46,12 +46,12 @@ namespace Spark.MetaStore
             {
                 await _fhirStoreAdministration.CleanAsync().ConfigureAwait(false);
                 await _fhirIndex.CleanAsync().ConfigureAwait(false);
-            }).Wait();
+            }).GetAwaiter().GetResult();
         }
 
         private void StoreExamples()
         {
-            Task.Run(() => _fhirService.TransactionAsync(_examples)).Wait();
+            Task.Run(() => _fhirService.TransactionAsync(_examples)).GetAwaiter().GetResult();
         }
 
         [Obsolete("Use method with signature ImportLimitedExamples().")]

--- a/src/Spark/MetaStore/MaintenanceService.cs
+++ b/src/Spark/MetaStore/MaintenanceService.cs
@@ -13,34 +13,45 @@ using Spark.Service;
 using Spark.Core;
 using Spark.Engine.Core;
 using Spark.Engine.Interfaces;
+using Spark.Engine.Service;
 using Spark.Import;
+using Task = System.Threading.Tasks.Task;
 
 namespace Spark.MetaStore
 {
     public class MaintenanceService
     {
         
-        private readonly IFhirService _fhirService;
+        private readonly IAsyncFhirService _fhirService;
         private readonly IFhirStoreAdministration _fhirStoreAdministration;
         private readonly IFhirIndex _fhirIndex;
         private Bundle _examples;
 
         [Obsolete("Use constructor with signature ctor(IFhirService, IFhirStoreAdministration, IFhirIndex)")]
-        public MaintenanceService(IFhirService fhirService, ILocalhost localhost, IGenerator keyGenerator, IFhirStoreAdministration fhirStoreAdministration, IFhirIndex fhirIndex)
+        public MaintenanceService(IAsyncFhirService fhirService, ILocalhost localhost, IGenerator keyGenerator, IFhirStoreAdministration fhirStoreAdministration, IFhirIndex fhirIndex)
             :this(fhirService, fhirStoreAdministration, fhirIndex)
         {
         }
         
-        public MaintenanceService(IFhirService fhirService, IFhirStoreAdministration fhirStoreAdministration, IFhirIndex fhirIndex)
+        public MaintenanceService(IAsyncFhirService fhirService, IFhirStoreAdministration fhirStoreAdministration, IFhirIndex fhirIndex)
         {
             _fhirService = fhirService;
            _fhirStoreAdministration = fhirStoreAdministration;
            _fhirIndex = fhirIndex;
         }
 
+        private void CleanStorage()
+        {
+            Task.Run(async () =>
+            {
+                await _fhirStoreAdministration.CleanAsync().ConfigureAwait(false);
+                await _fhirIndex.CleanAsync().ConfigureAwait(false);
+            }).Wait();
+        }
+
         private void StoreExamples()
         {
-            _fhirService.Transaction(_examples);
+            Task.Run(() => _fhirService.TransactionAsync(_examples)).Wait();
         }
 
         [Obsolete("Use method with signature ImportLimitedExamples().")]
@@ -80,7 +91,7 @@ namespace Spark.MetaStore
             //Note: also clears the counters collection, so id generation starts anew and
             //clears all stored binaries at Amazon S3.
 
-            double time_cleaning = Performance.Measure(_fhirStoreAdministration.Clean) + Performance.Measure(_fhirIndex.Clean); 
+            double time_cleaning = Performance.Measure(CleanStorage); 
             double time_loading = Performance.Measure(ImportLimitedExamples);
             double time_storing = Performance.Measure(StoreExamples);
 
@@ -94,7 +105,7 @@ namespace Spark.MetaStore
         
         public string Clean()
         {
-            double time_cleaning = Performance.Measure(_fhirStoreAdministration.Clean) + Performance.Measure(_fhirIndex.Clean);
+            double time_cleaning = Performance.Measure(CleanStorage);
             
             string message = String.Format(
                 "Database was succesfully cleaned. \nTime spent:" +


### PR DESCRIPTION
 - `IAsyncFhirService` created
 - `IFhirService` marked as `Obsolete`. All method calls are delegated to `IAsyncFhirService`.
 - Using `IAsyncFhirService` in controllers.
 - Async methods added to the following interfaces
       - `IInteractionHandler`
       - `ITransactionService`
       - `IResourceStorageService`
       - `IFhirStore`
       - `IPagingService`
       - `ISnapshotPagination`
       - `ISnapshotStore`
       - `IHistoryService`
       - `IHistoryExtension`
       - `IFhirIndex`
       - `IIndexService`
       - `ISearchService`
       - `IFhirStoreAdministration`
 - Sync methods marked as `Obsolete` in these interfaces.
 - Calling `ConfigureAwait(false)` everywhere except tests (just in case).