### PR TITLE
Engine+Tests+Web+workflows: Target net8.0

### DIFF
--- a/.docker/linux/Spark.Dockerfile
+++ b/.docker/linux/Spark.Dockerfile
@@ -1,9 +1,7 @@
-FROM mcr.microsoft.com/dotnet/aspnet:6.0-bullseye-slim AS base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-bookworm-slim AS base
 WORKDIR /app
-EXPOSE 80
-EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0-bookworm-slim AS build
 WORKDIR /src
 COPY ["./src/Spark.Web/Spark.Web.csproj", "Spark.Web/Spark.Web.csproj"]
 COPY ["./src/Spark.Engine/Spark.Engine.csproj", "Spark.Engine/Spark.Engine.csproj"]

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -28,7 +28,7 @@ jobs:
           cd tests/integration-tests
           mkdir -p logs html_summaries json_results
           docker-compose up -d spark
-          docker-compose run --rm --no-deps plan_executor ./execute_all.sh 'http://spark/fhir' r4 'html|json|stdout'
+          docker-compose run --rm --no-deps plan_executor ./execute_all.sh 'http://spark:8080/fhir' r4 'html|json|stdout'
           docker-compose logs spark > logs/backend.log
       - 
         name: Combine test results

--- a/.github/workflows/nuget_deploy.yml
+++ b/.github/workflows/nuget_deploy.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 8.0.x
       - name: Build
         run: |
           dotnet pack "./src/Spark.Engine/Spark.Engine.csproj" -c Release

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 8.0.x
       - name: Build with dotnet
         run: dotnet build src/Spark.Web/Spark.Web.csproj -c Release
       - name: Unit tests

--- a/src/Spark.Engine.Test/Spark.Engine.Test.csproj
+++ b/src/Spark.Engine.Test/Spark.Engine.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Spark.Engine/Spark.Engine.csproj
+++ b/src/Spark.Engine/Spark.Engine.csproj
@@ -11,10 +11,10 @@
     <ItemGroup>
         <PackageReference Include="Fhir.Metrics" Version="1.2.2" />
         <PackageReference Include="Hl7.Fhir.R4" Version="5.4.0" />
-        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
         <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-        <PackageReference Include="System.Security.Cryptography.Xml" Version="6.0.1" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+        <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">

--- a/src/Spark.Engine/Spark.Engine.csproj
+++ b/src/Spark.Engine/Spark.Engine.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;net6.0;net462</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
         <LangVersion>8.0</LangVersion>
         <PackageId>Spark.Engine.R4</PackageId>
         <Product>Spark.Engine.R4</Product>
@@ -18,10 +18,6 @@
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.2.0" />
-    </ItemGroup>
-
-    <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
         <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.2.0" />
     </ItemGroup>
 

--- a/src/Spark.Mongo.Tests/Spark.Mongo.Tests.csproj
+++ b/src/Spark.Mongo.Tests/Spark.Mongo.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Spark.Web/Spark.Web.csproj
+++ b/src/Spark.Web/Spark.Web.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AspNetCoreModuleName>AspNetCoreModuleV2</AspNetCoreModuleName>
     <UserSecretsId>a4d3c2a3-5edd-47d1-8407-62489d5568c5</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.29" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="6.0.29" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.29" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.4" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 

--- a/tests/integration-tests/docker-compose.yml
+++ b/tests/integration-tests/docker-compose.yml
@@ -6,7 +6,12 @@ services:
     image: sparkfhir/spark:r4-latest
     environment:
       - StoreSettings__ConnectionString=mongodb://root:secret@mongodb:27017/spark?authSource=admin
-      - SparkSettings__Endpoint=http://spark/fhir
+      - SparkSettings__Endpoint=http://spark:8080/fhir
+      - ASPNETCORE_URLS=http://+:8080
+      - ASPNETCORE_HTTP_PORT=8080
+    ports:
+      - "8000:8080"
+      - "8001:8081"
     depends_on:
       - mongodb
   mongodb:
@@ -26,4 +31,3 @@ services:
       - ./logs:/app/logs:rw
       - ./html_summaries:/app/html_summaries:rw
       - ./json_results:/app/json_results:rw
-      


### PR DESCRIPTION
Spark.*.Tests and Spar.Web now target net8.0. All necessary dependencies
are upgraded to their .net8.0 version.

Docker files have been modified to adhere to the default port changes
done in ASP.NET Core 8.0.
See: https://learn.microsoft.com/en-us/dotnet/core/compatibility/containers/8.0/aspnet-port