### PR TITLE
fix: Fetch correct search parameter

### DIFF
--- a/src/Spark.Engine.Test/Search/CriteriumTests.cs
+++ b/src/Spark.Engine.Test/Search/CriteriumTests.cs
@@ -21,98 +21,97 @@ namespace Spark.Search
 	public class CriteriumTests
 #endif
 	{
-		/// <summary>
-		/// In DSTU2, prefixes have changed from > to gt, < to lt etc.
-		/// </summary>
 		[TestMethod]
-		public void ParseCriteriumDSTU2()
+		public void ParseCriterium()
 		{
-			var crit = Criterium.Parse("birthdate=2018-01-01");
+			var crit = Criterium.Parse("Patient", "birthdate", "2018-01-01");
 			Assert.AreEqual("birthdate", crit.ParamName);
 			Assert.IsNull(crit.Modifier);
 			Assert.AreEqual("2018-01-01", crit.Operand.ToString());
 			Assert.AreEqual(Operator.EQ, crit.Operator);
 
-			crit = Criterium.Parse("birthdate=eq2018-01-01");
+			crit = Criterium.Parse("Patient", "birthdate", "eq2018-01-01");
 			Assert.AreEqual("birthdate", crit.ParamName);
 			Assert.IsNull(crit.Modifier);
 			Assert.AreEqual("2018-01-01", crit.Operand.ToString());
 			Assert.AreEqual(Operator.EQ, crit.Operator);
 
-			crit = Criterium.Parse("birthdate=ne2018-01-01");
+			crit = Criterium.Parse("Patient", "birthdate", "ne2018-01-01");
 			Assert.AreEqual("birthdate", crit.ParamName);
 			Assert.IsNull(crit.Modifier);
 			Assert.AreEqual("2018-01-01", crit.Operand.ToString());
 			Assert.AreEqual(Operator.NOT_EQUAL, crit.Operator);
 
-			crit = Criterium.Parse("birthdate=gt2018-01-01");
+			crit = Criterium.Parse("Patient", "birthdate", "gt2018-01-01");
 			Assert.AreEqual("birthdate", crit.ParamName);
 			Assert.IsNull(crit.Modifier);
 			Assert.AreEqual("2018-01-01", crit.Operand.ToString());
 			Assert.AreEqual(Operator.GT, crit.Operator);
 
-			crit = Criterium.Parse("birthdate=ge2018-01-01");
+			crit = Criterium.Parse("Patient", "birthdate", "ge2018-01-01");
 			Assert.AreEqual("birthdate", crit.ParamName);
 			Assert.IsNull(crit.Modifier);
 			Assert.AreEqual("2018-01-01", crit.Operand.ToString());
 			Assert.AreEqual(Operator.GTE, crit.Operator);
 
-			crit = Criterium.Parse("birthdate=lt2018-01-01");
+			crit = Criterium.Parse("Patient", "birthdate", "lt2018-01-01");
 			Assert.AreEqual("birthdate", crit.ParamName);
 			Assert.IsNull(crit.Modifier);
 			Assert.AreEqual("2018-01-01", crit.Operand.ToString());
 			Assert.AreEqual(Operator.LT, crit.Operator);
 
-			crit = Criterium.Parse("birthdate=le2018-01-01");
+			crit = Criterium.Parse("Patient", "birthdate", "le2018-01-01");
 			Assert.AreEqual("birthdate", crit.ParamName);
 			Assert.IsNull(crit.Modifier);
 			Assert.AreEqual("2018-01-01", crit.Operand.ToString());
 			Assert.AreEqual(Operator.LTE, crit.Operator);
 
-			crit = Criterium.Parse("birthdate:modif1=ap2018-01-01");
+			crit = Criterium.Parse("Patient", "birthdate:modif1", "ap2018-01-01");
 			Assert.AreEqual("birthdate", crit.ParamName);
 			Assert.AreEqual("2018-01-01", crit.Operand.ToString());
 			Assert.AreEqual("modif1", crit.Modifier);
 			Assert.AreEqual(Operator.APPROX, crit.Operator);
 
-			crit = Criterium.Parse("birthdate:missing=true");
+			crit = Criterium.Parse("Patient", "birthdate:missing", "true");
 			Assert.AreEqual("birthdate", crit.ParamName);
 			Assert.IsNull(crit.Operand);
 			Assert.IsNull(crit.Modifier);
 			Assert.AreEqual(Operator.ISNULL, crit.Operator);
 
-			crit = Criterium.Parse("birthdate:missing=false");
+			crit = Criterium.Parse("Patient", "birthdate:missing", "false");
 			Assert.AreEqual("birthdate", crit.ParamName);
 			Assert.IsNull(crit.Operand);
 			Assert.IsNull(crit.Modifier);
 			Assert.AreEqual(Operator.NOTNULL, crit.Operator);
 		}
-        
-        [TestMethod]
-        public void ParseComparatorOperatorForDate()
-        {
-            var criterium = Criterium.Parse("birthdate=lt2018-01-01");
-            Assert.AreEqual(Operator.LT, criterium.Operator);
-        }
+		
+		[TestMethod]
+		public void ParseComparatorOperatorForDate()
+		{
+			var criterium = Criterium.Parse("Patient", "birthdate", "lt2018-01-01");
+			Assert.AreEqual(Operator.LT, criterium.Operator);
+		}
 
-        [TestMethod]
-        public void ParseComparatorOperatorForQuantity()
-        {
-            var criterium = Criterium.Parse("value-quantity=le5.4|http://unitsofmeasure.org|mg");
-            Assert.AreEqual(Operator.LTE, criterium.Operator);
-        }
+		[TestMethod]
+		public void ParseComparatorOperatorForQuantity()
+		{
+			var criterium = Criterium.Parse("Observation", "value-quantity", "le5.4|http://unitsofmeasure.org|mg");
+			Assert.AreEqual(Operator.LTE, criterium.Operator);
+		}
 
-        [TestMethod]
-        public void ParseComparatorOperatorForNumber()
-        {
-            var criterium = Criterium.Parse("length=gt20");
-            Assert.AreEqual(Operator.GT, criterium.Operator);
-        }
+		[TestMethod]
+		public void ParseComparatorOperatorForNumber()
+		{
+			var criterium = Criterium.Parse("Encounter", "length", "gt20");
+			Assert.AreEqual(Operator.GT, criterium.Operator);
+		}
 
-        [TestMethod]
+		[TestMethod]
 		public void ParseChain()
 		{
+#pragma warning disable 618
 			var crit = Criterium.Parse("par1:type1.par2.par3:text=hoi");
+#pragma warning restore 618
 			Assert.IsTrue(crit.Operator == Operator.CHAIN);
 			Assert.AreEqual("type1", crit.Modifier);
 			Assert.IsTrue(crit.Operand is Criterium);
@@ -179,7 +178,9 @@ namespace Spark.Search
 			var p3 = NumberValue.Parse("18.00");
 			Assert.AreEqual(18.00M, p3.Value);
 
+#pragma warning disable 618
 			var crit = Criterium.Parse("paramX=18.34");
+#pragma warning restore 618
 			var p4 = ((UntypedValue)crit.Operand).AsNumberValue();
 			Assert.AreEqual(18.34M, p4.Value);
 		}
@@ -197,7 +198,9 @@ namespace Spark.Search
 			var p2 = DateValue.Parse("1972-11-30T18:45:36Z");
 			Assert.AreEqual("1972-11-30", p2.ToString());
 
+#pragma warning disable 618
 			var crit = Criterium.Parse("paramX=1972-11-30");
+#pragma warning restore 618
 			var p3 = ((UntypedValue)crit.Operand).AsDateValue();
 			Assert.AreEqual("1972-11-30", p3.Value);
 
@@ -218,7 +221,9 @@ namespace Spark.Search
 			var p1 = new FhirDateTime(new DateTimeOffset(1972, 11, 30, 15, 20, 49, TimeSpan.Zero));
 			Assert.AreEqual("1972-11-30T15:20:49+00:00", p1.Value.ToString());
 
+#pragma warning disable 618
 			var crit = Criterium.Parse("paramX=1972-11-30T18:45:36Z");
+#pragma warning restore 618
 			var p3 = ((UntypedValue)crit.Operand).AsDateValue();
 			Assert.AreEqual("1972-11-30", p3.Value);
 
@@ -238,7 +243,9 @@ namespace Spark.Search
 			var p3 = StringValue.Parse(@"Pay \$300\|Pay \$100\|");
 			Assert.AreEqual("Pay $300|Pay $100|", p3.Value);
 
+#pragma warning disable 618
 			var crit = Criterium.Parse(@"paramX=Hello\, world");
+#pragma warning restore 618
 			var p4 = ((UntypedValue)crit.Operand).AsStringValue();
 			Assert.AreEqual("Hello, world", p4.Value);
 		}
