### PR TITLE
Documentation: Drop deprecated --db flag from mongorestore command

### DIFF
--- a/Documentation/Quickstart.md
+++ b/Documentation/Quickstart.md
@@ -24,16 +24,16 @@ Add the MongoDB store:
 dotnet add package Spark.Mongo.R4
 ```
 
-For testing purposes restore one of the examples database.
+For testing purposes restore one of the examples database. The database will be restored with the name `spark`.
 
 Windows:
 ```bash
-mongorestore /host:localhost /db:spark-test /archive:.\.docker\linux\r4.archive.gz /gzip
+mongorestore /host:localhost /archive:.\.docker\linux\r4.archive.gz /gzip
 ```
 
 Linux/Mac OS X: 
 ```bash
-mongorestore --host:localhost --db:spark-test --archive:./.docker/linux/r4.archive.gz --gzip
+mongorestore --host=localhost --archive=./.docker/linux/r4.archive.gz --gzip
 ```
 
 ## Configuration and infrastrucuture


### PR DESCRIPTION
This drops the deprecated `--db` flag from the mongorestore command in
the Quick Start example.