### PR TITLE
Search: Fix 'le' prefix on date search parameter type 

### DIFF
--- a/src/Spark.Mongo.Tests/Search/CriteriumQueryBuilderTests.cs
+++ b/src/Spark.Mongo.Tests/Search/CriteriumQueryBuilderTests.cs
@@ -80,7 +80,7 @@ namespace Spark.Mongo.Tests.Search
         [InlineData(ResourceType.Procedure, "date", "date=gt2010-01-01", "{ \"date.start\" : { \"$gte\" : ISODate(\"2010-01-02T00:00:00Z\") } }")]
         [InlineData(ResourceType.Procedure, "date", "date=ge2010-01-01", "{ \"date.start\" : { \"$gte\" : ISODate(\"2010-01-01T00:00:00Z\") } }")]
         [InlineData(ResourceType.Procedure, "date", "date=lt2010-01-01", "{ \"date.end\" : { \"$lt\" : ISODate(\"2010-01-01T00:00:00Z\") } }")]
-        [InlineData(ResourceType.Procedure, "date", "date=le2010-01-01", "{ \"date.end\" : { \"$lt\" : ISODate(\"2010-01-02T00:00:00Z\") } }")]
+        [InlineData(ResourceType.Procedure, "date", "date=le2010-01-01", "{ \"date.end\" : { \"$lte\" : ISODate(\"2010-01-02T00:00:00Z\") } }")]
         [InlineData(ResourceType.Procedure, "date", "date=sa2010-01-01", "{ \"date.start\" : { \"$gte\" : ISODate(\"2010-01-02T00:00:00Z\") } }")]
         [InlineData(ResourceType.Procedure, "date", "date=eb2010-01-01", "{ \"date.end\" : { \"$lte\" : ISODate(\"2010-01-01T00:00:00Z\") } }")]
         [InlineData(ResourceType.Procedure, "date", "date:missing=true", "{ \"$or\" : [{ \"date\" : { \"$exists\" : false } }, { \"date\" : null }] }")]

--- a/src/Spark.Mongo/Search/Searcher/CriteriaMongoExtensions.cs
+++ b/src/Spark.Mongo/Search/Searcher/CriteriaMongoExtensions.cs
@@ -457,8 +457,7 @@ namespace Spark.Search.Mongo
                 case Operator.LT:
                     return Builders<BsonDocument>.Filter.Lt(end, dateValueLower);
                 case Operator.LTE:
-                    return
-                        Builders<BsonDocument>.Filter.Lt(end, dateValueUpper);
+                    return Builders<BsonDocument>.Filter.Lte(end, dateValueUpper);
                 case Operator.STARTS_AFTER:
                     return Builders<BsonDocument>.Filter.Gte(start, dateValueUpper);
                 case Operator.ENDS_BEFORE:

--- a/src/Spark.Mongo/Search/Searcher/CriteriaMongoExtensions.cs
+++ b/src/Spark.Mongo/Search/Searcher/CriteriaMongoExtensions.cs
@@ -441,22 +441,21 @@ namespace Spark.Search.Mongo
             {
                 case Operator.APPROX:
                 case Operator.EQ:
-                    return
-                        Builders<BsonDocument>.Filter.And(Builders<BsonDocument>.Filter.Gte(end, dateValueLower), Builders<BsonDocument>.Filter.Lt(start, dateValueUpper));
+                    return Builders<BsonDocument>.Filter.And(
+                            Builders<BsonDocument>.Filter.Gte(end, dateValueLower), 
+                            Builders<BsonDocument>.Filter.Lt(start, dateValueUpper)
+                        );
                 case Operator.NOT_EQUAL:
                     return Builders<BsonDocument>.Filter.Or(
                             Builders<BsonDocument>.Filter.Lte(end, dateValueLower),
                             Builders<BsonDocument>.Filter.Gte(start, dateValueUpper)
                         );
                 case Operator.GT:
-                    return
-                        Builders<BsonDocument>.Filter.Gte(start, dateValueUpper);
+                    return Builders<BsonDocument>.Filter.Gte(start, dateValueUpper);
                 case Operator.GTE:
-                    return
-                        Builders<BsonDocument>.Filter.Gte(start, dateValueLower);
+                    return Builders<BsonDocument>.Filter.Gte(start, dateValueLower);
                 case Operator.LT:
-                    return
-                        Builders<BsonDocument>.Filter.Lt(end, dateValueLower);
+                    return Builders<BsonDocument>.Filter.Lt(end, dateValueLower);
                 case Operator.LTE:
                     return
                         Builders<BsonDocument>.Filter.Lt(end, dateValueUpper);


### PR DESCRIPTION
This fixes an issue on the 'le' (less than or equal) prefix on the date
search parameter type failing to return hits where query date and the
resource date was at the exact same time, i.e:
'2021-01-06T13:00:00 <= 2021-01-06T13:00:00'