### PR TITLE
fix: Avoid duplicate search indexes under heavy load

### DIFF
--- a/src/Spark.Mongo/Search/Infrastructure/MongoIndexStore.cs
+++ b/src/Spark.Mongo/Search/Infrastructure/MongoIndexStore.cs
@@ -55,10 +55,7 @@ namespace Spark.Mongo.Search.Common
         {
             string keyvalue = document.GetValue(InternalField.ID).ToString();
             var query = Builders<BsonDocument>.Filter.Eq(InternalField.ID, keyvalue);
-
-            // todo: should use Update: collection.Update();
-            await Collection.DeleteManyAsync(query).ConfigureAwait(false);
-            await Collection.InsertOneAsync(document).ConfigureAwait(false);
+            await Collection.ReplaceOneAsync(query, document, new ReplaceOptions { IsUpsert = true }).ConfigureAwait(false);
         }
 
         public async Task DeleteAsync(Entry entry)


### PR DESCRIPTION
Under heavy load / rapid updates we could end with duplicate search
indexes. A race condition between to requests could end up creating this
condition. See issue #399 and #398 for more details