### PR TITLE
Engine: Better resolve handling for search parameters of type 'reference' 

### DIFF
--- a/Spark.sln
+++ b/Spark.sln
@@ -68,6 +68,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{C6DB166C-A
 		docs\InstallingSpark.md = docs\InstallingSpark.md
 		docs\RunningSparkInDocker.md = docs\RunningSparkInDocker.md
 		docs\UsingSpark.md = docs\UsingSpark.md
+		docs\MigrateFromv1Tov2.md = docs\MigrateFromv1Tov2.md
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "scripts", "scripts", "{977F2FE5-C232-4F93-AA0A-73DB85A20879}"

--- a/docs/MigrateFromv1Tov2.md
+++ b/docs/MigrateFromv1Tov2.md
@@ -1,5 +1,11 @@
 ## Migrate from 1.0 to 2.0
 
+### New IGenerator implementation
 MongoIdGenerator is replaced by GuidGenerator and is the new default
 identity generator for resource's. See issue https://github.com/FirelyTeam/spark/issues/572
 for more information.
+
+### Rebuild indexes
+Better resolve handling for search parameters of type reference has been added, for this to take effect on existing
+resources the index has to be rebuilt. This can be done by by using the Admin UI that comes with Spark.Web or wire up
+IndexRebuildService in your implementation.

--- a/docs/MigrateFromv1Tov2.md
+++ b/docs/MigrateFromv1Tov2.md
@@ -1,9 +1,8 @@
 ## Migrate from 1.0 to 2.0
 
 ### New IGenerator implementation
-MongoIdGenerator is replaced by GuidGenerator and is the new default
-identity generator for resource's. See issue https://github.com/FirelyTeam/spark/issues/572
-for more information.
+MongoIdGenerator is replaced by GuidGenerator and is the new default identity generator for resource's.
+See issue https://github.com/FirelyTeam/spark/issues/572 for more information.
 
 ### Rebuild indexes
 Better resolve handling for search parameters of type reference has been added, for this to take effect on existing

--- a/src/Spark.Engine.Test/Service/IndexServiceTests.cs
+++ b/src/Spark.Engine.Test/Service/IndexServiceTests.cs
@@ -54,16 +54,18 @@ namespace Spark.Engine.Test.Service
             };
             var searchParameters = new List<SearchParamDefinition> { spPatientName, spMiddleName };
             var resources = new Dictionary<Type, string> { { typeof(Patient), "Patient" }, { typeof(HumanName), "HumanName" } };
+
+            var resourceResolver = new ResourceResolver();
             
             // For this test setup we want a limited available types and search parameters.
             IFhirModel limitedFhirModel = new FhirModel(resources, searchParameters);
             ElementIndexer limitedElementIndexer = new ElementIndexer(limitedFhirModel);
-            _limitedIndexService = new IndexService(limitedFhirModel, indexStoreMock.Object, limitedElementIndexer);
+            _limitedIndexService = new IndexService(limitedFhirModel, indexStoreMock.Object, limitedElementIndexer, resourceResolver);
 
             // For this test setup we want all available types and search parameters.
             IFhirModel fullFhirModel = new FhirModel();
             ElementIndexer fullElementIndexer = new ElementIndexer(fullFhirModel);
-            _fullIndexService = new IndexService(fullFhirModel, indexStoreMock.Object, fullElementIndexer);
+            _fullIndexService = new IndexService(fullFhirModel, indexStoreMock.Object, fullElementIndexer, resourceResolver);
         }
         
         [TestMethod]

--- a/src/Spark.Engine/Extensions/NetCore/IServiceCollectionExtensions.cs
+++ b/src/Spark.Engine/Extensions/NetCore/IServiceCollectionExtensions.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2019-2021, Incendi (info@incendi.no) and contributors
+ * Copyright (c) 2019-2023, Incendi (info@incendi.no) and contributors
  * See the file CONTRIBUTORS for details.
  *
  * This file is licensed under the BSD 3-Clause license
