### PR TITLE
Features, refactor and fixes for Transaction/Batch processing

### DIFF
--- a/src/Spark.Engine/Core/Interaction.cs
+++ b/src/Spark.Engine/Core/Interaction.cs
@@ -89,6 +89,11 @@ namespace Spark.Engine.Core
             return new Entry(method, null, null, resource);
         }
 
+        public static Entry Create(Bundle.HTTPVerb method, IKey key)
+        {
+            return new Entry(method, key, null, null);
+        }
+
         public static Entry Create(Bundle.HTTPVerb method, IKey key, Resource resource)
         {
             return new Entry(method, key, null, resource);

--- a/src/Spark.Engine/Service/FhirServiceExtensions/GetManipulationOperation.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/GetManipulationOperation.cs
@@ -1,0 +1,38 @@
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Rest;
+using Spark.Engine.Core;
+using System;
+using System.Collections.Generic;
+
+namespace Spark.Engine.Service.FhirServiceExtensions
+{
+    public class GetManipulationOperation : ResourceManipulationOperation
+    {
+        public GetManipulationOperation(Resource resource, IKey operationKey, SearchResults searchResults, SearchParams searchCommand = null) 
+            : base(resource, operationKey, searchResults, searchCommand)
+        {
+        }
+        
+        public static Uri ReadSearchUri(Bundle.EntryComponent entry)
+        {
+            return entry.Request != null
+                ? new Uri(entry.Request.Url, UriKind.RelativeOrAbsolute)
+                : null;
+        }
+
+        protected override IEnumerable<Entry> ComputeEntries()
+        {
+            if (SearchResults != null)
+            {
+                foreach (string localKeyLiteral in SearchResults)
+                {
+                    yield return Entry.Create(Bundle.HTTPVerb.GET, Key.ParseOperationPath(localKeyLiteral));
+                }
+            }
+            else
+            {
+                yield return Entry.Create(Bundle.HTTPVerb.GET, OperationKey);
+            }
+        }
+    }
+}

--- a/src/Spark.Engine/Service/FhirServiceExtensions/ResourceManipulationOperationFactory.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/ResourceManipulationOperationFactory.cs
@@ -33,62 +33,62 @@ namespace Spark.Engine.Service.FhirServiceExtensions
             };
         }
 
-        private static SearchResults GetSearchResult(IKey key, ISearchService searchService, SearchParams command = null)
+        private static SearchResults GetSearchResult(IKey key, ISearchService searchService, SearchParams searchParams = null)
         {
-            if (command == null || command.Parameters.Count == 0)
+            if (searchParams == null || searchParams.Parameters.Count == 0)
                 return null;
-            if (command != null && searchService == null)
+            if (searchParams != null && searchService == null)
                 throw new InvalidOperationException("Unallowed operation");
-            return searchService.GetSearchResults(key.TypeName, command);
+            return searchService.GetSearchResults(key.TypeName, searchParams);
         }
         
-        private static async Task<SearchResults> GetSearchResultAsync(IKey key, ISearchService searchService, SearchParams command = null)
+        private static async Task<SearchResults> GetSearchResultAsync(IKey key, ISearchService searchService, SearchParams searchParams = null)
         {
-            if (command == null || command.Parameters.Count == 0)
+            if (searchParams == null || searchParams.Parameters.Count == 0)
                 return null;
-            if (command != null && searchService == null)
+            if (searchParams != null && searchService == null)
                 throw new InvalidOperationException("Unallowed operation");
-            return await searchService.GetSearchResultsAsync(key.TypeName, command).ConfigureAwait(false);
+            return await searchService.GetSearchResultsAsync(key.TypeName, searchParams).ConfigureAwait(false);
         }
 
