### PR TITLE
Add extensions support for patch

### DIFF
--- a/src/Spark.Engine.Test/Service/PatchServiceTests.cs
+++ b/src/Spark.Engine.Test/Service/PatchServiceTests.cs
@@ -206,17 +206,6 @@ namespace Spark.Engine.Test
                 return p.Parameter[0].Part[2];
             }, new Specimen() { Id = "test" });
         }
-        
-        [Fact]
-        public void CanApplyCollectionInsertWithIndexInPathPatchForNonNamedDataTypesWithExtension()
-        {
-            CanApplyCollectionOperationPatchForNonNamedDataTypesWithExtension((p) =>
-            {
-                //ToDo: is this correct according to spec?
-                p.AddInsertPatchParameter("Specimen.processing[0]", null, 0);
-                return p.Parameter[0].Part[2];
-            }, new Specimen() { Id = "test" });
-        }
 
         [Fact] 
         public void CanApplyCollectionReplacePatchForNonNamedDataTypesWithExtension()
@@ -318,7 +307,7 @@ namespace Spark.Engine.Test
         public void CanApplyCollectionInsertPatch()
         {
             var parameters = new Parameters();
-            parameters.AddInsertPatchParameter("Patient.name[0]", new HumanName { Given = new[] { "Jane" }, Family = "Doe", }, 0);
+            parameters.AddInsertPatchParameter("Patient.name", new HumanName { Given = new[] { "Jane" }, Family = "Doe", }, 0);
 
             var resource = new Patient
             {

--- a/src/Spark.Engine.Test/Service/PatchServiceTests.cs
+++ b/src/Spark.Engine.Test/Service/PatchServiceTests.cs
@@ -123,6 +123,18 @@ namespace Spark.Engine.Test
 
             Assert.Equal("1930-01-01", resource.BirthDate);
         }
+        
+        [Fact]
+        public void CanApplyCodeValueAsString()
+        {
+            var parameters = new Parameters();
+            parameters.AddReplacePatchParameter("MedicationRequest.status", new FhirString("completed"));
+
+            var resource = new MedicationRequest() { Id = "test"};
+            resource = (MedicationRequest)_patchService.Apply(resource, parameters);
+
+            Assert.Equal(MedicationRequest.medicationrequestStatus.Completed, resource.Status);
+        }
 
         [Fact]
         public void WhenApplyingPropertyAssignmentPatchToNonEmptyPropertyThenThrows()

--- a/src/Spark.Engine.Test/Service/PatchServiceTests.cs
+++ b/src/Spark.Engine.Test/Service/PatchServiceTests.cs
@@ -181,8 +181,11 @@ namespace Spark.Engine.Test
             var parameters = new Parameters();
             var extensions = new List<Extension>()
             {
-                new Extension("http://extensions.org/extensionone", new ResourceReference("Device/1")),
-                new Extension("http://extensions.org/extensiontwo", new Code("someCode"))
+                new Extension("http://extensions.org/extensionResourceReference", new ResourceReference("Device/1")),
+                new Extension("http://extensions.org/extensionCode", new Code("someCode")),
+                new Extension("http://extensions.org/extensionUrl", new FhirUri("someUrl")),
+                new Extension("http://extensions.org/extensionString", new FhirString("someString")),
+                new Extension("http://extensions.org/extensionDateTime", new FhirDateTime(DateTimeOffset.Now))
             };
             parameters.AddAddPatchParameter("Specimen", "processing", null);
             var valuePart = parameters.Parameter[0].Part[3];

--- a/src/Spark.Engine/Service/FhirServiceExtensions/PatchService.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/PatchService.cs
@@ -166,17 +166,14 @@ namespace Spark.Engine.Service.FhirServiceExtensions
         {
             return result switch
             {
-                IndexExpression indexExpression => Expression.Call(
-                    indexExpression.Object,
-                    GetMethod(indexExpression.Object!.Type, "Insert"),
-                    new[] { indexExpression.Arguments[0], valueExpression }),
                 MemberExpression me when me.Type.IsGenericType
                                          && GetMethod(me.Type, "Insert") != null =>
                     Expression.Block(
                         Expression.IfThen(
                             Expression.Equal(me, Expression.Default(result.Type)),
                             Expression.Throw(Expression.New(typeof(InvalidOperationException)))),
-                        Expression.Call(me, GetMethod(me.Type, "Insert"), Expression.Constant(insertIndex), valueExpression)),
+                        Expression.Call(me, GetMethod(me.Type, "Insert"), Expression.Constant(insertIndex),
+                            valueExpression)),
                 _ => result
             };
         }

--- a/src/Spark.Engine/Service/FhirServiceExtensions/PatchService.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/PatchService.cs
@@ -1,4 +1,5 @@
 ﻿using Hl7.Fhir.Introspection;