@@ -279,7 +286,9 @@ namespace Spark.Search
 			Assert.AreEqual("NOK", p8.Value);
 			Assert.IsTrue(p8.AnyNamespace);
 
+#pragma warning disable 618
 			var crit = Criterium.Parse("paramX=|NOK");
+#pragma warning restore 618
 			var p9 = ((UntypedValue)crit.Operand).AsTokenValue();
 			Assert.AreEqual("NOK", p9.Value);
 			Assert.IsFalse(p9.AnyNamespace);
@@ -313,7 +322,9 @@ namespace Spark.Search
 			Assert.AreEqual("http://system.com/id$4", p6.Namespace);
 			Assert.AreEqual("$/d", p6.Unit);
 
+#pragma warning disable 618
 			var crit = Criterium.Parse("paramX=3.14||mg");
+#pragma warning restore 618
 			var p7 = ((UntypedValue)crit.Operand).AsQuantityValue();
 			Assert.AreEqual(3.14M, p7.Number);
 			Assert.IsNull(p7.Namespace);
@@ -362,7 +373,9 @@ namespace Spark.Search
 			var p2 = new ReferenceValue("http://server.org/fhir/Patient/1");
 			Assert.AreEqual("http://server.org/fhir/Patient/1", p2.Value);
 
+#pragma warning disable 618
 			var crit = Criterium.Parse(@"paramX=http://server.org/\$4/fhir/Patient/1");
