### PR TITLE
docker: Copy in the Docker.Build.props when doing a docker build

### DIFF
--- a/.docker/linux/Spark.Dockerfile
+++ b/.docker/linux/Spark.Dockerfile
@@ -4,6 +4,7 @@ ENV ASPNETCORE_URLS=http://+:80
 
 FROM mcr.microsoft.com/dotnet/sdk:8.0-bookworm-slim AS build
 WORKDIR /src
+COPY ["./Directory.build.props", "../Directory.Build.props"]
 COPY ["./src/Spark.Web/Spark.Web.csproj", "Spark.Web/Spark.Web.csproj"]
 COPY ["./src/Spark.Engine/Spark.Engine.csproj", "Spark.Engine/Spark.Engine.csproj"]
 COPY ["./src/Spark.Mongo/Spark.Mongo.csproj", "Spark.Mongo/Spark.Mongo.csproj"]

--- a/src/Spark.Engine/SparkSettings.cs
+++ b/src/Spark.Engine/SparkSettings.cs
@@ -35,7 +35,7 @@ public class SparkSettings
         {
             var asm = Assembly.GetExecutingAssembly();
             FileVersionInfo version = FileVersionInfo.GetVersionInfo(asm.Location);
-            return string.Format("{0}.{1}", version.ProductMajorPart, version.ProductMinorPart);
+            return $"{version.ProductMajorPart}.{version.ProductMinorPart}.{version.ProductBuildPart}";
         }
     }
 }


### PR DESCRIPTION
Now we properly include the version number when building a docker image of our assemblies.