### PR TITLE
Engine: Do not crash when more than one contained resource lack an Id

### DIFF
--- a/src/Spark.Engine.Test/Service/IndexServiceTests2.cs
+++ b/src/Spark.Engine.Test/Service/IndexServiceTests2.cs
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2025, Incendi <info@incendi.no>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+using Hl7.Fhir.Model;
+using Moq;
+using Spark.Engine.Core;
+using Spark.Engine.Search;
+using Spark.Engine.Service.FhirServiceExtensions;
+using Spark.Engine.Store.Interfaces;
+using Xunit;
+using Task = System.Threading.Tasks.Task;
+
+namespace Spark.Engine.Test.Service;
+
+// FIXME: Migrate the old tests in IndexServiceTests to XUnit and Consolidate those tests with these tests.
+public class IndexServiceTests2
+{
+    [Fact]
+    public async Task IndexResourceWithContainedResourcesLackingAnIdShouldNotCrash()
+    {
+        FhirModel fhirModel = new();
+        Mock<IIndexStore> indexStoreMock = new();
+        ElementIndexer elementIndexer = new(fhirModel);
+        ResourceResolver resourceResolver = new();
+        IndexService indexService = new(fhirModel, indexStoreMock.Object, elementIndexer, resourceResolver);
+
+        Organization organization = new()
+        {
+            Name = "An Organization", Identifier = { new Identifier("http://a-fake-system", "a value") }
+        };
+
+        organization.Contained.Add(new Endpoint
+        {
+            Identifier = { new Identifier { System = "http://not-a-real-system", Value = "endpoint-1-identifier" } }
+        });
+        organization.Contained.Add(new Endpoint
+        {
+            Identifier = { new Identifier { System = "http://not-a-real-system", Value = "endpoint-2-identifier" } }
+        });
+
+        Key key = Key.Create(organization.TypeName, organization.Id);
+        await indexService.IndexResourceAsync(organization, key);
+    }
+}

--- a/src/Spark.Engine/Service/FhirServiceExtensions/IndexService.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/IndexService.cs
@@ -141,10 +141,12 @@ public class IndexService : IIndexService
                 // Create a unique id for each contained resource.
                 foreach (var containedResource in domainResource.Contained)
                 {
-                    string oldRef = "#" + containedResource.Id;
-                    string newId = Guid.NewGuid().ToString();
+                    string oldRef = string.IsNullOrWhiteSpace(containedResource.Id)
+                        ? $"#{Guid.NewGuid():D}"
+                        : $"#{containedResource.Id}";
+                    string newId = $"{Guid.NewGuid():D}";
                     containedResource.Id = newId;
-                    string newRef = containedResource.TypeName + "/" + newId;
+                    string newRef = $"{containedResource.TypeName}/{newId}";
                     referenceMap.Add(oldRef, newRef);
                 }
 

--- a/src/Spark.Engine/Service/FhirServiceExtensions/IndexService.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/IndexService.cs
@@ -153,14 +153,14 @@ public class IndexService : IIndexService
                 // Replace references to these contained resources with the newly created id's.
                 ResourceVisitor.VisitByType(
                     domainResource,
-                    (el, path) => {
-                        ResourceReference currentRefence = (el as ResourceReference);
-                        if (!string.IsNullOrEmpty(currentRefence.Reference))
-                        {
-                            referenceMap.TryGetValue(currentRefence.Reference, out string replacementId);
-                            if (replacementId != null)
-                                currentRefence.Reference = replacementId;
-                        }
+                    (element, _) => {
+                        ResourceReference currentRefence = (element as ResourceReference);
+                        if (string.IsNullOrEmpty(currentRefence?.Reference))
+                            return;
+
+                        referenceMap.TryGetValue(currentRefence.Reference, out string replacementId);
+                        if (replacementId != null)
+                            currentRefence.Reference = replacementId;
                     },
                     typeof(ResourceReference));
             }


### PR DESCRIPTION
If more than one contained resource lacks an Id we will try to twice insert a value of "#" in `IndexService`'s internal reference map.

Also, in a separate commit, adds a null check for `currentReference` in `IndexService`.

Closes #510 