### PR TITLE
 fix: Remove text/plain from Media Type drop down

### DIFF
--- a/src/Spark.Web/Startup.cs
+++ b/src/Spark.Web/Startup.cs
@@ -102,6 +102,9 @@ namespace Spark.Web
             {
                 options.InputFormatters.RemoveType<SystemTextJsonInputFormatter>();
                 options.OutputFormatters.RemoveType<SystemTextJsonOutputFormatter>();
+                // We remove StringOutputFormatter to make Swagger happy by not 
+                // showing text/plain in the list of available media types.
+                options.OutputFormatters.RemoveType<StringOutputFormatter>();
                 options.EnableEndpointRouting = false;
             }).SetCompatibilityVersion(CompatibilityVersion.Version_3_0);
 


### PR DESCRIPTION
* text/plain is not a valid Accept header for FHIR APIs therefore. By
  removing StringOutputFormatter from OutputFormatters we no longer tell
  Swagger we support text/plain.