### PR TITLE
Engine+Mongo: Match any element where [system] match identifier [STU3]

### DIFF
--- a/src/Spark.Engine.Test/Search/CriteriumTests.cs
+++ b/src/Spark.Engine.Test/Search/CriteriumTests.cs
@@ -254,16 +254,16 @@ namespace Spark.Search
         [TestMethod]
         public void HandleTokenParam()
         {
-            var p1 = new TokenValue("NOK", "http://somewhere.nl/codes");
+            var p1 = new TokenValue { Namespace = "http://somewhere.nl/codes", Value = "NOK" };
             Assert.AreEqual("http://somewhere.nl/codes|NOK", p1.ToString());
 
-            var p2 = new TokenValue("y|n", "http://some|where.nl/codes");
+            var p2 = new TokenValue { Namespace = "http://some|where.nl/codes", Value = "yln" };
             Assert.AreEqual(@"http://some\|where.nl/codes|y\|n", p2.ToString());
 
-            var p3 = new TokenValue("NOK", matchAnyNamespace: true);
+            var p3 = new TokenValue { Value = "NOK", AnyNamespace = true };
             Assert.AreEqual("NOK", p3.ToString());
 
-            var p4 = new TokenValue("NOK", matchAnyNamespace: false);
+            var p4 = new TokenValue { Value = "NOK", AnyNamespace = false };
             Assert.AreEqual("|NOK", p4.ToString());
 
             var p5 = TokenValue.Parse("http://somewhere.nl/codes|NOK");
@@ -396,7 +396,7 @@ namespace Spark.Search
         public void HandleComposites()
         {
             var pX = new CompositeValue(new ValueExpression[] { new StringValue("hello, world!"), new NumberValue(14.8M) });
-            var pY = new TokenValue("NOK", "http://somesuch.org");
+            var pY = new TokenValue { Namespace = "http://somesuch.org", Value = "NOK" };
             var p1 = new ChoiceValue(new ValueExpression[] { pX, pY });
             Assert.AreEqual(@"hello\, world!$14.8,http://somesuch.org|NOK", p1.ToString());
 

--- a/src/Spark.Engine/Search/ValueExpressionTypes/TokenValue.cs
+++ b/src/Spark.Engine/Search/ValueExpressionTypes/TokenValue.cs
@@ -13,11 +13,15 @@ namespace Spark.Search
 {
     public class TokenValue : ValueExpression
     {
-        public string Namespace { get; private set; }
+        public string Namespace { get; set; }
 
-        public string Value { get; private set; }
+        public string Value { get; set; }
 
-        public bool AnyNamespace { get; private set; }
+        public bool AnyNamespace { get; set; }
+
+        public TokenValue()
+        {
+        }
 
         public TokenValue(string value, bool matchAnyNamespace)
         {
@@ -59,15 +63,15 @@ namespace Spark.Search
 
             if (hasNamespace)
             {
-                if(pair[1] == string.Empty)
-                    throw new FormatException("Token query parameters should at least specify a value after the '|'");
-
                 string pair1 = StringValue.UnescapeString(pair[1]);
 
                 if (pair0 == string.Empty)
                     return new TokenValue(pair1, matchAnyNamespace: false );
-                else
-                    return new TokenValue(pair1, pair0);
+
+                if (string.IsNullOrEmpty(pair1))
+                    return new TokenValue { Namespace = pair0, AnyNamespace = false };
+
+                return new TokenValue(pair1, pair0);
             }
             else
             {

--- a/src/Spark.Engine/Search/ValueExpressionTypes/TokenValue.cs
+++ b/src/Spark.Engine/Search/ValueExpressionTypes/TokenValue.cs
@@ -19,23 +19,6 @@ namespace Spark.Search
 
         public bool AnyNamespace { get; set; }
 
-        public TokenValue()
-        {
-        }
-
-        public TokenValue(string value, bool matchAnyNamespace)
-        {
-            Value = value;
-            AnyNamespace = matchAnyNamespace;
-        }
-
-        public TokenValue(string value, string ns)
-        {
-            Value = value;
-            AnyNamespace = false;
-            Namespace = ns;
-        }
-
         public override string ToString()
         {
             if (!AnyNamespace)
@@ -61,22 +44,19 @@ namespace Spark.Search
 
             string pair0 = StringValue.UnescapeString(pair[0]);
 
-            if (hasNamespace)
-            {
-                string pair1 = StringValue.UnescapeString(pair[1]);
+            if (!hasNamespace) return
+                new TokenValue { Value = pair0, AnyNamespace = true };
 
-                if (pair0 == string.Empty)
-                    return new TokenValue(pair1, matchAnyNamespace: false );
+            string pair1 = StringValue.UnescapeString(pair[1]);
 
-                if (string.IsNullOrEmpty(pair1))
-                    return new TokenValue { Namespace = pair0, AnyNamespace = false };
+            if (string.IsNullOrEmpty(pair0))
+                return new TokenValue { Value = pair1, AnyNamespace = false };
 
-                return new TokenValue(pair1, pair0);
-            }
-            else
-            {
-                return new TokenValue(pair0, matchAnyNamespace: true);
-            }            
+            if (string.IsNullOrEmpty(pair1))
+                return new TokenValue { Namespace = pair0, AnyNamespace = false };
+
+            return new TokenValue { Namespace = pair0, Value = pair1, AnyNamespace = false };
+
         }     
     }
 }

--- a/src/Spark.Mongo/Search/Searcher/CriteriaMongoExtensions.cs
+++ b/src/Spark.Mongo/Search/Searcher/CriteriaMongoExtensions.cs
@@ -343,9 +343,12 @@ namespace Spark.Search.Mongo
                         var plainStringQueries = new List<FilterDefinition<BsonDocument>>{
                             Builders<BsonDocument>.Filter.Type(parameterName, BsonType.String)};
 
-                        noArrayQueries.Add(Builders<BsonDocument>.Filter.Eq(codefield, typedEqOperand.Value));
-                        arrayQueries.Add(Builders<BsonDocument>.Filter.Eq("code", typedEqOperand.Value));
-                        plainStringQueries.Add(Builders<BsonDocument>.Filter.Eq(parameterName, typedEqOperand.Value));
+                        if (!string.IsNullOrEmpty(typedEqOperand.Value))
+                        {
+                            noArrayQueries.Add(Builders<BsonDocument>.Filter.Eq(codefield, typedEqOperand.Value));
+                            arrayQueries.Add(Builders<BsonDocument>.Filter.Eq("code", typedEqOperand.Value));
+                            plainStringQueries.Add(Builders<BsonDocument>.Filter.Eq(parameterName, typedEqOperand.Value));
+                        }
 
                         //Handle the system part, if present.
                         if (!typedEqOperand.AnyNamespace)


### PR DESCRIPTION
This implements partly the token type: '[parameter]=[system]|' from the
spec entry at: http://hl7.org/fhir/STU3/search.html#token.

Currently we can match any element where the value of [system] matches
the system property of Identifier, not including Coding.

The whole spec entry reads as such:
[parameter]=[system]|: any element where the value of [system] matches
the system property of the Identifier or Coding.