### PR TITLE
feature+fix: Introduce parameter '_offset' for offset in search results

### DIFF
--- a/src/Spark.Engine/Core/Const.cs
+++ b/src/Spark.Engine/Core/Const.cs
@@ -23,6 +23,7 @@ namespace Spark.Engine.Core
     {
         public const string SNAPSHOT_ID = "id";
         public const string SNAPSHOT_INDEX = "start";
+        public const string OFFSET = "_offset";
         public const string SUMMARY = "_summary";
         public const string COUNT = "_count";
         public const string SINCE = "_since";

--- a/src/Spark.Engine/Extensions/HttpRequestFhirExtensions.cs
+++ b/src/Spark.Engine/Extensions/HttpRequestFhirExtensions.cs
@@ -14,6 +14,7 @@ using Hl7.Fhir.Model;
 using Spark.Engine.Core;
 using Hl7.Fhir.Rest;
 using Hl7.Fhir.Utility;
+using Spark.Engine.Utility;
 using Spark.Formatters;
 using System.Collections.Specialized;
 using System.Runtime.CompilerServices;
@@ -43,6 +44,19 @@ namespace Spark.Engine.Extensions
         }
 
 #if NETSTANDARD2_0
+        public static int GetPagingOffsetParameter(this HttpRequest request)
+        {
+            var offset = FhirParameterParser.ParseIntParameter(request.GetParameter(FhirParameter.OFFSET));
+            if (!offset.HasValue)
+            {
+                // This part is kept as backwards compatibility for the "start" parameter which was used as an offset
+                // in earlier versions of Spark.
+                offset = FhirParameterParser.ParseIntParameter(request.GetParameter(FhirParameter.SNAPSHOT_INDEX));
+            }
+
+            return offset.HasValue ? offset.Value : 0;
+        }
+
         internal static string GetRequestUri(this HttpRequest request)
         {
             var httpRequestFeature = request.HttpContext.Features.Get<IHttpRequestFeature>();
@@ -168,6 +182,19 @@ namespace Spark.Engine.Extensions
         }
 
 #endif
+
+        public static int GetOffset(this HttpRequestMessage request)
+        {
+            var offset = FhirParameterParser.ParseIntParameter(request.GetParameter(FhirParameter.OFFSET));
+            if (!offset.HasValue)
+            {
+                // This part is kept as backwards compatibility for the "start" parameter which was used as an offset
+                // in earlier versions of Spark.
+                offset = FhirParameterParser.ParseIntParameter(request.GetParameter(FhirParameter.SNAPSHOT_INDEX));
+            }
+
+            return offset.HasValue ? offset.Value : 0;
+        }
 
         internal static void AcquireHeaders(this HttpResponseMessage response, FhirResponse fhirResponse)
         {

--- a/src/Spark.Engine/Formatters/HtmlFhirFormatter.cs
+++ b/src/Spark.Engine/Formatters/HtmlFhirFormatter.cs
@@ -87,8 +87,15 @@ namespace Spark.Formatters
                             writer.WriteLine("    Summary only<br/>");
                         if (ps.AllKeys.Contains(FhirParameter.COUNT))
                             writer.WriteLine(string.Format("    Count: {0}<br/>", ps[FhirParameter.COUNT]));
-                        if (ps.AllKeys.Contains(FhirParameter.SNAPSHOT_INDEX))
+                        if (ps.AllKeys.Contains(FhirParameter.OFFSET))
+                        {
+                            writer.WriteLine(string.Format("    From RowNum: {0}<br/>", ps[FhirParameter.OFFSET]));
+                        }
+                        else if (ps.AllKeys.Contains(FhirParameter.SNAPSHOT_INDEX))
+                        {
+                            // Kept as backwards compatibility for the "start" parameter which was used as an offset
                             writer.WriteLine(string.Format("    From RowNum: {0}<br/>", ps[FhirParameter.SNAPSHOT_INDEX]));
+                        }
                         if (ps.AllKeys.Contains(FhirParameter.SINCE))
                             writer.WriteLine(string.Format("    Since: {0}<br/>", ps[FhirParameter.SINCE]));
 

--- a/src/Spark.Engine/Service/FhirServiceExtensions/SnapshotPaginationService.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/SnapshotPaginationService.cs
@@ -176,30 +176,30 @@ namespace Spark.Engine.Service.FhirServiceExtensions
             return result;
         }
 