@@ -141,6 +141,8 @@ namespace Spark.Engine.Extensions
             services.TryAddTransient<ElementIndexer>();
 
             services.TryAddTransient<IReferenceNormalizationService, ReferenceNormalizationService>();
+
+            services.TryAddSingleton<ResourceResolver>();
 
             services.TryAddTransient<IIndexService, IndexService>();
             services.TryAddTransient<ILocalhost>((provider) => new Localhost(settings.Endpoint));

--- a/src/Spark.Engine/Search/ResourceResolver.cs
+++ b/src/Spark.Engine/Search/ResourceResolver.cs
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2023, Incendi (info@incendi.no) and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/spark/stu3/master/LICENSE
+ */
+
+using Hl7.Fhir.ElementModel;
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Serialization;
+using Hl7.Fhir.Specification;
+using Newtonsoft.Json.Linq;
+using System.Text.RegularExpressions;
+
+namespace Spark.Engine.Search
+{
+    public class ResourceResolver
+    {
+        private const string RESOURCE_TYPE_CAPTURE = "resourceType";
+        private const string RESOURCE_ID_CAPTURE = "resourceId";
+
+        private readonly Regex _referenceRegex;
+        private readonly IStructureDefinitionSummaryProvider _structureDefinitionSummaryProvider;
+
+        public ResourceResolver()
+        {
+            var resourceTypesPattern = string.Join("|", ModelInfo.SupportedResources);
+            var referenceCaptureRegexPattern = $@"(?<{RESOURCE_TYPE_CAPTURE}>{resourceTypesPattern})\/(?<{RESOURCE_ID_CAPTURE}>[A-Za-z0-9\-\.]{{1,64}})(\/_history\/[A-Za-z0-9\-\.]{{1,64}})?";
+            _referenceRegex = new Regex(referenceCaptureRegexPattern, RegexOptions.Singleline | RegexOptions.Compiled | RegexOptions.ExplicitCapture);
+
+            _structureDefinitionSummaryProvider = new PocoStructureDefinitionSummaryProvider();
+        }
+
+        public ITypedElement Resolve(string reference)
+        {
+            if (string.IsNullOrWhiteSpace(reference))
+            {
+                return null;
+            }
+
+            var match = _referenceRegex.Match(reference);
+            if (!match.Success)
+            {
+                return null;
+            }
+
+            string resourceTypeInString = match.Groups[RESOURCE_TYPE_CAPTURE].Value;
+            string resourceId = match.Groups[RESOURCE_ID_CAPTURE].Value;
+            ISourceNode node = FhirJsonNode.Create(
+                JObject.FromObject(
+                    new
+                    {
+                        resourceType = resourceTypeInString,
+                        id = resourceId,
+                    }));
+
+            return node.ToTypedElement(_structureDefinitionSummaryProvider);
+        }
+    }
+}

--- a/src/Spark.Engine/Service/FhirServiceExtensions/IndexService.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/IndexService.cs
@@ -34,10 +34,10 @@ namespace Spark.Engine.Service.FhirServiceExtensions
 
         public IndexService(IFhirModel fhirModel, IIndexStore indexStore, ElementIndexer elementIndexer, ResourceResolver elementResolver)
         {
-            _fhirModel = fhirModel;
-            _indexStore = indexStore;
-            _elementIndexer = elementIndexer;
-            _elementResolver = elementResolver;
+            _fhirModel = fhirModel ?? throw new ArgumentNullException(nameof(fhirModel));
+            _indexStore = indexStore ?? throw new ArgumentNullException(nameof(indexStore));
+            _elementIndexer = elementIndexer ?? throw new ArgumentNullException(nameof(elementIndexer));
+            _elementResolver = elementResolver ?? throw new ArgumentNullException(nameof(elementResolver));
         }
 
         public void Process(Entry entry)


### PR DESCRIPTION
For this to take effect on existing implementations it is necessary to rebuild the index by using the Admin UI that comes with Spark.Web or wire up `IndexRebuildService` in your implementaion.

Se independent commits for details.

Resolves #436
Resolves #521 
Resolves #522 
Resolves #526 

Co-authored-by: @whyfate 