-        public static ResourceManipulationOperation CreatePost(Resource resource, IKey key, ISearchService searchService = null, SearchParams command = null)
+        public static ResourceManipulationOperation CreatePost(Resource resource, IKey key, ISearchService searchService = null, SearchParams searchParams = null)
         {
-            return new PostManipulationOperation(resource, key, GetSearchResult(key, searchService, command), command);
+            return new PostManipulationOperation(resource, key, GetSearchResult(key, searchService, searchParams), searchParams);
         }
 
-        public static async Task<ResourceManipulationOperation> CreatePostAsync(Resource resource, IKey key, ISearchService searchService = null, SearchParams command = null)
+        public static async Task<ResourceManipulationOperation> CreatePostAsync(Resource resource, IKey key, ISearchService searchService = null, SearchParams searchParams = null)
         {
-            return new PostManipulationOperation(resource, key, await GetSearchResultAsync(key, searchService, command).ConfigureAwait(false), command);
+            return new PostManipulationOperation(resource, key, await GetSearchResultAsync(key, searchService, searchParams).ConfigureAwait(false), searchParams);
         }
 
-        public static ResourceManipulationOperation CreatePut(Resource resource, IKey key, ISearchService searchService = null, SearchParams command = null)
+        public static ResourceManipulationOperation CreatePut(Resource resource, IKey key, ISearchService searchService = null, SearchParams searchParams = null)
         {
-            return new PutManipulationOperation(resource, key,GetSearchResult(key, searchService, command), command);
+            return new PutManipulationOperation(resource, key,GetSearchResult(key, searchService, searchParams), searchParams);
         }
 
-        public static async Task<ResourceManipulationOperation> CreatePutAsync(Resource resource, IKey key, ISearchService searchService = null, SearchParams command = null)
+        public static async Task<ResourceManipulationOperation> CreatePutAsync(Resource resource, IKey key, ISearchService searchService = null, SearchParams searchParams = null)
         {
-            return new PutManipulationOperation(resource, key, await GetSearchResultAsync(key, searchService, command).ConfigureAwait(false), command);
+            return new PutManipulationOperation(resource, key, await GetSearchResultAsync(key, searchService, searchParams).ConfigureAwait(false), searchParams);
         }
 
-        public static ResourceManipulationOperation CreateDelete(IKey key, ISearchService searchService = null, SearchParams command = null)
+        public static ResourceManipulationOperation CreateDelete(IKey key, ISearchService searchService = null, SearchParams searchParams = null)
         {
-            return new DeleteManipulationOperation(null, key, GetSearchResult(key, searchService, command), command);
+            return new DeleteManipulationOperation(null, key, GetSearchResult(key, searchService, searchParams), searchParams);
         }
 
-        public static async Task<ResourceManipulationOperation> CreateDeleteAsync(IKey key, ISearchService searchService = null, SearchParams command = null)
+        public static async Task<ResourceManipulationOperation> CreateDeleteAsync(IKey key, ISearchService searchService = null, SearchParams searchParams = null)
         {
-            return new DeleteManipulationOperation(null, key, await GetSearchResultAsync(key, searchService, command).ConfigureAwait(false), command);
+            return new DeleteManipulationOperation(null, key, await GetSearchResultAsync(key, searchService, searchParams).ConfigureAwait(false), searchParams);
         }
 
-        private static ResourceManipulationOperation CreateDelete(Resource resource, IKey key, ISearchService searchService = null, SearchParams command = null)
+        private static ResourceManipulationOperation CreateDelete(Resource resource, IKey key, ISearchService searchService = null, SearchParams searchParams = null)
         {
-            return new DeleteManipulationOperation(null, key, GetSearchResult(key, searchService, command), command);
+            return new DeleteManipulationOperation(null, key, GetSearchResult(key, searchService, searchParams), searchParams);
         }
         
