### PR TITLE
fix: Update search index for search parameter 'name' on Patient

### DIFF
--- a/src/Spark.Engine/Search/ElementIndexer.cs
+++ b/src/Spark.Engine/Search/ElementIndexer.cs
@@ -428,8 +428,14 @@ namespace Spark.Engine.Search
 
             var values = new List<Expression>();
             values.AddRange(ToExpressions(element.GivenElement));
-            if(element.FamilyElement != null)
+            if (element.FamilyElement != null)
                 values.AddRange(ToExpressions(element.FamilyElement));
+            if (element.PrefixElement != null && element.PrefixElement.Count > 0)
+                values.AddRange(ToExpressions(element.PrefixElement));
+            if (element.SuffixElement != null && element.SuffixElement.Count > 0)
+                values.AddRange(ToExpressions(element.SuffixElement));
+            if (element.TextElement != null)
+                values.AddRange(ToExpressions(element.TextElement));
 
             return values;
         }


### PR DESCRIPTION
This updates the search index for search parameter 'name' on the Patient
resource. In addition to given and family it now includes prefix, suffix
and text.

Fixes issue #357