### PR TITLE
Engine: Drop target for .NET Framework 4.6.2 and target 4.7.2

### DIFF
--- a/src/Spark.Engine/ExceptionHandling/ExceptionResponseMessageFactory.cs
+++ b/src/Spark.Engine/ExceptionHandling/ExceptionResponseMessageFactory.cs
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#if NET462
+#if NET472
 using System;
 using System.Net;
 using System.Net.Http;

--- a/src/Spark.Engine/ExceptionHandling/FhirErrorMessageHandler.cs
+++ b/src/Spark.Engine/ExceptionHandling/FhirErrorMessageHandler.cs
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#if NET462
+#if NET472
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Spark.Engine/ExceptionHandling/FhirGlobalExceptionHandler.cs
+++ b/src/Spark.Engine/ExceptionHandling/FhirGlobalExceptionHandler.cs
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#if NET462
+#if NET472
 using System.Net.Http;
 using System.Web.Http.ExceptionHandling;
 using System.Web.Http.Results;

--- a/src/Spark.Engine/Extensions/HttpConfigurationFhirExtensions.cs
+++ b/src/Spark.Engine/Extensions/HttpConfigurationFhirExtensions.cs
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#if NET462
+#if NET472
 using System.Web.Http;
 using System.Web.Http.Validation;
 using System.Net.Http.Formatting;

--- a/src/Spark.Engine/Extensions/X509Certificate2Extensions.cs
+++ b/src/Spark.Engine/Extensions/X509Certificate2Extensions.cs
@@ -13,7 +13,7 @@ internal static class X509Certificate2Extensions
 {
     public static AsymmetricAlgorithm GetPrivateKey(this X509Certificate2 certificate)
     {
-#if NETSTANDARD2_0 || NET462
+#if NETSTANDARD2_0 || NET472
         return certificate.PrivateKey;
 #else
             if (!certificate.HasPrivateKey)

--- a/src/Spark.Engine/Filters/CompressionHandler.cs
+++ b/src/Spark.Engine/Filters/CompressionHandler.cs
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
- #if NET462
+ #if NET472
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Spark.Engine/Filters/FhirExceptionFilter.cs
+++ b/src/Spark.Engine/Filters/FhirExceptionFilter.cs
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#if NET462
+#if NET472
 using System.Net.Http;
 using Spark.Engine.ExceptionHandling;
 using System.Web.Http;

--- a/src/Spark.Engine/Filters/FhirResponseHandler.cs
+++ b/src/Spark.Engine/Filters/FhirResponseHandler.cs
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#if NET462
+#if NET472
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Spark.Engine/Maintenance/MaintenanceModeNetHttpHandler.cs
+++ b/src/Spark.Engine/Maintenance/MaintenanceModeNetHttpHandler.cs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#if NET462
+#if NET472
 using System.Net;
 using System.Net.Http;
 using System.Threading;

--- a/src/Spark.Engine/Spark.Engine.csproj
+++ b/src/Spark.Engine/Spark.Engine.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
         <AssemblyName>Spark.Engine.R4</AssemblyName>
         <LangVersion>latest</LangVersion>
         <PackageId>Spark.Engine.R4</PackageId>
@@ -22,7 +22,7 @@
         <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.2.0" />
     </ItemGroup>
 
-    <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
         <PackageReference Include="Microsoft.AspNet.WebApi" Version="5.3.0" />
     </ItemGroup>
 


### PR DESCRIPTION
This drops the target for .NET Framework 4.6.2 and targets instead .NET Framework 4.7.2.