### PR TITLE
Engine+Mongo: Drop target for netstandard2.0

### DIFF
--- a/src/Spark.Engine/Core/ConditionalHeaderParameters.cs
+++ b/src/Spark.Engine/Core/ConditionalHeaderParameters.cs
@@ -9,7 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using Spark.Engine.Extensions;
-#if NETSTANDARD2_0 || NET6_0_OR_GREATER
+#if NETSTANDARD2_1 || NET6_0_OR_GREATER
 using Microsoft.AspNetCore.Http;
 #endif
 
@@ -23,7 +23,7 @@ public class ConditionalHeaderParameters
         IfModifiedSince = request.IfModifiedSince();
     }
 
-#if NETSTANDARD2_0 || NET6_0_OR_GREATER
+#if NETSTANDARD2_1 || NET6_0_OR_GREATER
         public ConditionalHeaderParameters(HttpRequest request)
         {
             IfNoneMatchTags = request.IfNoneMatch();

--- a/src/Spark.Engine/Core/HistoryParameters.cs
+++ b/src/Spark.Engine/Core/HistoryParameters.cs
@@ -9,7 +9,7 @@ using System;
 using System.Net.Http;
 using Spark.Engine.Extensions;
 using Spark.Engine.Utility;
-#if NETSTANDARD2_0 || NET6_0_OR_GREATER
+#if NETSTANDARD2_1 || NET6_0_OR_GREATER
 using Microsoft.AspNetCore.Http;
 #endif
 
@@ -28,7 +28,7 @@ public class HistoryParameters
         SortBy = request.GetParameter(FhirParameter.SORT);
     }
 
-#if NETSTANDARD2_0 || NET6_0_OR_GREATER
+#if NETSTANDARD2_1 || NET6_0_OR_GREATER
         public HistoryParameters(HttpRequest request)
         {
             Count = FhirParameterParser.ParseIntParameter(request.GetParameter(FhirParameter.COUNT));

--- a/src/Spark.Engine/ExceptionHandling/NetCore/ErrorHandler.cs
+++ b/src/Spark.Engine/ExceptionHandling/NetCore/ErrorHandler.cs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#if NETSTANDARD2_0 || NET6_0_OR_GREATER
+#if NETSTANDARD2_1 || NET6_0_OR_GREATER
 using FhirModel = Hl7.Fhir.Model;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Formatters;

--- a/src/Spark.Engine/Extensions/HttpHeadersExtensions.cs
+++ b/src/Spark.Engine/Extensions/HttpHeadersExtensions.cs
@@ -11,7 +11,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
-#if NETSTANDARD2_0 || NET6_0_OR_GREATER
+#if NETSTANDARD2_1 || NET6_0_OR_GREATER
 using Microsoft.AspNetCore.Http;
 #endif
 
@@ -53,7 +53,7 @@ public static class HttpRequestExtensions
                || ContentType.JSON_CONTENT_HEADERS.Contains(contentType);
     }
 
-#if NETSTANDARD2_0 || NET6_0_OR_GREATER
+#if NETSTANDARD2_1 || NET6_0_OR_GREATER
         public static string GetParameter(this HttpRequest request, string key)
         {
             string value = null;

--- a/src/Spark.Engine/Extensions/HttpRequestFhirExtensions.cs
+++ b/src/Spark.Engine/Extensions/HttpRequestFhirExtensions.cs
@@ -17,7 +17,7 @@ using Spark.Engine.Utility;
 using Spark.Formatters;
 using System.Collections.Specialized;
 using System.Runtime.CompilerServices;
-#if NETSTANDARD2_0 || NET6_0_OR_GREATER
+#if NETSTANDARD2_1 || NET6_0_OR_GREATER
 using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Http.Headers;
@@ -42,7 +42,7 @@ public static class HttpRequestFhirExtensions
         }
     }
 
