### PR TITLE
[STU3] Meta: Set AssemblyName explicitly for Spark.{Engine,Mongo}

### DIFF
--- a/src/Spark.Engine/Spark.Engine.csproj
+++ b/src/Spark.Engine/Spark.Engine.csproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
+        <AssemblyName>Spark.Engine.STU3</AssemblyName>
         <LangVersion>8.0</LangVersion>
         <PackageId>Spark.Engine.STU3</PackageId>
         <Product>Spark.Engine.STU3</Product>

--- a/src/Spark.Mongo/Spark.Mongo.csproj
+++ b/src/Spark.Mongo/Spark.Mongo.csproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
+        <AssemblyName>Spark.Mongo.STU3</AssemblyName>
         <LangVersion>8.0</LangVersion>
         <PackageId>Spark.Mongo.STU3</PackageId>
         <Product>Spark.Mongo.STU3</Product>


### PR DESCRIPTION
This is useful for those that cross-reference assemblies across different versions of FHIR. I.e your application supports both STU3 and R4.

Closes: #748