### PR TITLE
Engine: Content-Type may contain additional parameters

### DIFF
--- a/src/Spark.Engine/Extensions/HttpHeadersExtensions.cs
+++ b/src/Spark.Engine/Extensions/HttpHeadersExtensions.cs
@@ -23,8 +23,9 @@ public static class HttpRequestExtensions
     public static bool IsContentTypeHeaderFhirMediaType(string contentType)
     {
         if (string.IsNullOrEmpty(contentType)) return false;
-        return ContentType.XML_CONTENT_HEADERS.Contains(contentType)
-               || ContentType.JSON_CONTENT_HEADERS.Contains(contentType);
+        var mediaType = contentType.Split(';')[0];
+        return ContentType.XML_CONTENT_HEADERS.Contains(mediaType, StringComparer.OrdinalIgnoreCase)
+               || ContentType.JSON_CONTENT_HEADERS.Contains(mediaType, StringComparer.OrdinalIgnoreCase);
     }
 
     public static string GetParameter(this HttpRequest request, string key)


### PR DESCRIPTION
When comparing the media type split by ';' so we do not accidentally include additional parameters like charset or boundary or some other bogus data after the ';'.