### PR TITLE
Engine: Use HttpRequestFeature.Path instead of RawTarget

### DIFF
--- a/src/Spark.Engine/Extensions/HttpRequestFhirExtensions.cs
+++ b/src/Spark.Engine/Extensions/HttpRequestFhirExtensions.cs
@@ -60,7 +60,7 @@ namespace Spark.Engine.Extensions
         internal static string GetRequestUri(this HttpRequest request)
         {
             var httpRequestFeature = request.HttpContext.Features.Get<IHttpRequestFeature>();
-            return $"{request.Scheme}://{request.Host}{httpRequestFeature.RawTarget}";
+            return $"{request.Scheme}://{request.Host}{httpRequestFeature.Path}";
         }
 
         internal static DateTimeOffset? IfModifiedSince(this HttpRequest request)


### PR DESCRIPTION
HttpRequestFeature.RawTarget contains according to the documentation: "This property contains the raw path and full query, as well as other request targets such as * for OPTIONS requests".

We only want the Requset Path identifying the requested resource so let's use HttpRequestFeature.Path.

Fixes: #509