### PR TITLE
fix: Respond 406 or 415 on unsupported formats

### DIFF
--- a/src/Spark.Engine/Core/Error.cs
+++ b/src/Spark.Engine/Core/Error.cs
@@ -49,6 +49,16 @@ namespace Spark.Core
             return new SparkException(HttpStatusCode.NotImplemented, message, values);
         }
 
+        public static SparkException NotAcceptable(string message = null)
+        {
+            return new SparkException(HttpStatusCode.NotAcceptable, message ?? "Not Acceptable");
+        }
+
+        public static SparkException UnsupportedMediaType(string message = null)
+        {
+            return new SparkException(HttpStatusCode.UnsupportedMediaType, message ?? "Unsupported Media Type");
+        }
+
         private static OperationOutcome.IssueComponent CreateValidationResult(string details, IEnumerable<string> location)
         {
             return new OperationOutcome.IssueComponent()

--- a/src/Spark.Engine/Core/MimeType.cs
+++ b/src/Spark.Engine/Core/MimeType.cs
@@ -18,6 +18,8 @@ namespace Spark.Engine.Core
         public static string DefaultXmlMimeType = ContentType.XML_CONTENT_HEADER;
         public static IEnumerable<string> JsonMimeTypes => ContentType.JSON_CONTENT_HEADERS;
         public static IEnumerable<string> XmlMimeTypes => ContentType.XML_CONTENT_HEADERS;
-        public static IEnumerable<string> SupportedMimeTypes => JsonMimeTypes.Concat(XmlMimeTypes).Concat(new[] { "*/*" });
+        public static IEnumerable<string> SupportedMimeTypes => JsonMimeTypes
+            .Concat(XmlMimeTypes)
+            .Concat(new[] { "application/octet-stream", "application/x-www-form-urlencoded", "*/*" });
     }
 }

--- a/src/Spark.Engine/Handlers/NetCore/FormatTypeHandler.cs
+++ b/src/Spark.Engine/Handlers/NetCore/FormatTypeHandler.cs
@@ -2,8 +2,10 @@
 using Hl7.Fhir.Rest;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
+using Spark.Core;
 using Spark.Engine.Core;
 using Spark.Engine.Extensions;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Spark.Engine.Handlers.NetCore
@@ -40,6 +42,23 @@ namespace Spark.Engine.Handlers.NetCore
                     string contentType = context.Request.ContentType;
                     context.Request.Headers.Add("X-Content-Type", contentType);
                     context.Request.ContentType = FhirMediaType.OCTET_STREAM_CONTENT_HEADER;
+                }
+            }
+
+            //application/foobar
+            if (context.Request.Headers.ContainsKey("Accept"))
+            {
+                var acceptHeader = context.Request.Headers["Accept"].ToString();
+                if (!MimeType.SupportedMimeTypes.Any(mimeType => acceptHeader.Contains(mimeType)))
+                {
+                    throw Error.NotAcceptable();
+                }
+            }
+            if(context.Request.ContentType != null)
+            {
+                if (!MimeType.SupportedMimeTypes.Any(mimeType => context.Request.ContentType.Contains(mimeType)))
+                {
+                    throw Error.UnsupportedMediaType();
                 }
             }
 


### PR DESCRIPTION
* If Accept header contains an unsupported format we respond with
  HTTP Status Code: 406 - Not Acceptable
* If Content-Type header contains an unsupported format we respond with
  HTTP Status: 415 - Unsupported Media Type
* Fixes #323 