### PR TITLE
fix+refactor: Fetching search parameters

### DIFF
--- a/src/Spark.Engine/Extensions/SearchParamDefinitionExtensions.cs
+++ b/src/Spark.Engine/Extensions/SearchParamDefinitionExtensions.cs
@@ -16,39 +16,12 @@ namespace Spark.Engine.Extensions
         /// </param>
         /// <param name="name">A <see cref="string"/> representing the name of the search parameter.</param>
         /// <returns>Returns true if the search parameter is of type Number, Date or Quanity, otherwise false.</returns>
-        internal static bool CanHaveOperatorPrefix(this List<SearchParamDefinition> searchParamDefinitions, string name)
+        internal static bool CanHaveOperatorPrefix(this List<SearchParamDefinition> searchParamDefinitions, string resourceType, string name)
         {
-            SearchParamDefinition searchParamDefinition = searchParamDefinitions.Find(p => p.Name == name);
+            SearchParamDefinition searchParamDefinition = searchParamDefinitions.Find(p => (p.Resource == resourceType || p.Resource == nameof(Resource)) && p.Name == name);
             return searchParamDefinition != null && (searchParamDefinition.Type == SearchParamType.Number
                 || searchParamDefinition.Type == SearchParamType.Date
                 || searchParamDefinition.Type == SearchParamType.Quantity);
-        }
-        
-        /// <summary>
-        /// Returns true if the search parameter is one of the following types: Number, Date or Quantity.
-        /// See https://www.hl7.org/fhir/stu3/search.html#prefix for more information.
-        /// </summary>
-        /// <param name="searchParamDefinitions">
-        /// A List of <see cref="SearchParamDefinition"/>, since this is an extension this is usually a reference 
-        /// to ModelInfo.SearcParameters.
-        /// </param>
-        /// <param name="resourceType">A <see cref="string"/> representing the resource type of the search parameter</param>
-        /// <param name="name">A <see cref="string"/> representing the name of the search parameter.</param>
-        /// <returns>Returns true if the search parameter is of type Number, Date or Quanity, otherwise false.</returns>
-        internal static bool CanHaveOperatorPrefix(this List<SearchParamDefinition> searchParamDefinitions, string resourceType, string name)
-        {
-            // If this is a global SearchParameter then do not include the resource type.
-            SearchParamDefinition searchParamDefinition = IsGlobalSearchParameter(name)
-                ? searchParamDefinitions.Find(p => p.Name == name)
-                : searchParamDefinitions.Find(p => p.Resource == resourceType && p.Name == name);
-            return searchParamDefinition != null && (searchParamDefinition.Type == SearchParamType.Number
-                                                     || searchParamDefinition.Type == SearchParamType.Date
-                                                     || searchParamDefinition.Type == SearchParamType.Quantity);
-        }
-
-        private static bool IsGlobalSearchParameter(string name)
-        {
-            return name.IndexOf('_') == 0;
         }
     }
 }

--- a/src/Spark.Engine/Search/ValueExpressionTypes/Criterium.cs
+++ b/src/Spark.Engine/Search/ValueExpressionTypes/Criterium.cs
@@ -173,10 +173,7 @@ namespace Spark.Search
             else
             {
                 // If this an ordered parameter type, then we accept a comparator prefix: https://www.hl7.org/fhir/stu3/search.html#prefix
-                var canHaveOperatorPrefix = resourceType == null
-                    ? ModelInfo.SearchParameters.CanHaveOperatorPrefix(name)
-                    : ModelInfo.SearchParameters.CanHaveOperatorPrefix(resourceType, name);
-                if (canHaveOperatorPrefix)
+                if (ModelInfo.SearchParameters.CanHaveOperatorPrefix(resourceType, name))
                 {
                     var compVal = findComparator(value);
                     type = compVal.Item1;


### PR DESCRIPTION
Fetching of global search parameters are now less likely to fail by 
comparing if SearchParameter.Resource == nameof(Resource).
It also refactors the work done in commit 0a8686870 by removing now 
unnecessary code.