### PR TITLE
fix+refactor: SnapshotPaginationProvider race condition

### DIFF
--- a/src/Spark.Engine/Service/FhirServiceExtensions/SnapshotPaginationProvider.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/SnapshotPaginationProvider.cs
@@ -7,26 +7,18 @@
  * available at https://raw.githubusercontent.com/FirelyTeam/spark/stu3/master/LICENSE
  */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Hl7.Fhir.Model;
-using Spark.Core;
 using Spark.Engine.Core;
-using Spark.Engine.Extensions;
 using Spark.Engine.Store.Interfaces;
 using Spark.Service;
 
 namespace Spark.Engine.Service.FhirServiceExtensions
 {
-    public class SnapshotPaginationProvider : ISnapshotPaginationProvider, ISnapshotPagination
+    public class SnapshotPaginationProvider : ISnapshotPaginationProvider
     {
         private IFhirStore _fhirStore;
         private readonly ITransfer _transfer;
         private readonly ILocalhost _localhost;
         private readonly ISnapshotPaginationCalculator _snapshotPaginationCalculator;
-        private Snapshot _snapshot;
      
         public SnapshotPaginationProvider(IFhirStore fhirStore, ITransfer transfer, ILocalhost localhost, ISnapshotPaginationCalculator snapshotPaginationCalculator)
         {
@@ -38,207 +30,7 @@ namespace Spark.Engine.Service.FhirServiceExtensions
 
         public ISnapshotPagination StartPagination(Snapshot snapshot)
         {
-            _snapshot = snapshot;
-            return this;
-        }
-
-        public Bundle GetPage(int? index = null, Action<Entry> transformElement = null)
-        {
-            if (_snapshot == null)
-                throw Error.NotFound("There is no paged snapshot");
-
-            if (!_snapshot.InRange(index ?? 0))
-            {
-                throw Error.NotFound(
-                    "The specified index lies outside the range of available results ({0}) in snapshot {1}",
-                    _snapshot.Keys.Count(), _snapshot.Id);
-            }
-
-            return CreateBundle(index);
-        }
-
-        public async Task<Bundle> GetPageAsync(int? index = null, Action<Entry> transformElement = null)
-        {
-            if (_snapshot == null)
-                throw Error.NotFound("There is no paged snapshot");
-
-            if (!_snapshot.InRange(index ?? 0))
-            {
-                throw Error.NotFound(
-                    "The specified index lies outside the range of available results ({0}) in snapshot {1}",
-                    _snapshot.Keys.Count(), _snapshot.Id);
-            }
-
-            return await CreateBundleAsync(index).ConfigureAwait(false);
-        }
-
-        private Bundle CreateBundle(int? start = null)
-        {
-            Bundle bundle = new Bundle
-            {
-                Type = _snapshot.Type,
-                Total = _snapshot.Count,
-                Id = Guid.NewGuid().ToString()
-            };
-
-            List<IKey> keys = _snapshotPaginationCalculator.GetKeysForPage(_snapshot, start).ToList();
-            var entries = _fhirStore.Get(keys).ToList();
-            if (_snapshot.SortBy != null)
-            {
-                entries = entries.Select(e => new { Entry = e, Index = keys.IndexOf(e.Key) })
-                    .OrderBy(e => e.Index)
-                    .Select(e => e.Entry).ToList();
-            }
-            IList<Entry> included = GetIncludesRecursiveFor(entries, _snapshot.Includes);
-            entries.Append(included);
-
-            _transfer.Externalize(entries);
-            bundle.Append(entries);
-            BuildLinks(bundle, start);
-
-            return bundle;
-        }
-
-        private async Task<Bundle> CreateBundleAsync(int? start = null)
-        {
-            Bundle bundle = new Bundle
-            {
-                Type = _snapshot.Type,
-                Total = _snapshot.Count,
-                Id = Guid.NewGuid().ToString()
-            };
-
-            List<IKey> keys = _snapshotPaginationCalculator.GetKeysForPage(_snapshot, start).ToList();
-            var entries = (await _fhirStore.GetAsync(keys).ConfigureAwait(false)).ToList();
-            if (_snapshot.SortBy != null)
-            {
-                entries = entries.Select(e => new {Entry = e, Index = keys.IndexOf(e.Key)})
-                    .OrderBy(e => e.Index)
-                    .Select(e => e.Entry).ToList();
-            }
-            IList<Entry> included = await GetIncludesRecursiveForAsync(entries, _snapshot.Includes).ConfigureAwait(false);
-            entries.Append(included);
-
-            _transfer.Externalize(entries);
-            bundle.Append(entries);
-            BuildLinks(bundle, start);
-
-            return bundle;
-        }
-
-        private IList<Entry> GetIncludesRecursiveFor(IList<Entry> entries, IEnumerable<string> includes)
-        {
-            IList<Entry> included = new List<Entry>();
-
-            var latest = GetIncludesFor(entries, includes);
-            int previouscount;
-            do
-            {
-                previouscount = included.Count;
-                included.AppendDistinct(latest);
-                latest = GetIncludesFor(latest, includes);
-            }
-            while (included.Count > previouscount);
-            return included;
-        }
-
-        private async Task<IList<Entry>> GetIncludesRecursiveForAsync(IList<Entry> entries, IEnumerable<string> includes)
-        {
-            IList<Entry> included = new List<Entry>();
-
-            var latest = await GetIncludesForAsync(entries, includes).ConfigureAwait(false);
-            int previouscount;
-            do
-            {
-                previouscount = included.Count;
-                included.AppendDistinct(latest);
-                latest = await GetIncludesForAsync(latest, includes).ConfigureAwait(false);
-            }
-            while (included.Count > previouscount);
-            return included;
-        }
-
-        private IList<Entry> GetIncludesFor(IList<Entry> entries, IEnumerable<string> includes)
-        {
-            if (includes == null) return new List<Entry>();
-
-            IEnumerable<string> paths = includes.SelectMany(i => IncludeToPath(i));
-            IList<IKey> identifiers = entries.GetResources().GetReferences(paths).Distinct().Select(k => (IKey)Key.ParseOperationPath(k)).ToList();
-
-            IList<Entry> result = _fhirStore.Get(identifiers).ToList();
-
-            return result;
-        }
-
-        private async Task<IList<Entry>> GetIncludesForAsync(IList<Entry> entries, IEnumerable<string> includes)
-        {
-            if (includes == null) return new List<Entry>();
-
-            IEnumerable<string> paths = includes.SelectMany(i => IncludeToPath(i));
-            IList<IKey> identifiers = entries.GetResources().GetReferences(paths).Distinct().Select(k => (IKey)Key.ParseOperationPath(k)).ToList();
-
-            IList<Entry> result = (await _fhirStore.GetAsync(identifiers).ConfigureAwait(false)).ToList();
-
-            return result;
-        }
-
-        private void BuildLinks(Bundle bundle, int? start = null)
-        {
-            bundle.SelfLink = start == null
-                ? _localhost.Absolute(new Uri(_snapshot.FeedSelfLink, UriKind.RelativeOrAbsolute))
-                : BuildSnapshotPageLink(0);
-            bundle.FirstLink = BuildSnapshotPageLink(0);
-            bundle.LastLink = BuildSnapshotPageLink(_snapshotPaginationCalculator.GetIndexForLastPage(_snapshot));
-
-            int? previousPageIndex = _snapshotPaginationCalculator.GetIndexForPreviousPage(_snapshot, start);
-            if (previousPageIndex != null)
-            {
-                bundle.PreviousLink = BuildSnapshotPageLink(previousPageIndex);
-            }
-
-            int? nextPageIndex = _snapshotPaginationCalculator.GetIndexForNextPage(_snapshot, start);
-            if (nextPageIndex != null)
-            {
-                bundle.NextLink = BuildSnapshotPageLink(nextPageIndex);
-            }
-        }
-
-        private Uri BuildSnapshotPageLink(int? snapshotIndex)
-        {
-            if (snapshotIndex == null)
-                return null;
-
-            Uri baseurl;
-            if (string.IsNullOrEmpty(_snapshot.Id) == false)
-            {
-                //baseUrl for statefull pagination
-                baseurl = new Uri(_localhost.DefaultBase + "/" + FhirRestOp.SNAPSHOT)
-                    .AddParam(FhirParameter.SNAPSHOT_ID, _snapshot.Id);
-            }
-            else
-            {
-                //baseUrl for stateless pagination
-                baseurl = new Uri(_snapshot.FeedSelfLink);
-            }
-
-            return baseurl
-                .AddParam(FhirParameter.SNAPSHOT_INDEX, snapshotIndex.ToString());
-        }
-
-        private IEnumerable<string> IncludeToPath(string include)
-        {
-            string[] _include = include.Split(':');
-            string resource = _include.FirstOrDefault();
-            string paramname = _include.Skip(1).FirstOrDefault();
-            var param = ModelInfo.SearchParameters.FirstOrDefault(p => p.Resource == resource && p.Name == paramname);
-            if (param != null)
-            {
-                return param.Path;
-            }
-            else
-            {
-                return Enumerable.Empty<string>();
-            }
+            return new SnapshotPaginationService(_fhirStore, _transfer, _localhost, _snapshotPaginationCalculator, snapshot);
         }
     }
 }

--- a/src/Spark.Engine/Service/FhirServiceExtensions/SnapshotPaginationService.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/SnapshotPaginationService.cs
@@ -1,0 +1,238 @@
+﻿/* 
+ * Copyright (c) 2021, Incendi (info@incendi.no) and contributors
+ * See the file CONTRIBUTORS for details.
+ * 
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/spark/stu3/master/LICENSE
+ */
+
+using Hl7.Fhir.Model;
+using Spark.Core;
+using Spark.Engine.Core;
+using Spark.Engine.Extensions;
+using Spark.Engine.Store.Interfaces;
+using Spark.Service;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Spark.Engine.Service.FhirServiceExtensions
+{
+    internal class SnapshotPaginationService : ISnapshotPagination
+    {
+        private IFhirStore _fhirStore;
+        private readonly ITransfer _transfer;
+        private readonly ILocalhost _localhost;
+        private readonly ISnapshotPaginationCalculator _snapshotPaginationCalculator;
+        private readonly Snapshot _snapshot;
+
+        public SnapshotPaginationService(IFhirStore fhirStore, ITransfer transfer, ILocalhost localhost, ISnapshotPaginationCalculator snapshotPaginationCalculator, Snapshot snapshot)
+        {
+            _fhirStore = fhirStore;
+            _transfer = transfer;
+            _localhost = localhost;
+            _snapshotPaginationCalculator = snapshotPaginationCalculator;
+            _snapshot = snapshot;
+        }
+        
+        public Bundle GetPage(int? index = null, Action<Entry> transformElement = null)
+        {
+            if (_snapshot == null)
+                throw Error.NotFound("There is no paged snapshot");
+
+            if (!_snapshot.InRange(index ?? 0))
+            {
+                throw Error.NotFound(
+                    "The specified index lies outside the range of available results ({0}) in snapshot {1}",
+                    _snapshot.Keys.Count(), _snapshot.Id);
+            }
+
+            return CreateBundle(index);
+        }
+
+        public async Task<Bundle> GetPageAsync(int? index = null, Action<Entry> transformElement = null)
+        {
+            if (_snapshot == null)
+                throw Error.NotFound("There is no paged snapshot");
+
+            if (!_snapshot.InRange(index ?? 0))
+            {
+                throw Error.NotFound(
+                    "The specified index lies outside the range of available results ({0}) in snapshot {1}",
+                    _snapshot.Keys.Count(), _snapshot.Id);
+            }
+
+            return await CreateBundleAsync(index).ConfigureAwait(false);
+        }
+
+        private Bundle CreateBundle(int? start = null)
+        {
+            Bundle bundle = new Bundle
+            {
+                Type = _snapshot.Type,
+                Total = _snapshot.Count,
+                Id = Guid.NewGuid().ToString()
+            };
+
+            List<IKey> keys = _snapshotPaginationCalculator.GetKeysForPage(_snapshot, start).ToList();
+            var entries = _fhirStore.Get(keys).ToList();
+            if (_snapshot.SortBy != null)
+            {
+                entries = entries.Select(e => new { Entry = e, Index = keys.IndexOf(e.Key) })
+                    .OrderBy(e => e.Index)
+                    .Select(e => e.Entry).ToList();
+            }
+            IList<Entry> included = GetIncludesRecursiveFor(entries, _snapshot.Includes);
+            entries.Append(included);
+
+            _transfer.Externalize(entries);
+            bundle.Append(entries);
+            BuildLinks(bundle, start);
+
+            return bundle;
+        }
+
+        private async Task<Bundle> CreateBundleAsync(int? start = null)
+        {
+            Bundle bundle = new Bundle
+            {
+                Type = _snapshot.Type,
+                Total = _snapshot.Count,
+                Id = Guid.NewGuid().ToString()
+            };
+
+            List<IKey> keys = _snapshotPaginationCalculator.GetKeysForPage(_snapshot, start).ToList();
+            var entries = (await _fhirStore.GetAsync(keys).ConfigureAwait(false)).ToList();
+            if (_snapshot.SortBy != null)
+            {
+                entries = entries.Select(e => new {Entry = e, Index = keys.IndexOf(e.Key)})
+                    .OrderBy(e => e.Index)
+                    .Select(e => e.Entry).ToList();
+            }
+            IList<Entry> included = await GetIncludesRecursiveForAsync(entries, _snapshot.Includes).ConfigureAwait(false);
+            entries.Append(included);
+
+            _transfer.Externalize(entries);
+            bundle.Append(entries);
+            BuildLinks(bundle, start);
+
+            return bundle;
+        }
+
+        private IList<Entry> GetIncludesRecursiveFor(IList<Entry> entries, IEnumerable<string> includes)
+        {
+            IList<Entry> included = new List<Entry>();
+
+            var latest = GetIncludesFor(entries, includes);
+            int previouscount;
+            do
+            {
+                previouscount = included.Count;
+                included.AppendDistinct(latest);
+                latest = GetIncludesFor(latest, includes);
+            }
+            while (included.Count > previouscount);
+            return included;
+        }
+
+        private async Task<IList<Entry>> GetIncludesRecursiveForAsync(IList<Entry> entries, IEnumerable<string> includes)
+        {
+            IList<Entry> included = new List<Entry>();
+
+            var latest = await GetIncludesForAsync(entries, includes).ConfigureAwait(false);
+            int previouscount;
+            do
+            {
+                previouscount = included.Count;
+                included.AppendDistinct(latest);
+                latest = await GetIncludesForAsync(latest, includes).ConfigureAwait(false);
+            }
+            while (included.Count > previouscount);
+            return included;
+        }
+
+        private IList<Entry> GetIncludesFor(IList<Entry> entries, IEnumerable<string> includes)
+        {
+            if (includes == null) return new List<Entry>();
+
+            IEnumerable<string> paths = includes.SelectMany(i => IncludeToPath(i));
+            IList<IKey> identifiers = entries.GetResources().GetReferences(paths).Distinct().Select(k => (IKey)Key.ParseOperationPath(k)).ToList();
+
+            IList<Entry> result = _fhirStore.Get(identifiers).ToList();
+
+            return result;
+        }
+
+        private async Task<IList<Entry>> GetIncludesForAsync(IList<Entry> entries, IEnumerable<string> includes)
+        {
+            if (includes == null) return new List<Entry>();
+
+            IEnumerable<string> paths = includes.SelectMany(i => IncludeToPath(i));
+            IList<IKey> identifiers = entries.GetResources().GetReferences(paths).Distinct().Select(k => (IKey)Key.ParseOperationPath(k)).ToList();
+
+            IList<Entry> result = (await _fhirStore.GetAsync(identifiers).ConfigureAwait(false)).ToList();
+
+            return result;
+        }
+
+        private void BuildLinks(Bundle bundle, int? start = null)
+        {
+            bundle.SelfLink = start == null
+                ? _localhost.Absolute(new Uri(_snapshot.FeedSelfLink, UriKind.RelativeOrAbsolute))
+                : BuildSnapshotPageLink(0);
+            bundle.FirstLink = BuildSnapshotPageLink(0);
+            bundle.LastLink = BuildSnapshotPageLink(_snapshotPaginationCalculator.GetIndexForLastPage(_snapshot));
+
+            int? previousPageIndex = _snapshotPaginationCalculator.GetIndexForPreviousPage(_snapshot, start);
+            if (previousPageIndex != null)
+            {
+                bundle.PreviousLink = BuildSnapshotPageLink(previousPageIndex);
+            }
+
+            int? nextPageIndex = _snapshotPaginationCalculator.GetIndexForNextPage(_snapshot, start);
+            if (nextPageIndex != null)
+            {
+                bundle.NextLink = BuildSnapshotPageLink(nextPageIndex);
+            }
+        }
+
+        private Uri BuildSnapshotPageLink(int? snapshotIndex)
+        {
+            if (snapshotIndex == null)
+                return null;
+
+            Uri baseurl;
+            if (string.IsNullOrEmpty(_snapshot.Id) == false)
+            {
+                //baseUrl for statefull pagination
+                baseurl = new Uri(_localhost.DefaultBase + "/" + FhirRestOp.SNAPSHOT)
+                    .AddParam(FhirParameter.SNAPSHOT_ID, _snapshot.Id);
+            }
+            else
+            {
+                //baseUrl for stateless pagination
+                baseurl = new Uri(_snapshot.FeedSelfLink);
+            }
+
+            return baseurl
+                .AddParam(FhirParameter.SNAPSHOT_INDEX, snapshotIndex.ToString());
+        }
+
+        private IEnumerable<string> IncludeToPath(string include)
+        {
+            string[] _include = include.Split(':');
+            string resource = _include.FirstOrDefault();
+            string paramname = _include.Skip(1).FirstOrDefault();
+            var param = ModelInfo.SearchParameters.FirstOrDefault(p => p.Resource == resource && p.Name == paramname);
+            if (param != null)
+            {
+                return param.Path;
+            }
+            else
+            {
+                return Enumerable.Empty<string>();
+            }
+        }
+    }
+}


### PR DESCRIPTION
SnapshotPaginationProvider which was acting as both an
ISnapshotPaginationProvider and ISnapshotPagination kept a reference to
a Snapshot internally. This was causing trouble since AsyncFhirService
is a singleton, and ISnapshotPaginationProvider which is a dependency
to AsyncFhirService was therefore also effectively a singleton.

When a race condition between to competing requests occured second
request would overwrite the internal reference of Snapshot in
ISnapshotPaginationProvider before the first request would have time to
call GetPage/GetPageAsync

This was fixed by splitting the implementations of
ISnapshotPaginationProvider and ISnapshotPagination into separate
classes. The implementation of ISnapshotPaginationProvider is now always
returning a freshly instantiated instance of ISnapshotPagination instead
of a reference to itself.

Fixes #393 