-#if NETSTANDARD2_0 || NET6_0_OR_GREATER
+#if NETSTANDARD2_1 || NET6_0_OR_GREATER
         public static int GetPagingOffsetParameter(this HttpRequest request)
         {
             var offset = FhirParameterParser.ParseIntParameter(request.GetParameter(FhirParameter.OFFSET));

--- a/src/Spark.Engine/Extensions/NetCore/HttpContextExtensions.cs
+++ b/src/Spark.Engine/Extensions/NetCore/HttpContextExtensions.cs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#if NETSTANDARD2_0 || NET6_0_OR_GREATER
+#if NETSTANDARD2_1 || NET6_0_OR_GREATER
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Mvc.Formatters;

--- a/src/Spark.Engine/Extensions/NetCore/IApplicationBuilderExtensions.cs
+++ b/src/Spark.Engine/Extensions/NetCore/IApplicationBuilderExtensions.cs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#if NETSTANDARD2_0 || NET6_0_OR_GREATER
+#if NETSTANDARD2_1 || NET6_0_OR_GREATER
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
 using Spark.Engine.ExceptionHandling;

--- a/src/Spark.Engine/Extensions/NetCore/IServiceCollectionExtensions.cs
+++ b/src/Spark.Engine/Extensions/NetCore/IServiceCollectionExtensions.cs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#if NETSTANDARD2_0 || NET6_0_OR_GREATER
+#if NETSTANDARD2_1 || NET6_0_OR_GREATER
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
 using Microsoft.AspNetCore.Mvc;

--- a/src/Spark.Engine/Extensions/NetCore/SparkOptions.cs
+++ b/src/Spark.Engine/Extensions/NetCore/SparkOptions.cs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#if NETSTANDARD2_0 || NET6_0_OR_GREATER
+#if NETSTANDARD2_1 || NET6_0_OR_GREATER
 using Microsoft.AspNetCore.Mvc;
 using System;
 

--- a/src/Spark.Engine/Extensions/OperationOutcomeExtensions.cs
+++ b/src/Spark.Engine/Extensions/OperationOutcomeExtensions.cs
@@ -16,7 +16,7 @@ using Spark.Engine.Core;
 using System.Diagnostics;
 using System.Linq;
 using Spark.Engine.Utility;
-#if NETSTANDARD2_0 || NET6_0_OR_GREATER
+#if NETSTANDARD2_1 || NET6_0_OR_GREATER
 using Microsoft.AspNetCore.Mvc;
 #endif
 
@@ -26,7 +26,7 @@ public static class OperationOutcomeExtensions
 {
     internal static Func<string, string> pascalToCamelCase = (pascalCase) => $"{char.ToLower(pascalCase[0])}{pascalCase.Substring(1)}";
 
-#if NETSTANDARD2_0 || NET6_0_OR_GREATER
+#if NETSTANDARD2_1 || NET6_0_OR_GREATER
         public static OperationOutcome AddValidationProblems(this OperationOutcome outcome, Type resourceType, HttpStatusCode code, ValidationProblemDetails validationProblems)
         {
             if (resourceType == null) throw new ArgumentNullException(nameof(resourceType));

--- a/src/Spark.Engine/Extensions/X509Certificate2Extensions.cs
+++ b/src/Spark.Engine/Extensions/X509Certificate2Extensions.cs
@@ -13,7 +13,7 @@ internal static class X509Certificate2Extensions
 {
     public static AsymmetricAlgorithm GetPrivateKey(this X509Certificate2 certificate)
     {
-#if NETSTANDARD2_0 || NET472
+#if NETSTANDARD2_1 || NET472
         return certificate.PrivateKey;
 #else
             if (!certificate.HasPrivateKey)

--- a/src/Spark.Engine/Filters/UnsupportedMediaTypeFilter.cs
+++ b/src/Spark.Engine/Filters/UnsupportedMediaTypeFilter.cs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#if NETSTANDARD2_0 || NET6_0_OR_GREATER
+#if NETSTANDARD2_1 || NET6_0_OR_GREATER
 using Microsoft.AspNetCore.Mvc.Filters;
 using Spark.Core;
 using Spark.Engine.Core;

--- a/src/Spark.Engine/Formatters/NetCore/AsyncResourceJsonInputFormatter.cs
+++ b/src/Spark.Engine/Formatters/NetCore/AsyncResourceJsonInputFormatter.cs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#if NETSTANDARD2_0 || NET6_0_OR_GREATER
+#if NETSTANDARD2_1 || NET6_0_OR_GREATER
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
 using Microsoft.AspNetCore.Mvc.Formatters;

--- a/src/Spark.Engine/Formatters/NetCore/AsyncResourceJsonOutputFormatter.cs
+++ b/src/Spark.Engine/Formatters/NetCore/AsyncResourceJsonOutputFormatter.cs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#if NETSTANDARD2_0 || NET6_0_OR_GREATER
+#if NETSTANDARD2_1 || NET6_0_OR_GREATER
 using FhirModel = Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
 using Microsoft.AspNetCore.Mvc.Formatters;

--- a/src/Spark.Engine/Formatters/NetCore/AsyncResourceXmlInputFormatter.cs
+++ b/src/Spark.Engine/Formatters/NetCore/AsyncResourceXmlInputFormatter.cs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#if NETSTANDARD2_0 || NET6_0_OR_GREATER
+#if NETSTANDARD2_1 || NET6_0_OR_GREATER
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
 using Microsoft.AspNetCore.Mvc.Formatters;

--- a/src/Spark.Engine/Formatters/NetCore/AsyncResourceXmlOutputFormatter.cs
+++ b/src/Spark.Engine/Formatters/NetCore/AsyncResourceXmlOutputFormatter.cs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#if NETSTANDARD2_0 || NET6_0_OR_GREATER
+#if NETSTANDARD2_1 || NET6_0_OR_GREATER
 using FhirModel = Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
 using Microsoft.AspNetCore.Mvc.Formatters;

--- a/src/Spark.Engine/Formatters/NetCore/BinaryInputFormatter.cs
+++ b/src/Spark.Engine/Formatters/NetCore/BinaryInputFormatter.cs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#if NETSTANDARD2_0 || NET6_0_OR_GREATER
+#if NETSTANDARD2_1 || NET6_0_OR_GREATER
 using Hl7.Fhir.Model;
 using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.Extensions.Primitives;

--- a/src/Spark.Engine/Formatters/NetCore/BinaryOutputFormatter.cs
+++ b/src/Spark.Engine/Formatters/NetCore/BinaryOutputFormatter.cs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#if NETSTANDARD2_0 || NET6_0_OR_GREATER
+#if NETSTANDARD2_1 || NET6_0_OR_GREATER
 using FhirModel = Hl7.Fhir.Model;
 using Microsoft.AspNetCore.Mvc.Formatters;
 using Spark.Engine.Core;

--- a/src/Spark.Engine/Formatters/NetCore/FhirOutputFormatterSelector.cs
+++ b/src/Spark.Engine/Formatters/NetCore/FhirOutputFormatterSelector.cs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#if NETSTANDARD2_0 || NET6_0_OR_GREATER
+#if NETSTANDARD2_1 || NET6_0_OR_GREATER
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.AspNetCore.Mvc.Infrastructure;

--- a/src/Spark.Engine/Formatters/NetCore/JsonArrayPool.cs
+++ b/src/Spark.Engine/Formatters/NetCore/JsonArrayPool.cs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#if NETSTANDARD2_0 || NET6_0_OR_GREATER
+#if NETSTANDARD2_1 || NET6_0_OR_GREATER
 using Newtonsoft.Json;
 using System;
 using System.Buffers;

--- a/src/Spark.Engine/Formatters/NetCore/ResourceJsonInputFormatter.cs
+++ b/src/Spark.Engine/Formatters/NetCore/ResourceJsonInputFormatter.cs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#if NETSTANDARD2_0 || NET6_0_OR_GREATER
+#if NETSTANDARD2_1 || NET6_0_OR_GREATER
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
 using Microsoft.AspNetCore.Http;

--- a/src/Spark.Engine/Formatters/NetCore/ResourceJsonOutputFormatter.cs
+++ b/src/Spark.Engine/Formatters/NetCore/ResourceJsonOutputFormatter.cs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#if NETSTANDARD2_0 || NET6_0_OR_GREATER
+#if NETSTANDARD2_1 || NET6_0_OR_GREATER
 using FhirModel = Hl7.Fhir.Model;
 using Hl7.Fhir.Rest;
 using Hl7.Fhir.Serialization;

--- a/src/Spark.Engine/Formatters/NetCore/ResourceXmlInputFormatter.cs
+++ b/src/Spark.Engine/Formatters/NetCore/ResourceXmlInputFormatter.cs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#if NETSTANDARD2_0 || NET6_0_OR_GREATER
+#if NETSTANDARD2_1 || NET6_0_OR_GREATER
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
 using Microsoft.AspNetCore.Http;

--- a/src/Spark.Engine/Formatters/NetCore/ResourceXmlOutputFormatter.cs
+++ b/src/Spark.Engine/Formatters/NetCore/ResourceXmlOutputFormatter.cs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#if NETSTANDARD2_0 || NET6_0_OR_GREATER
+#if NETSTANDARD2_1 || NET6_0_OR_GREATER
 using FhirModel = Hl7.Fhir.Model;
 using Hl7.Fhir.Rest;
 using Hl7.Fhir.Serialization;

--- a/src/Spark.Engine/Handlers/NetCore/FormatTypeHandler.cs
+++ b/src/Spark.Engine/Handlers/NetCore/FormatTypeHandler.cs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#if NETSTANDARD2_0 || NET6_0_OR_GREATER
+#if NETSTANDARD2_1 || NET6_0_OR_GREATER
 using Hl7.Fhir.Rest;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;

--- a/src/Spark.Engine/Maintenance/MaintenanceModeHandler.cs
+++ b/src/Spark.Engine/Maintenance/MaintenanceModeHandler.cs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#if NETSTANDARD2_0 || NET6_0_OR_GREATER
+#if NETSTANDARD2_1 || NET6_0_OR_GREATER
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 

--- a/src/Spark.Engine/Spark.Engine.csproj
+++ b/src/Spark.Engine/Spark.Engine.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
+        <TargetFrameworks>netstandard2.1;net472</TargetFrameworks>
         <AssemblyName>Spark.Engine.R4</AssemblyName>
         <LangVersion>latest</LangVersion>
         <PackageId>Spark.Engine.R4</PackageId>
@@ -18,7 +18,7 @@
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
     </ItemGroup>
 
-    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
         <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.2.0" />
     </ItemGroup>
 

--- a/src/Spark.Mongo/Spark.Mongo.csproj
+++ b/src/Spark.Mongo/Spark.Mongo.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFramework>netstandard2.1</TargetFramework>
         <AssemblyName>Spark.Mongo.R4</AssemblyName>
         <LangVersion>latest</LangVersion>
         <PackageId>Spark.Mongo.R4</PackageId>


### PR DESCRIPTION
This drops the netstandard2.1 target and targets netstandard2.1 instead.