-        private static async Task<ResourceManipulationOperation> CreateDeleteAsync(Resource resource, IKey key, ISearchService searchService = null, SearchParams command = null)
+        private static async Task<ResourceManipulationOperation> CreateDeleteAsync(Resource resource, IKey key, ISearchService searchService = null, SearchParams searchParams = null)
         {
-            return new DeleteManipulationOperation(null, key, await GetSearchResultAsync(key, searchService, command).ConfigureAwait(false), command);
+            return new DeleteManipulationOperation(null, key, await GetSearchResultAsync(key, searchService, searchParams).ConfigureAwait(false), searchParams);
         }
 
         public static ResourceManipulationOperation GetManipulationOperation(Bundle.EntryComponent entryComponent, ILocalhost localhost, ISearchService searchService = null)

--- a/src/Spark.Engine/Service/FhirServiceExtensions/ResourceManipulationOperationFactory.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/ResourceManipulationOperationFactory.cs
@@ -22,14 +22,16 @@ namespace Spark.Engine.Service.FhirServiceExtensions
             {
                 { Bundle.HTTPVerb.POST, CreatePost },
                 { Bundle.HTTPVerb.PUT, CreatePut },
-                { Bundle.HTTPVerb.DELETE, CreateDelete }
+                { Bundle.HTTPVerb.DELETE, CreateDelete },
+                { Bundle.HTTPVerb.GET, CreateGet },
             };
             
             _asyncBuilders = new Dictionary<Bundle.HTTPVerb, Func<Resource, IKey, ISearchService, SearchParams, Task<ResourceManipulationOperation>>>
             {
                 { Bundle.HTTPVerb.POST, CreatePostAsync },
                 { Bundle.HTTPVerb.PUT, CreatePutAsync },
-                { Bundle.HTTPVerb.DELETE, CreateDeleteAsync }
+                { Bundle.HTTPVerb.DELETE, CreateDeleteAsync },
+                { Bundle.HTTPVerb.GET, CreateGetAsync },
             };
         }
 
@@ -91,6 +93,16 @@ namespace Spark.Engine.Service.FhirServiceExtensions
             return new DeleteManipulationOperation(null, key, await GetSearchResultAsync(key, searchService, searchParams).ConfigureAwait(false), searchParams);
         }
 
+        private static ResourceManipulationOperation CreateGet(Resource resource, IKey key, ISearchService searchService, SearchParams searchParams)
+        {
+            return new GetManipulationOperation(resource, key, GetSearchResult(key, searchService, searchParams), searchParams);
+        }
+
+        private static async Task<ResourceManipulationOperation> CreateGetAsync(Resource resource, IKey key, ISearchService searchService, SearchParams searchParams)
+        {
+            return new GetManipulationOperation(resource, key, await GetSearchResultAsync(key, searchService, searchParams), searchParams);
+        }
+
         public static ResourceManipulationOperation GetManipulationOperation(Bundle.EntryComponent entryComponent, ILocalhost localhost, ISearchService searchService = null)
         {
             Bundle.HTTPVerb method = localhost.ExtrapolateMethod(entryComponent, null);
@@ -126,6 +138,10 @@ namespace Spark.Engine.Service.FhirServiceExtensions
             else if (method == Bundle.HTTPVerb.DELETE)
             {
                 searchUri = DeleteManipulationOperation.ReadSearchUri(entryComponent);
+            }
+            else if (method == Bundle.HTTPVerb.GET)
+            {
+                searchUri = FhirServiceExtensions.GetManipulationOperation.ReadSearchUri(entryComponent);
             }
             return searchUri;
         }


### PR DESCRIPTION
Adds IResourceStorageService as an input parameter to the classes that inherit from ResourceManipulationOperation. This will enable us to retrieve existing data from the storage layer. Useful for the Patch (R4) and Get operations (STU3 and R4).

Removes the private member variable searchService (ISearchService) and instead passes searchService to the various methods that rely on it.

Renamed parameter on private methods from 'command' to 'searchParams'.

Re-ordering entries in a transaction bundle so that we conform to the transaction processing rules in the spec: http://www.hl7.org/fhir/stu3/http.html#2.21.0.17.2.

Support for GET interaction in batch/transaction bundles.
