### PR TITLE
Engine: Initialize a FhirEvalutionContext via ctor

### DIFF
--- a/src/Spark.Engine/Service/FhirServiceExtensions/ElementNavFhirExtensionsNew.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/ElementNavFhirExtensionsNew.cs
@@ -34,7 +34,7 @@ internal static class ElementNavFhirExtensionsNew
         FhirEvaluationContext ctx = null)
     {
         var inputNav = input.ToTypedElement();
-        var result = inputNav.Select(expression, ctx ?? FhirEvaluationContext.CreateDefault());
+        var result = inputNav.Select(expression, ctx ?? new FhirEvaluationContext());
         return result.ToFhirValues();
     }
 


### PR DESCRIPTION
Static method FhirEvaluationContext.CreateDefault() is marked as obsolete initialize a FhirEvalutionContext via the ctor instead.