### PR TITLE
docker: Properly case Directory.Build.props

### DIFF
--- a/.docker/linux/Spark.Dockerfile
+++ b/.docker/linux/Spark.Dockerfile
@@ -4,7 +4,7 @@ ENV ASPNETCORE_URLS=http://+:80
 
 FROM mcr.microsoft.com/dotnet/sdk:8.0-bookworm-slim AS build
 WORKDIR /src
-COPY ["./Directory.build.props", "../Directory.Build.props"]
+COPY ["./Directory.Build.props", "../Directory.Build.props"]
 COPY ["./src/Spark.Web/Spark.Web.csproj", "Spark.Web/Spark.Web.csproj"]
 COPY ["./src/Spark.Engine/Spark.Engine.csproj", "Spark.Engine/Spark.Engine.csproj"]
 COPY ["./src/Spark.Mongo/Spark.Mongo.csproj", "Spark.Mongo/Spark.Mongo.csproj"]


### PR DESCRIPTION
This is a follow-up after commit: dd3a21db214ba652da27ddfcee062a2720c5b0bc