### PR TITLE
Engine: Move internal type system under Types namespace

### DIFF
--- a/Documentation/MigrateFromv2Tov3.md
+++ b/Documentation/MigrateFromv2Tov3.md
@@ -31,3 +31,18 @@ We now target `netstandard2.1` and `net472`, allowing Spark to run on .NET 8.0 a
 - `ToHttpResponseMessage(this OperationOutcome, ResourceFormat)` has been removed.
 - `FhirService(IFhirServiceExtension[], IFhirResponseFactory, ITransfer, ICompositeServiceListener)` has been removed, use
   `FhirService(IFhirServiceExtension[], IFhirResponseFactory, ICompositeServiceListener)` instead.
+
+### Namespace changes
+- `Spark.Search.ChoiceValue` moved to `Spark.Engine.Search.ChoiceValue`
+- `Spark.Search.CompositeValue` moved to `Spark.Engine.Search.CompositeValue`
+- `Spark.Search.Criterium` moved to `Spark.Engine.Search.Criterium`
+- `Spark.Search.DateTimeValue` moved to `Spark.Engine.Search.DateTimeValue`
+- `Spark.Search.DateValue` moved to `Spark.Engine.Search.DateValue`
+- `Spark.Search.Expression` moved to `Spark.Engine.Search.Expression`
+- `Spark.Search.NumberValue` moved to `Spark.Engine.Search.NumberValue`
+- `Spark.Search.QuantityValue` moved to `Spark.Engine.Search.QuantityValue`
+- `Spark.Search.ReferenceValue` moved to `Spark.Engine.Search.ReferenceValue`
+- `Spark.Search.StringValue` moved to `Spark.Engine.Search.StringValue`
+- `Spark.Search.TokenValue` moved to `Spark.Engine.Search.TokenValue`
+- `Spark.Search.UntypedValue` moved to `Spark.Engine.Search.UntypedValue`
+- `Spark.Search.ValueExpression` moved to `Spark.Engine.Search.ValueExpression`

--- a/src/Spark.Engine.Test/Search/CriteriumTests.cs
+++ b/src/Spark.Engine.Test/Search/CriteriumTests.cs
@@ -8,8 +8,8 @@
 using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Hl7.Fhir.Model;
+using Spark.Engine.Search.Types;
 using Spark.Search.Support;
-
 
 namespace Spark.Search;
 

