### PR TITLE
fix+refactor: Binary requests can set Accept header

### DIFF
--- a/src/Spark.Engine/Extensions/HttpRequestFhirExtensions.cs
+++ b/src/Spark.Engine/Extensions/HttpRequestFhirExtensions.cs
@@ -137,6 +137,13 @@ namespace Spark.Engine.Extensions
                 return false;
         }
 
+        internal static bool IsRawBinaryRequest(this HttpRequest request)
+        {
+            var ub = new UriBuilder(request.GetRequestUri());
+            return ub.Path.Contains("Binary")
+                && !ub.Path.EndsWith("_search");
+        }
+
         internal static bool IsRawBinaryPostOrPutRequest(this HttpRequest request)
         {
             var ub = new UriBuilder(request.GetRequestUri());

--- a/src/Spark.Engine/Extensions/NetCore/IServiceCollectionExtensions.cs
+++ b/src/Spark.Engine/Extensions/NetCore/IServiceCollectionExtensions.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Spark.Engine.Core;
 using Spark.Engine.FhirResponseFactory;
+using Spark.Engine.Filters;
 using Spark.Engine.Formatters;
 using Spark.Engine.Interfaces;
 using Spark.Engine.Search;
@@ -101,6 +102,8 @@ namespace Spark.Engine.Extensions
 
             return services.AddMvcCore(options =>
             {
+                options.Filters.Add<UnsupportedMediaTypeFilter>(-3001);
+
                 if (settings.UseAsynchronousIO)
                 {
                     options.InputFormatters.Add(new AsyncResourceJsonInputFormatter(new FhirJsonParser(settings.ParserSettings)));

--- a/src/Spark.Engine/Filters/UnsupportedMediaTypeFilter.cs
+++ b/src/Spark.Engine/Filters/UnsupportedMediaTypeFilter.cs
@@ -1,0 +1,44 @@
+﻿#if NETSTANDARD2_0
+using Microsoft.AspNetCore.Mvc.Filters;
+using Spark.Core;
+using Spark.Engine.Core;
+using Spark.Engine.Extensions;
+using System.Linq;
+
+namespace Spark.Engine.Filters
+{
+    internal class UnsupportedMediaTypeFilter : IActionFilter, IFilterMetadata
+    {
+        ///<inheritdoc/>
+        public void OnActionExecuted(ActionExecutedContext context)
+        {
+            
+        }
+
+        ///<inheritdoc/>
+        public void OnActionExecuting(ActionExecutingContext context)
+        {
+            var request = context.HttpContext.Request;
+
+            if (request.IsRawBinaryRequest()) return;
+
+            if (request.Headers.ContainsKey("Accept"))
+            {
+                var acceptHeader = request.Headers["Accept"].ToString();
+                if (!FhirMediaType.SupportedMimeTypes.Any(mimeType => acceptHeader.Contains(mimeType)))
+                {
+                    throw Error.NotAcceptable();
+                }
+            }
+
+            if (context.HttpContext.Request.ContentType != null)
+            {
+                if (!FhirMediaType.SupportedMimeTypes.Any(mimeType => context.HttpContext.Request.ContentType.Contains(mimeType)))
+                {
+                    throw Error.UnsupportedMediaType();
+                }
+            }
+        }
+    }
+}
+#endif

--- a/src/Spark.Engine/Handlers/NetCore/FormatTypeHandler.cs
+++ b/src/Spark.Engine/Handlers/NetCore/FormatTypeHandler.cs
@@ -2,10 +2,8 @@
 using Hl7.Fhir.Rest;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
-using Spark.Core;
 using Spark.Engine.Core;
 using Spark.Engine.Extensions;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace Spark.Engine.Handlers.NetCore
@@ -42,23 +40,6 @@ namespace Spark.Engine.Handlers.NetCore
                     string contentType = context.Request.ContentType;
                     context.Request.Headers.Add("X-Content-Type", contentType);
                     context.Request.ContentType = FhirMediaType.OctetStreamMimeType;
-                }
-            }
-
-            //application/foobar
-            if (context.Request.Headers.ContainsKey("Accept"))
-            {
-                var acceptHeader = context.Request.Headers["Accept"].ToString();
-                if (!FhirMediaType.SupportedMimeTypes.Any(mimeType => acceptHeader.Contains(mimeType)))
-                {
-                    throw Error.NotAcceptable();
-                }
-            }
-            if(context.Request.ContentType != null)
-            {
-                if (!FhirMediaType.SupportedMimeTypes.Any(mimeType => context.Request.ContentType.Contains(mimeType)))
-                {
-                    throw Error.UnsupportedMediaType();
                 }
             }
 


### PR DESCRIPTION
* Binary GET requests are allowed to set Accept Header values which are
  outside the normal application/fhir+json, application/fhir+xml.
  A Binary GET request is allowed to set the Accept header to text/plain,
  application/pdf etc.
* Refactored the Not Supported Format Response functionality. Moved it
  from FormatTypeHandler to UnsupportedMediaTypeHandler which is an
  IActionFilter
* Issue #323, #360