### PR TITLE
Engine: Handle same search parameter multiple times in POST search

### DIFF
--- a/src/Spark.Engine/Extensions/HttpHeadersExtensions.cs
+++ b/src/Spark.Engine/Extensions/HttpHeadersExtensions.cs
@@ -71,12 +71,10 @@ namespace Spark.Engine.Extensions
         public static SearchParams GetSearchParamsFromBody(this HttpRequest request)
         {
             var list = new List<Tuple<string, string>>();
-
             foreach (var parameter in request.Form)
             {
-                list.Add(new Tuple<string, string>(parameter.Key, parameter.Value));
+                list.AddRange(parameter.Value.Select(value => new Tuple<string, string>(parameter.Key, value)));
             }
-
             return request.GetSearchParams().AddAll(list);
         }
 


### PR DESCRIPTION
This patch fixes an issue where we would fail to properly parse multiples of the same search parameter on POST searches.

i.e: period=ge2004-12-20&period=lt2005-12-31

Fixes: #691

@JeremiahSanders are you able to verify this patch before I merge it?