--- a/src/Spark.Engine.Test/Search/ElementIndexerTests.cs
+++ b/src/Spark.Engine.Test/Search/ElementIndexerTests.cs
@@ -1,7 +1,7 @@
-﻿/* 
+﻿/*
  * Copyright (c) 2015-2018, Firely <info@fire.ly>
  * Copyright (c) 2018-2025, Incendi <info@incendi.no>
- * 
+ *
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
@@ -9,10 +9,11 @@ using Hl7.Fhir.Model;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Spark.Engine.Core;
 using Spark.Engine.Model;
-using Spark.Search;
+using Spark.Engine.Search.Types;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Expression = Spark.Engine.Search.Types.Expression;
 
 namespace Spark.Engine.Search.Tests;
 
@@ -45,7 +46,7 @@ public class ElementIndexerTests
         Assert.AreEqual(1081.54M, ((NumberValue)result.First()).Value);
     }
 
-    private void CheckPeriod(List<Spark.Search.Expression> result, string start, string end)
+    private void CheckPeriod(List<Expression> result, string start, string end)
     {
         var nrOfComponents = 0;
         if (!string.IsNullOrWhiteSpace(start)) nrOfComponents++;
@@ -359,7 +360,7 @@ public class ElementIndexerTests
         Assert.AreEqual(1, result.Where(r => (r as StringValue).Value == "Pietje").Count());
     }
 
-    public void CheckQuantity(List<Spark.Search.Expression> result, decimal? value, string unit, string system, string decimals)
+    public void CheckQuantity(List<Expression> result, decimal? value, string unit, string system, string decimals)
     {
         var nrOfElements = (value.HasValue ? 1 : 0) + new List<String> { unit, system, decimals }.Where(s => s != null).Count();
 

--- a/src/Spark.Engine.Test/Service/IndexServiceTests.cs
+++ b/src/Spark.Engine.Test/Service/IndexServiceTests.cs
@@ -1,7 +1,7 @@
-﻿/* 
+﻿/*
  * Copyright (c) 2015-2018, Firely <info@fire.ly>
  * Copyright (c) 2018-2025, Incendi <info@incendi.no>
- * 
+ *
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
@@ -12,9 +12,9 @@ using Moq;
 using Spark.Engine.Core;
 using Spark.Engine.Model;
 using Spark.Engine.Search;
+using Spark.Engine.Search.Types;
 using Spark.Engine.Service.FhirServiceExtensions;
 using Spark.Engine.Store.Interfaces;
-using Spark.Search;
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/Spark.Engine/Core/SearchResults.cs
+++ b/src/Spark.Engine/Core/SearchResults.cs
@@ -1,15 +1,14 @@
-﻿/* 
+﻿/*
  * Copyright (c) 2014-2018, Firely <info@fire.ly>
  * Copyright (c) 2021-2025, Incendi <info@incendi.no>
- * 
+ *
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+using Hl7.Fhir.Model;
+using Spark.Engine.Search.Types;
 using System.Collections.Generic;
 using System.Linq;
-
-using Hl7.Fhir.Model;
-using Spark.Search;
 
 namespace Spark.Engine.Core;
 

--- a/src/Spark.Engine/Extensions/QuantityExtensions.cs
+++ b/src/Spark.Engine/Extensions/QuantityExtensions.cs
@@ -1,17 +1,17 @@
-﻿/* 
+﻿/*
  * Copyright (c) 2015-2018, Firely <info@fire.ly>
  * Copyright (c) 2018-2025, Incendi <info@incendi.no>
- * 
+ *
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
 using Fhir.Metrics;
-using FM = Hl7.Fhir.Model;
+using Spark.Engine.Model;
+using Spark.Engine.Search.Types;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Spark.Search;
-using Spark.Engine.Model;
+using FM = Hl7.Fhir.Model;
 
 namespace Spark.Engine.Extensions;
 

--- a/src/Spark.Engine/Model/IndexEntry.cs
+++ b/src/Spark.Engine/Model/IndexEntry.cs
@@ -1,11 +1,11 @@
-﻿/* 
+﻿/*
  * Copyright (c) 2015-2018, Firely <info@fire.ly>
  * Copyright (c) 2021-2025, Incendi <info@incendi.no>
- * 
+ *
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-using Spark.Search;
+using Spark.Engine.Search.Types;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/src/Spark.Engine/Search/ElementIndexer.cs
+++ b/src/Spark.Engine/Search/ElementIndexer.cs
@@ -11,11 +11,11 @@ using Spark.Engine.Core;
 using Spark.Engine.Extensions;
 using Spark.Engine.Logging;
 using Spark.Engine.Model;
-using Spark.Search;
+using Spark.Engine.Search.Types;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Expression = Spark.Search.Expression;
+using Expression = Spark.Engine.Search.Types.Expression;
 
 namespace Spark.Engine.Search;
 
@@ -201,7 +201,7 @@ public class ElementIndexer
         return ListOf(new StringValue(element.Value));
     }
 
-    private List<Expression> ToExpressions(Hl7.Fhir.Model.Date element)
+    private List<Expression> ToExpressions(Date element)
     {
         if (element == null || String.Empty.Equals(element.Value))
             return null;

--- a/src/Spark.Engine/Search/IReferenceNormalizationService.cs
+++ b/src/Spark.Engine/Search/IReferenceNormalizationService.cs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-using Spark.Search;
+using Spark.Engine.Search.Types;
 
 namespace Spark.Engine.Search;
 

--- a/src/Spark.Engine/Search/ReferenceNormalizationService.cs
+++ b/src/Spark.Engine/Search/ReferenceNormalizationService.cs
@@ -7,7 +7,7 @@
 using System;
 using System.Linq;
 using Spark.Engine.Core;
-using Spark.Search;
+using Spark.Engine.Search.Types;
 
 namespace Spark.Engine.Search;
 

--- a/src/Spark.Engine/Search/Types/ChoiceValue.cs
+++ b/src/Spark.Engine/Search/Types/ChoiceValue.cs
@@ -9,7 +9,7 @@ using Spark.Search.Support;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Spark.Search;
+namespace Spark.Engine.Search.Types;
 
 public class ChoiceValue : ValueExpression
 {

--- a/src/Spark.Engine/Search/Types/CompositeValue.cs
+++ b/src/Spark.Engine/Search/Types/CompositeValue.cs
@@ -9,7 +9,7 @@ using Spark.Search.Support;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Spark.Search;
+namespace Spark.Engine.Search.Types;
 
 public class CompositeValue : ValueExpression
 {

--- a/src/Spark.Engine/Search/Types/Criterium.cs
+++ b/src/Spark.Engine/Search/Types/Criterium.cs
@@ -13,7 +13,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Spark.Search;
+namespace Spark.Engine.Search.Types;
 
 /// <summary>
 ///     Types of comparison operator applicable to searching on integer values

--- a/src/Spark.Engine/Search/Types/DateTimeValue.cs
+++ b/src/Spark.Engine/Search/Types/DateTimeValue.cs
@@ -9,7 +9,7 @@ using Hl7.Fhir.Model;
 using Spark.Search.Support;
 using System;
 
-namespace Spark.Search;
+namespace Spark.Engine.Search.Types;
 
 /// <summary>
 ///     DateTimeValue is always specified up to the second.

--- a/src/Spark.Engine/Search/Types/DateValue.cs
+++ b/src/Spark.Engine/Search/Types/DateValue.cs
@@ -9,7 +9,7 @@ using Hl7.Fhir.Model;
 using Spark.Search.Support;
 using System;
 
-namespace Spark.Search;
+namespace Spark.Engine.Search.Types;
 
 public class DateValue : ValueExpression
 {

--- a/src/Spark.Engine/Search/Types/Expression.cs
+++ b/src/Spark.Engine/Search/Types/Expression.cs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-namespace Spark.Search;
+namespace Spark.Engine.Search.Types;
 
 public abstract class Expression
 {

--- a/src/Spark.Engine/Search/Types/NumberValue.cs
+++ b/src/Spark.Engine/Search/Types/NumberValue.cs
@@ -6,7 +6,7 @@
 
 using Hl7.Fhir.Serialization;
 
-namespace Spark.Search;
+namespace Spark.Engine.Search.Types;
 
 public class NumberValue : ValueExpression
 {

--- a/src/Spark.Engine/Search/Types/QuantityValue.cs
+++ b/src/Spark.Engine/Search/Types/QuantityValue.cs
@@ -9,7 +9,7 @@ using Hl7.Fhir.Serialization;
 using Spark.Search.Support;
 using System;
 
-namespace Spark.Search;
+namespace Spark.Engine.Search.Types;
 
 public class QuantityValue : ValueExpression
 {

--- a/src/Spark.Engine/Search/Types/ReferenceValue.cs
+++ b/src/Spark.Engine/Search/Types/ReferenceValue.cs
@@ -8,7 +8,7 @@ using Hl7.Fhir.Model;
 using Spark.Search.Support;
 using System;
 
-namespace Spark.Search;
+namespace Spark.Engine.Search.Types;
 
 public class ReferenceValue : ValueExpression
 {

--- a/src/Spark.Engine/Search/Types/StringValue.cs
+++ b/src/Spark.Engine/Search/Types/StringValue.cs
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-namespace Spark.Search;
+namespace Spark.Engine.Search.Types;
 
 public class StringValue : ValueExpression
 {

--- a/src/Spark.Engine/Search/Types/TokenValue.cs
+++ b/src/Spark.Engine/Search/Types/TokenValue.cs
@@ -7,7 +7,7 @@
 
 using Spark.Search.Support;
 
-namespace Spark.Search;
+namespace Spark.Engine.Search.Types;
 
 public class TokenValue : ValueExpression
 {

--- a/src/Spark.Engine/Search/Types/UntypedValue.cs
+++ b/src/Spark.Engine/Search/Types/UntypedValue.cs
@@ -6,7 +6,7 @@
 
 using Hl7.Fhir.Model;
 
-namespace Spark.Search;
+namespace Spark.Engine.Search.Types;
 
 public class UntypedValue : ValueExpression
 {

--- a/src/Spark.Engine/Search/Types/ValueExpression.cs
+++ b/src/Spark.Engine/Search/Types/ValueExpression.cs
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-namespace Spark.Search;
+namespace Spark.Engine.Search.Types;
 
 public abstract class ValueExpression : Expression
 {

--- a/src/Spark.Engine/Service/FhirServiceExtensions/IndexService.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/IndexService.cs
@@ -9,13 +9,14 @@ using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.FhirPath;
 using Hl7.Fhir.Model;
 using Hl7.FhirPath;
+using Spark.Engine.Auxiliary;
 using Spark.Engine.Core;
 using Spark.Engine.Extensions;
 using Spark.Engine.Model;
 using Spark.Engine.Search;
 using Spark.Engine.Search.Model;
+using Spark.Engine.Search.Types;
 using Spark.Engine.Store.Interfaces;
-using Spark.Search;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -42,7 +43,7 @@ public class IndexService : IIndexService
     {
         if (entry.HasResource())
         {
-            await IndexResourceAsync(entry.Resource, entry.Key).ConfigureAwait(false);
+            await ((Task)IndexResourceAsync(entry.Resource, entry.Key)).ConfigureAwait(false);
         }
         else
         {
@@ -87,7 +88,7 @@ public class IndexService : IIndexService
             // TODO: Do we need to index composite search parameters, some 
             // of them are already indexed by ordinary search parameters so
             // need to make sure that we don't do overlapping indexing.
-            if (searchParameter.Type == Hl7.Fhir.Model.SearchParamType.Composite) continue;
+            if (searchParameter.Type == SearchParamType.Composite) continue;
 
             var indexValue = new IndexValue(searchParameter.Code);
             IEnumerable<Base> resolvedValues;
@@ -148,7 +149,7 @@ public class IndexService : IIndexService
                 }
 
                 // Replace references to these contained resources with the newly created id's.
-                Auxiliary.ResourceVisitor.VisitByType(
+                ResourceVisitor.VisitByType(
                     domainResource,
                     (el, path) => {
                         ResourceReference currentRefence = (el as ResourceReference);

--- a/src/Spark.Mongo.Tests/Indexer/MongoIndexMapperTest.cs
+++ b/src/Spark.Mongo.Tests/Indexer/MongoIndexMapperTest.cs
@@ -5,9 +5,9 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-using Spark.Search;
-using Spark.Mongo.Search.Indexer;
 using Spark.Engine.Model;
+using Spark.Engine.Search.Types;
+using Spark.Mongo.Search.Indexer;
 using Xunit;
 
 namespace Spark.Mongo.Tests.Indexer;

--- a/src/Spark.Mongo.Tests/Search/CriteriumQueryBuilderTests.cs
+++ b/src/Spark.Mongo.Tests/Search/CriteriumQueryBuilderTests.cs
@@ -9,7 +9,7 @@ using Hl7.Fhir.Utility;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 using MongoDB.Driver;
-using Spark.Search;
+using Spark.Engine.Search.Types;
 using Spark.Search.Mongo;
 using System.Linq;
 using Xunit;

--- a/src/Spark.Mongo/Search/Indexer/MongoIndexMapper.cs
+++ b/src/Spark.Mongo/Search/Indexer/MongoIndexMapper.cs
@@ -1,13 +1,13 @@
-﻿/* 
+﻿/*
  * Copyright (c) 2015-2018, Firely <info@fire.ly>
- * 
+ *
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
 using MongoDB.Bson;
 using Spark.Engine.Model;
+using Spark.Engine.Search.Types;
 using Spark.Mongo.Search.Common;
-using Spark.Search;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Spark.Mongo/Search/Searcher/CriteriaMongoExtensions.cs
+++ b/src/Spark.Mongo/Search/Searcher/CriteriaMongoExtensions.cs
@@ -16,6 +16,8 @@ using System.Reflection;
 using Spark.Mongo.Search.Common;
 using Spark.Engine.Extensions;
 using Hl7.Fhir.Utility;
+using Spark.Engine.Search.Types;
+using Expression = Spark.Engine.Search.Types.Expression;
 
 namespace Spark.Search.Mongo;
 

--- a/src/Spark.Mongo/Search/Searcher/MongoSearcher.cs
+++ b/src/Spark.Mongo/Search/Searcher/MongoSearcher.cs
@@ -1,22 +1,23 @@
-﻿/* 
+﻿/*
  * Copyright (c) 2014-2018, Firely <info@fire.ly>
  * Copyright (c) 2019-2025, Incendi <info@incendi.no>
- * 
+ *
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Rest;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using Spark.Engine.Core;
+using Spark.Engine.Extensions;
+using Spark.Engine.Search;
+using Spark.Engine.Search.Types;
+using Spark.Mongo.Search.Common;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using MongoDB.Bson;
-using MongoDB.Driver;
-using Hl7.Fhir.Model;
-using Hl7.Fhir.Rest;
-using Spark.Engine.Core;
-using Spark.Mongo.Search.Common;
-using Spark.Engine.Extensions;
-using Spark.Engine.Search;
 using SM = Spark.Engine.Search.Model;
 
 namespace Spark.Search.Mongo;

--- a/src/Spark.Mongo/Search/Utils/UnitsOfMeasureHelper.cs
+++ b/src/Spark.Mongo/Search/Utils/UnitsOfMeasureHelper.cs
@@ -1,13 +1,14 @@
-﻿/* 
+﻿/*
  * Copyright (c) 2014-2018, Firely <info@fire.ly>
- * 
+ *
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
 using Fhir.Metrics;
 using MongoDB.Bson;
-using FM = Hl7.Fhir.Model;
 using Spark.Engine.Extensions;
+using Spark.Engine.Search.Types;
+using FM = Hl7.Fhir.Model;
 
 namespace Spark.Search.Mongo;
 


### PR DESCRIPTION
Moved the internal type system classes from Spark.Search to Spark.Engine.Search.Types.