### PR TITLE
Revert github: Make dependabot ignore major versions for NuGet packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: daily
-    ignore:
-      - dependency-name: "*"
-        update-types: [ "version-update:semver-major" ]
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
This reverts commit 36dd3c82f52dfa9bda318017675c1de1db952ecb.