### PR TITLE
feature: Add modifier ':identifier' for Reference search parameter type

### DIFF
--- a/src/Spark.Engine/Search/ElementIndexer.cs
+++ b/src/Spark.Engine/Search/ElementIndexer.cs
@@ -377,35 +377,39 @@ namespace Spark.Engine.Search
 
         private List<Expression> ToExpressions(ResourceReference element)
         {
-            if (element == null || element.Url == null)
+            if (element == null)
                 return null;
 
-            Expression value = null;
-            var uri = element.Url;
-            if (uri.IsAbsoluteUri)
+            if (element.Url != null)
             {
-                //This is a fully specified url, either internal or external. Don't change it.
-                var stringValue = new StringValue(uri.ToString());
+                Expression value = null;
+                var uri = element.Url;
+                if (uri.IsAbsoluteUri)
+                {
+                    //This is a fully specified url, either internal or external. Don't change it.
+                    var stringValue = new StringValue(uri.ToString());
 
-                // normalize reference value to be able to use normalized criteria for search.
-                // https://github.com/FirelyTeam/spark/issues/35 
-                value = _referenceNormalizationService != null
-                    ? _referenceNormalizationService.GetNormalizedReferenceValue(stringValue, null)
-                    : stringValue;
+                    // normalize reference value to be able to use normalized criteria for search.
+                    // https://github.com/FirelyTeam/spark/issues/35 
+                    value = _referenceNormalizationService != null
+                        ? _referenceNormalizationService.GetNormalizedReferenceValue(stringValue, null)
+                        : stringValue;
+                }
+                else
+                {
+                    //This is a relative url, so it is meant to point to something internal to our server.
+                    value = new StringValue(uri.ToString());
+                    //TODO: expand to absolute url with Localhost?
+                }
+
+                return ListOf(value);
             }
-            else if (uri.ToString().StartsWith("#"))
+            else if (element.Identifier != null)
             {
-                //TODO: This is a reference to a contained resource in the same bundle. Should we index it at all?
-            }
-            else
-            {
-                //This is a relative url, so it is meant to point to something internal to our server.
-                value = new StringValue(uri.ToString());
-                //TODO: expand to absolute url with Localhost?
+                return ToExpressions(element.Identifier);
             }
 
-            return ListOf(value);
-
+            return null;
         }
 
         /// <summary>

--- a/src/Spark.Mongo/Search/Common/Config.cs
+++ b/src/Spark.Mongo/Search/Common/Config.cs
@@ -67,7 +67,8 @@ namespace Spark.Mongo.Search.Common
             BELOW = "below",
             ABOVE = "above",
             NOT = "not",
-            NONE = "";
+            NONE = "",
+            IDENTIFIER = "identifier";
     }
     
     public static class Config

--- a/src/Spark.Mongo/Search/Searcher/CriteriaMongoExtensions.cs
+++ b/src/Spark.Mongo/Search/Searcher/CriteriaMongoExtensions.cs
@@ -97,13 +97,17 @@ namespace Spark.Search.Mongo
                         return QuantityQuery(parameterName, op, valueOperand);
                     case SearchParamType.Reference:
                         //Chain is handled in MongoSearcher, so here we have the result of a closed criterium: IN [ list of id's ]
-                        if (parameter.Target?.Any() == true && valueOperand != null && !valueOperand.ToUnescapedString().Contains("/"))
+                        if (parameter.Target?.Any() == true && modifier != Modifier.IDENTIFIER && valueOperand != null && !valueOperand.ToUnescapedString().Contains("/"))
                         {
                             // For searching by reference without type specified.
                             // If reference target type is known, create the exact query like ^(Person|Group)/(123|456)$
                             return Builders<BsonDocument>.Filter.Regex(parameterName,
                                 new BsonRegularExpression(new Regex(
                                     $"^({string.Join("|", parameter.Target)})/({valueOperand.ToUnescapedString().Replace(",","|")})$")));
+                        }
+                        else if (modifier == Modifier.IDENTIFIER)
+                        {
+                            return TokenQuery(parameterName, op, Modifier.EXACT, valueOperand);
                         }
                         else
                         {

--- a/src/Spark.Mongo/Search/Searcher/MongoSearcher.cs
+++ b/src/Spark.Mongo/Search/Searcher/MongoSearcher.cs
@@ -398,7 +398,7 @@ namespace Spark.Search.Mongo
             foreach (var crit in criteria)
             {
                 var critSp = crit.FindSearchParamDefinition(resourceType);
-                if (critSp != null && critSp.Type == SearchParamType.Reference && crit.Operator != Operator.CHAIN && crit.Modifier != Modifier.MISSING && crit.Operand != null)
+                if (critSp != null && critSp.Type == SearchParamType.Reference && crit.Operator != Operator.CHAIN && crit.Modifier != Modifier.MISSING && crit.Modifier != Modifier.IDENTIFIER && crit.Operand != null)
                 {
                     if (_referenceNormalizationService != null &&
                         searchSettings.ShouldSkipReferenceCheck(resourceType, crit.ParamName))


### PR DESCRIPTION
References are allowed to have an identifier. The modifier :identifier
allows for searching by the identifier rather than the literal
reference:
GET [base]/Observation?subject:identifier=http://acme.org/mrn|123456

#430 