+#pragma warning restore 618
 			var p3 = ((UntypedValue)crit.Operand).AsReferenceValue();
 			Assert.AreEqual("http://server.org/$4/fhir/Patient/1", p3.Value);
 		}

--- a/src/Spark.Engine/Extensions/SearchParamDefinitionExtensions.cs
+++ b/src/Spark.Engine/Extensions/SearchParamDefinitionExtensions.cs
@@ -23,5 +23,32 @@ namespace Spark.Engine.Extensions
                 || searchParamDefinition.Type == SearchParamType.Date
                 || searchParamDefinition.Type == SearchParamType.Quantity);
         }
+        
+        /// <summary>
+        /// Returns true if the search parameter is one of the following types: Number, Date or Quantity.
+        /// See https://www.hl7.org/fhir/stu3/search.html#prefix for more information.
+        /// </summary>
+        /// <param name="searchParamDefinitions">
+        /// A List of <see cref="SearchParamDefinition"/>, since this is an extension this is usually a reference 
+        /// to ModelInfo.SearcParameters.
+        /// </param>
+        /// <param name="resourceType">A <see cref="string"/> representing the resource type of the search parameter</param>
+        /// <param name="name">A <see cref="string"/> representing the name of the search parameter.</param>
+        /// <returns>Returns true if the search parameter is of type Number, Date or Quanity, otherwise false.</returns>
+        internal static bool CanHaveOperatorPrefix(this List<SearchParamDefinition> searchParamDefinitions, string resourceType, string name)
+        {
+            // If this is a global SearchParameter then do not include the resource type.
+            SearchParamDefinition searchParamDefinition = IsGlobalSearchParameter(name)
+                ? searchParamDefinitions.Find(p => p.Name == name)
+                : searchParamDefinitions.Find(p => p.Resource == resourceType && p.Name == name);
+            return searchParamDefinition != null && (searchParamDefinition.Type == SearchParamType.Number
+                                                     || searchParamDefinition.Type == SearchParamType.Date
+                                                     || searchParamDefinition.Type == SearchParamType.Quantity);
+        }
+
+        private static bool IsGlobalSearchParameter(string name)
+        {
+            return name.IndexOf('_') == 0;
+        }
     }
 }

--- a/src/Spark.Mongo.Tests/Search/CriteriumQueryBuilderTests.cs
+++ b/src/Spark.Mongo.Tests/Search/CriteriumQueryBuilderTests.cs
@@ -109,7 +109,9 @@ namespace Spark.Mongo.Tests.Search
             bsonSerializerRegistry.RegisterSerializationProvider(new BsonSerializationProvider());
 
             var resourceTypeAsString = resourceType.GetLiteral();
-            var criterium = Criterium.Parse(query);
+            var keyVal = query.SplitLeft('=');
+            if (keyVal.Item2 == null) throw Error.Argument("text", "Value must contain an '=' to separate key and value");
+            var criterium = Criterium.Parse(resourceTypeAsString, keyVal.Item1, keyVal.Item2);
             criterium.SearchParameters.AddRange(ModelInfo.SearchParameters.Where(p => p.Resource == resourceTypeAsString && p.Name == searchParameter));
 
             var filter = criterium.ToFilter(resourceType.GetLiteral());

--- a/src/Spark.Mongo/Search/Searcher/MongoSearcher.cs
+++ b/src/Spark.Mongo/Search/Searcher/MongoSearcher.cs
@@ -530,7 +530,7 @@ namespace Spark.Search.Mongo
 
             SearchResults results = new SearchResults();
 
-            var criteria = parseCriteria(searchCommand, results);
+            var criteria = parseCriteria(resourceType, searchCommand, results);
 
             if (!results.HasErrors)
             {
@@ -563,7 +563,7 @@ namespace Spark.Search.Mongo
 
             SearchResults results = new SearchResults();
 
-            var criteria = parseCriteria(searchCommand, results);
+            var criteria = parseCriteria(resourceType, searchCommand, results);
 
             if (!results.HasErrors)
             {
@@ -730,14 +730,14 @@ namespace Spark.Search.Mongo
             return result;
         }
 
-        private List<Criterium> parseCriteria(SearchParams searchCommand, SearchResults results)
+        private List<Criterium> parseCriteria(string resourceType, SearchParams searchCommand, SearchResults results)
         {
             var result = new List<Criterium>();
             foreach (var c in searchCommand.Parameters)
             {
                 try
                 {
-                    result.Add(Criterium.Parse(c.Item1, c.Item2));
+                    result.Add(Criterium.Parse(resourceType, c.Item1, c.Item2));
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
This fixes an issue where fetching a SearchParameter by name resulted
in us fetching a search parameter for a different resource.

This changes the behavior of our underlying API so that when fetching a
SearchParameter we filter by both resource type in - the name of the
Search parameter.

Fixes #415