-        private void BuildLinks(Bundle bundle, int? start = null)
+        private void BuildLinks(Bundle bundle, int? offset = null)
         {
-            bundle.SelfLink = start == null
+            bundle.SelfLink = offset == null
                 ? _localhost.Absolute(new Uri(_snapshot.FeedSelfLink, UriKind.RelativeOrAbsolute))
-                : BuildSnapshotPageLink(start);
+                : BuildSnapshotPageLink(offset);
             bundle.FirstLink = BuildSnapshotPageLink(0);
             bundle.LastLink = BuildSnapshotPageLink(_snapshotPaginationCalculator.GetIndexForLastPage(_snapshot));
 
-            int? previousPageIndex = _snapshotPaginationCalculator.GetIndexForPreviousPage(_snapshot, start);
+            int? previousPageIndex = _snapshotPaginationCalculator.GetIndexForPreviousPage(_snapshot, offset);
             if (previousPageIndex != null)
             {
                 bundle.PreviousLink = BuildSnapshotPageLink(previousPageIndex);
             }
 
-            int? nextPageIndex = _snapshotPaginationCalculator.GetIndexForNextPage(_snapshot, start);
+            int? nextPageIndex = _snapshotPaginationCalculator.GetIndexForNextPage(_snapshot, offset);
             if (nextPageIndex != null)
             {
                 bundle.NextLink = BuildSnapshotPageLink(nextPageIndex);
             }
         }
 
-        private Uri BuildSnapshotPageLink(int? snapshotIndex)
+        private Uri BuildSnapshotPageLink(int? offset)
         {
-            if (snapshotIndex == null)
+            if (offset == null)
                 return null;
 
             Uri baseurl;
@@ -215,7 +215,7 @@ namespace Spark.Engine.Service.FhirServiceExtensions
                 baseurl = new Uri(_snapshot.FeedSelfLink);
             }
 
-            return baseurl.AddParam(FhirParameter.OFFSET, snapshotIndex.ToString());
+            return baseurl.AddParam(FhirParameter.OFFSET, offset.ToString());
         }
 
         private IEnumerable<string> IncludeToPath(string include)

--- a/src/Spark.Engine/Service/FhirServiceExtensions/SnapshotPaginationService.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/SnapshotPaginationService.cs
@@ -215,8 +215,7 @@ namespace Spark.Engine.Service.FhirServiceExtensions
                 baseurl = new Uri(_snapshot.FeedSelfLink);
             }
 
-            return baseurl
-                .AddParam(FhirParameter.SNAPSHOT_INDEX, snapshotIndex.ToString());
+            return baseurl.AddParam(FhirParameter.OFFSET, snapshotIndex.ToString());
         }
 
         private IEnumerable<string> IncludeToPath(string include)