+using Hl7.Fhir.Utility;
 
 namespace Spark.Engine.Service.FhirServiceExtensions
 {
@@ -29,25 +30,24 @@ namespace Spark.Engine.Service.FhirServiceExtensions
                 var operationType = component.Part.First(x => x.Name == "type").Value.ToString();
                 var path = component.Part.First(x => x.Name == "path").Value.ToString();
                 var name = component.Part.FirstOrDefault(x => x.Name == "name")?.Value.ToString();
-                var value = (object)component.Part.FirstOrDefault(x => x.Name == "value")?.Value 
-                            ?? component.Part.FirstOrDefault(x => x.Name == "value")?.Part;
+                var valuePart = component.Part.FirstOrDefault(x => x.Name == "value") 
+                            ?? component.Part.FirstOrDefault(x => x.Name == "value");
 
                 var parameterExpression = Expression.Parameter(resource.GetType(), "x");
                 var expression = operationType == "add" ? _compiler.Parse($"{path}.{name}") : _compiler.Parse(path);
                 var result = expression.Accept(
                         new ResourceVisitor(parameterExpression),
                         new fhirExpression.SymbolTable());
-                var valueExpression = CreateValueExpression(value, result);
                 switch (operationType)
                 {
                     case "add":
-                        result = AddValue(result, valueExpression);
+                        result = AddValue(result, CreateValueExpression(valuePart, result.Type));
                         break;
                     case "insert":
-                        result = InsertValue(result, valueExpression);
+                        result = InsertValue(result, CreateValueExpression(valuePart, result.Type));
                         break;
                     case "replace":
-                        result = Expression.Assign(result, valueExpression);
+                        result = Expression.Assign(result, CreateValueExpression(valuePart, result.Type));
                         break;
                     case "delete":
                         result = DeleteValue(result);
@@ -65,39 +65,80 @@ namespace Spark.Engine.Service.FhirServiceExtensions
 
             return resource;
         }
-
-        private static Expression CreateValueExpression(object value, Expression result)
+        
+        private static Expression CreateValueExpression(Parameters.ParameterComponent part, Type resultType)
         {
-            Expression FromString(string str)
+            return part.Value == null
+                ? Expression.MemberInit(
+                    Expression.New(resultType.GenericTypeArguments[0].GetConstructor(Array.Empty<Type>())),
+                    GetPartsBindings(part.Part, resultType))
+                : GetConstantExpression(part.Value, resultType);
+        }
+        
+        private static Expression GetConstantExpression(DataType value, Type valueType)
+        {
+            Expression FromString(string str, Type targetType)
             {
-                return result is MemberExpression me
+                return targetType.CanBeTreatedAsType(typeof(DataType))
                     ? (Expression) Expression.MemberInit(
-                        Expression.New(me.Type.GetConstructor(Array.Empty<Type>())),
+                        Expression.New(targetType.GetConstructor(Array.Empty<Type>())),
                         Expression.Bind(
-                            me.Type.GetProperty("ObjectValue"),
+                            targetType.GetProperty("ObjectValue"),
                             Expression.Constant(str)))
-                    : Expression.Constant(value);
+                    : Expression.Constant(str);
             }
             
-            Expression FromParts(List<Parameters.ParameterComponent> parts)
-            {
-                return result.Type.IsGenericType
-                    ? (Expression) Expression.MemberInit(
-                        Expression.New(result.Type.GenericTypeArguments[0].GetConstructor(Array.Empty<Type>())),
-                        parts.Select(x => Expression.Bind(
-                            result.Type.GenericTypeArguments[0].GetProperties().Single(
-                                p => p.GetCustomAttribute<FhirElementAttribute>()?.Name == x.Name),
-                            Expression.Constant(x.Value))))
-                    : Expression.Constant(value);
-            }
-
             return value switch
             {
-                Code code => FromString(code.Value),
-                FhirString str => FromString(str.Value),
-                List<Parameters.ParameterComponent> parts => FromParts(parts),
+                Code code => FromString(code.Value, valueType == typeof(DataType) ? typeof(Code) : valueType),
+                FhirUri uir => FromString(uir.Value, valueType),
                 _ => Expression.Constant(value)
             };
+        }
+
+        private static IEnumerable<MemberBinding> GetPartsBindings(List<Parameters.ParameterComponent> parts, Type resultType)
+        {
+            foreach (var partGroup in parts.GroupBy(x => x.Name))
+            {
+                var property = resultType.GenericTypeArguments[0].GetProperties().Single(
+                    p => p.GetCustomAttribute<FhirElementAttribute>()?.Name == partGroup.Key);
+                if (property.PropertyType.IsGenericType)
+                {
+                    var listExpression = GetCollectionExpression(property, partGroup);
+                    yield return Expression.Bind(property, listExpression);
+                }
+                else
+                {
+                    var propertyValue = CreateValueExpression(partGroup.Single(), property.PropertyType);
+                    yield return Expression.Bind(property, propertyValue);
+                }
+            }
+        }
+
+        private static Expression GetCollectionExpression(PropertyInfo property, IEnumerable<Parameters.ParameterComponent> parts)
+        {
+            var variableExpr = Expression.Variable(property.PropertyType);
+            return Expression.Block(new [] {variableExpr}, GetCollectionCreationExpressions(variableExpr, property, parts));
+        }
+
+        private static IEnumerable<Expression> GetCollectionCreationExpressions(ParameterExpression variableExpr, PropertyInfo property, IEnumerable<Parameters.ParameterComponent> parts)
+        {
+            LabelTarget returnTarget = Expression.Label(property.PropertyType);
+            
+            GotoExpression returnExpression = Expression.Return(returnTarget, 
+                variableExpr, property.PropertyType);
+
+            LabelExpression returnLabel = Expression.Label(returnTarget, Expression.New(property.PropertyType.GetConstructor(Array.Empty<Type>())));
+
+            yield return Expression.Assign(variableExpr, Expression.New(property.PropertyType.GetConstructor(Array.Empty<Type>())));
+            foreach (var part in parts)
+            {
+                yield return Expression.Call(variableExpr, GetMethod(variableExpr.Type, "Add"),
+                    CreateValueExpression(part, property.PropertyType));
+            }
+
+            yield return returnExpression;
+            yield return returnLabel;
         }
 
         private static Expression MoveItem(Expression result, int source, int destination)

--- a/src/Spark.Engine/Service/FhirServiceExtensions/PatchService.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/PatchService.cs
@@ -91,7 +91,8 @@ namespace Spark.Engine.Service.FhirServiceExtensions
             return value switch
             {
                 Code code => FromString(code.Value, valueType == typeof(DataType) ? typeof(Code) : valueType),
-                FhirUri uir => FromString(uir.Value, valueType == typeof(DataType) ? typeof(FhirUri) : valueType),
+                FhirUri uri => FromString(uri.Value, valueType == typeof(DataType) ? typeof(FhirUri) : valueType),
+                FhirString s => FromString(s.Value, valueType == typeof(DataType) ? typeof(FhirString) : valueType),
                 _ => Expression.Constant(value)
             };
         }

