### PR TITLE
docker: Add environment variable ASPNETCORE_URLS to Spark.Dockerfile

### DIFF
--- a/.docker/docker-compose.example.yml
+++ b/.docker/docker-compose.example.yml
@@ -9,7 +9,6 @@ services:
       - SparkSettings__Endpoint=http://localhost:5555/fhir
     ports:
       - "5555:80"
-      - "44344:443"
     depends_on:
       - mongodb
   mongodb:

--- a/.docker/linux/Spark.Dockerfile
+++ b/.docker/linux/Spark.Dockerfile
@@ -1,5 +1,6 @@
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-bookworm-slim AS base
 WORKDIR /app
+ENV ASPNETCORE_URLS=http://+:80
 
 FROM mcr.microsoft.com/dotnet/sdk:8.0-bookworm-slim AS build
 WORKDIR /src


### PR DESCRIPTION
Add environment variable ASPNETCORE_URLS and specify that it should listen to port 80 for any incoming requests.