### PR TITLE
Meta: Set AssemblyName explicitly for Spark.{Engine,Mongo}

### DIFF
--- a/src/Spark.Engine/Spark.Engine.csproj
+++ b/src/Spark.Engine/Spark.Engine.csproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
+        <AssemblyName>Spark.Engine.R4</AssemblyName>
         <LangVersion>8.0</LangVersion>
         <PackageId>Spark.Engine.R4</PackageId>
         <Product>Spark.Engine.R4</Product>

--- a/src/Spark.Mongo/Spark.Mongo.csproj
+++ b/src/Spark.Mongo/Spark.Mongo.csproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
+        <AssemblyName>Spark.Mongo.R4</AssemblyName>
         <LangVersion>8.0</LangVersion>
         <PackageId>Spark.Mongo.R4</PackageId>
         <Product>Spark.Mongo.R4</Product>


### PR DESCRIPTION
This is useful for those that cross-reference assemblies across different versions of FHIR. I.e your application supports both STU3 and R4.

Closes: #748 