--- a/src/Spark.Engine/Service/FhirServiceExtensions/PatchService.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/PatchService.cs
@@ -68,9 +68,10 @@ namespace Spark.Engine.Service.FhirServiceExtensions
         
         private static Expression CreateValueExpression(Parameters.ParameterComponent part, Type resultType)
         {
+            resultType = part.Value == null && resultType.IsGenericType ? resultType.GenericTypeArguments[0] : resultType;
             return part.Value == null
                 ? Expression.MemberInit(
-                    Expression.New(resultType.GenericTypeArguments[0].GetConstructor(Array.Empty<Type>())),
+                    Expression.New(resultType.GetConstructor(Array.Empty<Type>())),
                     GetPartsBindings(part.Part, resultType))
                 : GetConstantExpression(part.Value, resultType);
         }
@@ -101,7 +102,7 @@ namespace Spark.Engine.Service.FhirServiceExtensions
         {
             foreach (var partGroup in parts.GroupBy(x => x.Name))
             {
-                var property = resultType.GenericTypeArguments[0].GetProperties().Single(
+                var property = resultType.GetProperties().Single(
                     p => p.GetCustomAttribute<FhirElementAttribute>()?.Name == partGroup.Key);
                 if (property.PropertyType.IsGenericType)
                 {

--- a/src/Spark.Engine/Service/FhirServiceExtensions/PatchService.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/PatchService.cs
@@ -91,7 +91,7 @@ namespace Spark.Engine.Service.FhirServiceExtensions
             return value switch
             {
                 Code code => FromString(code.Value, valueType == typeof(DataType) ? typeof(Code) : valueType),
-                FhirUri uir => FromString(uir.Value, valueType),
+                FhirUri uir => FromString(uir.Value, valueType == typeof(DataType) ? typeof(FhirUri) : valueType),
                 _ => Expression.Constant(value)
             };
         }


### PR DESCRIPTION
Add extensions support for Patch as discussed [here](https://chat.fhir.org/#narrow/stream/179166-implementers/topic/Use.20Patch.20with.20extensions). 

I tested with some scenarios which could cause troubles. As long as FHIR Model types are consistent in annotation and dataTypes - there should be no issues.

I think @kennethmyhra is aware of the discussion mentioned at top.