### PR TITLE
refactor: Move ValidationErrorHandler into AddFhir

### DIFF
--- a/src/Spark.Engine/Extensions/NetCore/IServiceCollectionExtensions.cs
+++ b/src/Spark.Engine/Extensions/NetCore/IServiceCollectionExtensions.cs
@@ -16,6 +16,7 @@ using Spark.Service;
 using System;
 using System.Buffers;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Spark.Engine.Extensions
 {
@@ -27,9 +28,10 @@ namespace Spark.Engine.Extensions
 
             services.AddFhirHttpSearchParameters();
 
+            services.SetContentTypeAsFhirMediaTypeOnValidationError();
+
             services.TryAddSingleton<SparkSettings>(settings);
             services.TryAddTransient<ElementIndexer>();
-
 
             services.TryAddTransient<IReferenceNormalizationService, ReferenceNormalizationService>();
 
@@ -157,6 +159,31 @@ namespace Spark.Engine.Extensions
                 , new ModelInfo.SearchParamDefinition { Resource = "Resource", Name = "_tag", Type = SearchParamType.Token, Path = new string[] { "Resource.meta.tag" } }
                 , new ModelInfo.SearchParamDefinition { Resource = "Resource", Name = "_profile", Type = SearchParamType.Uri, Path = new string[] { "Resource.meta.profile" } }
                 , new ModelInfo.SearchParamDefinition { Resource = "Resource", Name = "_security", Type = SearchParamType.Token, Path = new string[] { "Resource.meta.security" } }
+            });
+        }
+
+        private static void SetContentTypeAsFhirMediaTypeOnValidationError(this IServiceCollection services)
+        {
+            // Validation errors need to be returned as application/json or application/xml
+            // instead of application/problem+json and application/problem+xml.
+            // (https://github.com/FirelyTeam/spark/issues/282)
+            services.Configure<ApiBehaviorOptions>(options =>
+            {
+                var defaultInvalidModelStateResponseFactory = options.InvalidModelStateResponseFactory;
+                options.InvalidModelStateResponseFactory = context =>
+                {
+                    var actionResult = defaultInvalidModelStateResponseFactory(context) as ObjectResult;
+                    if (actionResult != null)
+                    {
+                        actionResult.ContentTypes.Clear();
+                        foreach (var mediaType in FhirMediaType.JsonMimeTypes
+                            .Concat(FhirMediaType.XmlMimeTypes))
+                        {
+                            actionResult.ContentTypes.Add(mediaType);
+                        }
+                    }
+                    return actionResult;
+                };
             });
         }
     }

--- a/src/Spark.Web/Startup.cs
+++ b/src/Spark.Web/Startup.cs
@@ -19,7 +19,6 @@ using System.Linq;
 using Microsoft.Extensions.Logging;
 using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.Extensions.Hosting;
-using Hl7.Fhir.Rest;
 
 namespace Spark.Web
 {
@@ -112,28 +111,6 @@ namespace Spark.Web
             });
 
             services.AddSignalR();
-
-            // Make validation errors to be returned as application/json or application/xml
-            // instead of application/problem+json and application/problem+xml.
-            // (https://github.com/FirelyTeam/spark/issues/282)
-            services.Configure<ApiBehaviorOptions>(options =>
-            {
-                var defaultInvalidModelStateResponseFactory = options.InvalidModelStateResponseFactory;
-                options.InvalidModelStateResponseFactory = context =>
-                {
-                    var actionResult = defaultInvalidModelStateResponseFactory(context) as ObjectResult;
-                    if (actionResult != null)
-                    {
-                        actionResult.ContentTypes.Clear();
-                        foreach (var mediaType in ContentType.JSON_CONTENT_HEADERS
-                            .Concat(ContentType.XML_CONTENT_HEADERS))
-                        {
-                            actionResult.ContentTypes.Add(mediaType);
-                        }
-                    }
-                    return actionResult;
-                };
-            });
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.


### PR DESCRIPTION
* Moved the Validation Error Handler into AddFhir so it's part of
  Framework instead of a manual operation for users of the NuGet
  packages