### PR TITLE
Engine: Rename IGenerator to IIdentityGenerator

### DIFF
--- a/docs/MigrateFromv1Tov2.md
+++ b/docs/MigrateFromv1Tov2.md
@@ -1,5 +1,8 @@
 ## Migrate from 1.0 to 2.0
 
+### Interfaces and classes that have been renamed
+- IGenerator has been renamed to IIdentityGenerator
+
 ### New IGenerator implementation
 MongoIdGenerator is replaced by GuidGenerator and is the new default identity generator for resource's.
 See issue https://github.com/FirelyTeam/spark/issues/572 for more information.

--- a/src/Spark.Engine/Core/UriHelper.cs
+++ b/src/Spark.Engine/Core/UriHelper.cs
@@ -68,7 +68,7 @@ namespace Spark.Engine.Core
             }
         }
 
-        public static Uri HistoryKeyFor(this IGenerator generator, Uri key)
+        public static Uri HistoryKeyFor(this IIdentityGenerator generator, Uri key)
         {
             var identity = new ResourceIdentity(key);
             string vid = generator.NextVersionId(identity.ResourceType, identity.Id);

--- a/src/Spark.Engine/Extensions/GeneratorKeyExtensions.cs
+++ b/src/Spark.Engine/Extensions/GeneratorKeyExtensions.cs
@@ -7,14 +7,14 @@ namespace Spark.Engine.Extensions
 {
     public static class GeneratorKeyExtensions
     {
-        public static Key NextHistoryKey(this IGenerator generator, IKey key)
+        public static Key NextHistoryKey(this IIdentityGenerator generator, IKey key)
         {
             Key historykey = key.Clone();
             historykey.VersionId = generator.NextVersionId(key.TypeName, key.ResourceId);
             return historykey;
         }
 
-        public static Key NextKey(this IGenerator generator, Resource resource)
+        public static Key NextKey(this IIdentityGenerator generator, Resource resource)
         {
             string resourceid = generator.NextResourceId(resource);
             Key key = resource.ExtractKey();
@@ -22,7 +22,7 @@ namespace Spark.Engine.Extensions
             return Key.Create(key.TypeName, resourceid, versionid);
         }
 
-        public static void AddHistoryKeys(this IGenerator generator, List<Entry> entries)
+        public static void AddHistoryKeys(this IIdentityGenerator generator, List<Entry> entries)
         {
             // PERF: this needs a performance improvement.
             foreach (Entry entry in entries)

--- a/src/Spark.Engine/Extensions/NetCore/IServiceCollectionExtensions.cs
+++ b/src/Spark.Engine/Extensions/NetCore/IServiceCollectionExtensions.cs
@@ -50,9 +50,9 @@ namespace Spark.Engine.Extensions
         }
 
         public static void AddIdGenerator<T>(this IServiceCollection services)
-            where T : class, IGenerator
+            where T : class, IIdentityGenerator
         {
-            services.TryAddTransient<IGenerator, T>();
+            services.TryAddTransient<IIdentityGenerator, T>();
         }
 
         internal static void AddFhirExtensions(this IServiceCollection services, IDictionary<Type, Type> fhirServiceExtensions)

--- a/src/Spark.Engine/Interfaces/IIdentityGenerator.cs
+++ b/src/Spark.Engine/Interfaces/IIdentityGenerator.cs
@@ -10,7 +10,7 @@ using Hl7.Fhir.Model;
 
 namespace Spark.Core
 {
-    public interface IGenerator
+    public interface IIdentityGenerator
     {
         string NextResourceId(Resource resource);
         string NextVersionId(string resourceIdentifier);

--- a/src/Spark.Engine/Service/FhirServiceExtensions/FhirExtensionsBuilder.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/FhirExtensionsBuilder.cs
@@ -59,7 +59,7 @@ namespace Spark.Engine.Service.FhirServiceExtensions
         {
             IFhirStore fhirStore = _fhirStoreBuilder.GetStore<IFhirStore>();
             ISnapshotStore snapshotStore = _fhirStoreBuilder.GetStore<ISnapshotStore>();
-            IGenerator storeGenerator = _fhirStoreBuilder.GetStore<IGenerator>();
+            IIdentityGenerator storeGenerator = _fhirStoreBuilder.GetStore<IIdentityGenerator>();
             if (fhirStore != null)
                 return new PagingService(snapshotStore, new SnapshotPaginationProvider(fhirStore, new Transfer(storeGenerator, new Localhost(_baseUri), _sparkSettings), new Localhost(_baseUri), new SnapshotPaginationCalculator()));
             return null;
@@ -68,7 +68,7 @@ namespace Spark.Engine.Service.FhirServiceExtensions
         protected virtual IFhirServiceExtension GetStorage()
         {
             IFhirStore fhirStore = _fhirStoreBuilder.GetStore<IFhirStore>();
-            IGenerator fhirGenerator = _fhirStoreBuilder.GetStore<IGenerator>();
+            IIdentityGenerator fhirGenerator = _fhirStoreBuilder.GetStore<IIdentityGenerator>();
             if (fhirStore != null)
                 return new ResourceStorageService(new Transfer(fhirGenerator, new Localhost(_baseUri), _sparkSettings),  fhirStore);
             return null;

--- a/src/Spark.Engine/Service/Import.cs
+++ b/src/Spark.Engine/Service/Import.cs
@@ -26,9 +26,9 @@ namespace Spark.Service
         private readonly Mapper<string, IKey> _mapper;
         private readonly List<Entry> _entries;
         private readonly ILocalhost _localhost;
-        private readonly IGenerator _generator;
+        private readonly IIdentityGenerator _generator;
 
-        public Import(ILocalhost localhost, IGenerator generator)
+        public Import(ILocalhost localhost, IIdentityGenerator generator)
         {
             _localhost = localhost;
             _generator = generator;

--- a/src/Spark.Engine/Service/Transfer.cs
+++ b/src/Spark.Engine/Service/Transfer.cs
@@ -13,10 +13,10 @@ namespace Spark.Service
     public class Transfer : ITransfer
     {
         private readonly ILocalhost _localhost;
-        private readonly IGenerator _generator;
+        private readonly IIdentityGenerator _generator;
         private readonly SparkSettings _settings;
 
-        public Transfer(IGenerator generator, ILocalhost localhost, SparkSettings settings = null)
+        public Transfer(IIdentityGenerator generator, ILocalhost localhost, SparkSettings settings = null)
         {
             _generator = generator;
             _localhost = localhost;

--- a/src/Spark.Mongo/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Spark.Mongo/Extensions/IServiceCollectionExtensions.cs
@@ -27,7 +27,7 @@ namespace Spark.Mongo.Extensions
         public static void AddMongoFhirStore(this IServiceCollection services, StoreSettings settings)
         {
             services.TryAddSingleton(settings);
-            services.TryAddTransient<IIdentityGenerator>((provider) => new GuidGenerator(settings.ConnectionString));
+            services.TryAddTransient<IIdentityGenerator>((provider) => new GuidIdentityGenerator(settings.ConnectionString));
             services.TryAddTransient<IFhirStore>((provider) => new MongoFhirStore(settings.ConnectionString));
             services.TryAddTransient<IFhirStorePagedReader>((provider) => new MongoFhirStorePagedReader(settings.ConnectionString));
             services.TryAddTransient<IHistoryStore>((provider) => new HistoryStore(settings.ConnectionString));

--- a/src/Spark.Mongo/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Spark.Mongo/Extensions/IServiceCollectionExtensions.cs
@@ -27,7 +27,7 @@ namespace Spark.Mongo.Extensions
         public static void AddMongoFhirStore(this IServiceCollection services, StoreSettings settings)
         {
             services.TryAddSingleton(settings);
-            services.TryAddTransient<IGenerator>((provider) => new GuidGenerator(settings.ConnectionString));
+            services.TryAddTransient<IIdentityGenerator>((provider) => new GuidGenerator(settings.ConnectionString));
             services.TryAddTransient<IFhirStore>((provider) => new MongoFhirStore(settings.ConnectionString));
             services.TryAddTransient<IFhirStorePagedReader>((provider) => new MongoFhirStorePagedReader(settings.ConnectionString));
             services.TryAddTransient<IHistoryStore>((provider) => new HistoryStore(settings.ConnectionString));

--- a/src/Spark.Mongo/Store/GuidGenerator.cs
+++ b/src/Spark.Mongo/Store/GuidGenerator.cs
@@ -15,7 +15,7 @@ using System;
 
 namespace Spark.Mongo.Store
 {
-    public class GuidGenerator : IGenerator
+    public class GuidGenerator : IIdentityGenerator
     {
         private readonly IMongoDatabase _database;
         private readonly string _formatSpecifier;

--- a/src/Spark.Mongo/Store/GuidIdentityGenerator.cs
+++ b/src/Spark.Mongo/Store/GuidIdentityGenerator.cs
@@ -15,12 +15,12 @@ using System;
 
 namespace Spark.Mongo.Store
 {
-    public class GuidGenerator : IIdentityGenerator
+    public class GuidIdentityGenerator : IIdentityGenerator
     {
         private readonly IMongoDatabase _database;
         private readonly string _formatSpecifier;
 
-        public GuidGenerator(string mongoUrl, string formatSpecifier = "D")
+        public GuidIdentityGenerator(string mongoUrl, string formatSpecifier = "D")
         {
             _database = MongoDatabaseFactory.GetMongoDatabase(mongoUrl);
             _formatSpecifier = formatSpecifier;

--- a/src/Spark.Mongo/Store/MongoIdGenerator.cs
+++ b/src/Spark.Mongo/Store/MongoIdGenerator.cs
@@ -7,7 +7,7 @@ using Spark.Store.Mongo;
 
 namespace Spark.Mongo.Store
 {
-    public class MongoIdGenerator : IGenerator
+    public class MongoIdGenerator : IIdentityGenerator
     {
         public static string RESOURCEID = "{0}";
         public static string VERSIONID = "{0}";
@@ -18,18 +18,18 @@ namespace Spark.Mongo.Store
         {
             _database = MongoDatabaseFactory.GetMongoDatabase(mongoUrl);
         }
-        string IGenerator.NextResourceId(Resource resource)
+        string IIdentityGenerator.NextResourceId(Resource resource)
         {
             string id = Next(resource.TypeName);
             return string.Format(RESOURCEID, id);
         }
         
-        string IGenerator.NextVersionId(string resourceIdentifier)
+        string IIdentityGenerator.NextVersionId(string resourceIdentifier)
         {
             throw new NotImplementedException();
         }
 
-        string IGenerator.NextVersionId(string resourceType, string resourceIdentifier)
+        string IIdentityGenerator.NextVersionId(string resourceType, string resourceIdentifier)
         {
             string name = resourceType + "_history_" + resourceIdentifier;
             string versionId = Next(name);


### PR DESCRIPTION
A better reflection of the purpose of this interface. This is a breaking change and has been noted accordingly in the migration document.