### PR TITLE
R4/master

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -12,4 +12,7 @@
   <activePackageSource>
     <add key="All" value="(Aggregate source)" />
   </activePackageSource>
-</configuration>
+  <config>
+    <add key="repositoryPath" value=".\packages" />
+  </config>
+</configuration>	

--- a/src/Spark.Engine/Core/Interaction.cs
+++ b/src/Spark.Engine/Core/Interaction.cs
@@ -1,5 +1,6 @@
 ﻿using Hl7.Fhir.Model;
 using System;
+using Spark.Engine.Extensions;
 
 namespace Spark.Engine.Core
 {
@@ -53,7 +54,7 @@ namespace Spark.Engine.Core
                 if (Resource != null)
                 {
                     if (Resource.Meta == null) Resource.Meta = new Meta();
-                    Resource.Meta.LastUpdated = value;
+                    Resource.Meta.LastUpdated = value?.TruncateToMillis();
                 }
                 else
                 {

--- a/src/Spark.Engine/Extensions/DateTimeOffsetExtensions.cs
+++ b/src/Spark.Engine/Extensions/DateTimeOffsetExtensions.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Spark.Engine.Extensions
+{
+    public static class DateTimeOffsetExtensions
+    {
+        public static DateTimeOffset TruncateToMillis(this DateTimeOffset dateTime)
+        {
+            return dateTime.AddTicks(-(dateTime.Ticks % TimeSpan.TicksPerMillisecond));
+        }
+    }
+}


### PR DESCRIPTION
### Specify path to local packages.

Devs like me may have system-wide nuget packages path customized.

### Fix issue with history integration tests.

"lastUpdated" field is stored as a string, containing nanoseconds, which
aren't present in the @when field, as Mongo only stores datetime values
with millis-level precision.

What is done here, is truncating DateTimeOffset value to Millis, removing
nanoseconds data, before storing it to the db.