### PR TITLE
Fix mapping to properties for non named objects according to FHIR spec

### DIFF
--- a/src/Spark.Engine.Test/Service/PatchServiceTests.cs
+++ b/src/Spark.Engine.Test/Service/PatchServiceTests.cs
@@ -165,7 +165,7 @@ namespace Spark.Engine.Test
             var dateTime = new FhirDateTime(DateTimeOffset.Now);
             valuePart.Part.Add(new Parameters.ParameterComponent()
             {
-                Name = "time", Value = dateTime 
+                Name = "timeDateTime", Value = dateTime 
             });
 
             var resource = new Specimen() { Id = "test" };


### PR DESCRIPTION
Hi,

I've tested the patch with different server and then checked back with documentation and it seems that the solution is not working for the fields that have [Choice of Data type](https://www.hl7.org/fhir/formats.html#choice). So I updated the implementation based on the spec.
Maybe @kennethmyhra could check, since he checked initial PR.