--- a/src/Spark.Engine/Service/FhirServiceExtensions/SnapshotPaginationService.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/SnapshotPaginationService.cs
@@ -180,7 +180,7 @@ namespace Spark.Engine.Service.FhirServiceExtensions
         {
             bundle.SelfLink = start == null
                 ? _localhost.Absolute(new Uri(_snapshot.FeedSelfLink, UriKind.RelativeOrAbsolute))
-                : BuildSnapshotPageLink(0);
+                : BuildSnapshotPageLink(start);
             bundle.FirstLink = BuildSnapshotPageLink(0);
             bundle.LastLink = BuildSnapshotPageLink(_snapshotPaginationCalculator.GetIndexForLastPage(_snapshot));
 

--- a/src/Spark.Web/Controllers/FhirController.cs
+++ b/src/Spark.Web/Controllers/FhirController.cs
@@ -134,22 +134,19 @@ namespace Spark.Web.Controllers
         [HttpGet("{type}")]
         public async Task<FhirResponse> Search(string type)
         {
-            int start = FhirParameterParser.ParseIntParameter(Request.GetParameter(FhirParameter.SNAPSHOT_INDEX)) ?? 0;
+            var offset = Request.GetPagingOffsetParameter();
             var searchparams = Request.GetSearchParams();
-            //int pagesize = Request.GetIntParameter(FhirParameter.COUNT) ?? Const.DEFAULT_PAGE_SIZE;
-            //string sortby = Request.GetParameter(FhirParameter.SORT);
 
-            return await _fhirService.SearchAsync(type, searchparams, start).ConfigureAwait(false);
+            return await _fhirService.SearchAsync(type, searchparams, offset).ConfigureAwait(false);
         }
 
         [HttpPost("{type}/_search")]
         public async Task<FhirResponse> SearchWithOperator(string type)
         {
-            // TODO: start index should be retrieved from the body.
-            int start = FhirParameterParser.ParseIntParameter(Request.GetParameter(FhirParameter.SNAPSHOT_INDEX)) ?? 0;
+            var offset = Request.GetPagingOffsetParameter();
             SearchParams searchparams = Request.GetSearchParamsFromBody();
 
-            return await _fhirService.SearchAsync(type, searchparams, start).ConfigureAwait(false);
+            return await _fhirService.SearchAsync(type, searchparams, offset).ConfigureAwait(false);
         }
 
         [HttpGet("{type}/_history")]
@@ -197,8 +194,8 @@ namespace Spark.Web.Controllers
         public async Task<FhirResponse> Snapshot()
         {
             string snapshot = Request.GetParameter(FhirParameter.SNAPSHOT_ID);
-            int start = FhirParameterParser.ParseIntParameter(Request.GetParameter(FhirParameter.SNAPSHOT_INDEX)) ?? 0;
-            return await _fhirService.GetPageAsync(snapshot, start).ConfigureAwait(false);
+            var offset = Request.GetPagingOffsetParameter();
+            return await _fhirService.GetPageAsync(snapshot, offset).ConfigureAwait(false);
         }
 
         // Operations

--- a/src/Spark/Controllers/FhirController.cs
+++ b/src/Spark/Controllers/FhirController.cs
@@ -132,7 +132,7 @@ namespace Spark.Controllers
         [HttpGet, Route("{type}")]
         public async Task<FhirResponse> Search(string type)
         {
-            int start = FhirParameterParser.ParseIntParameter(Request.GetParameter(FhirParameter.SNAPSHOT_INDEX)) ?? 0;
+            var offset = Request.GetPagingOffsetParameter();
             var searchparams = Request.GetSearchParams();
 
             return await _fhirService.SearchAsync(type, searchparams, start).ConfigureAwait(false);
@@ -141,8 +141,7 @@ namespace Spark.Controllers
         [HttpPost, Route("{type}/_search")]
         public async Task<FhirResponse> SearchWithOperator(string type)
         {
-            // TODO: start index should be retrieved from the body.
-            int start = FhirParameterParser.ParseIntParameter(Request.GetParameter(FhirParameter.SNAPSHOT_INDEX)) ?? 0;
+            var offset = Request.GetPagingOffsetParameter();
             SearchParams searchparams = Request.GetSearchParamsFromBody();
 
             return await _fhirService.SearchAsync(type, searchparams, start).ConfigureAwait(false);
@@ -186,8 +185,8 @@ namespace Spark.Controllers
         public async Task<FhirResponse> Snapshot()
         {
             string snapshot = Request.GetParameter(FhirParameter.SNAPSHOT_ID);
-            int start = FhirParameterParser.ParseIntParameter(Request.GetParameter(FhirParameter.SNAPSHOT_INDEX)) ?? 0;
-            return await _fhirService.GetPageAsync(snapshot, start).ConfigureAwait(false);
+            var offset = Request.GetPagingOffsetParameter();
+            return await _fhirService.GetPageAsync(snapshot, offset).ConfigureAwait(false);
         }
 
         // Operations


### PR DESCRIPTION
This fixes and issue where Spark uses 'start' as an offset for where to
offset to in a search result. 'start' is at this time used as a search
parameter for several resources in the FHIR specification. Therefore if
one used 'start' as a search parameter and also wanted to offset into
the search result, depending on the positioning, various problems would
arise.