### PR TITLE
Engine+Tests+Web: Enable support for non-FHIR APIs 

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -27,3 +27,4 @@ jobs:
         run: |
           dotnet test "./src/Spark.Engine.Test/Spark.Engine.Test.csproj"
           dotnet test "./src/Spark.Mongo.Tests/Spark.Mongo.Tests.csproj"
+          dotnet test "./src/Spark.Web.Tests/Spark.Web.Tests.csproj"

--- a/Spark.sln
+++ b/Spark.sln
@@ -82,6 +82,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "scripts", "scripts", "{977F
 		scripts\RemoveDuplicateId.js = scripts\RemoveDuplicateId.js
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Spark.Web.Tests", "src\Spark.Web.Tests\Spark.Web.Tests.csproj", "{DFC6C41A-7545-4256-8A2C-CBD6EC43541E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -108,6 +110,10 @@ Global
 		{6A59CE4B-D912-4995-A805-89705B8134E0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6A59CE4B-D912-4995-A805-89705B8134E0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6A59CE4B-D912-4995-A805-89705B8134E0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DFC6C41A-7545-4256-8A2C-CBD6EC43541E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DFC6C41A-7545-4256-8A2C-CBD6EC43541E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DFC6C41A-7545-4256-8A2C-CBD6EC43541E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DFC6C41A-7545-4256-8A2C-CBD6EC43541E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Spark.Engine.Test/Search/ReverseIncludeTests.cs
+++ b/src/Spark.Engine.Test/Search/ReverseIncludeTests.cs
@@ -1,13 +1,13 @@
-﻿/* 
+﻿/*
  * Copyright (c) 2016-2018, Firely <info@fire.ly>
- * Copyright (c) 2021-2024, Incendi <info@incendi.no>
- * 
+ * Copyright (c) 2021-2025, Incendi <info@incendi.no>
+ *
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Spark.Engine.Search.Model;
+using System;
 
 namespace Spark.Engine.Test.Search;
 

--- a/src/Spark.Engine/Core/FhirMediaType.cs
+++ b/src/Spark.Engine/Core/FhirMediaType.cs
@@ -23,12 +23,13 @@ public static class FhirMediaType
     public static string OctetStreamMimeType = "application/octet-stream";
     public static string FormUrlEncodedMimeType = "application/x-www-form-urlencoded";
     public static string AnyMimeType = "*/*";
+    public static string MultipartFormDataMimeType = "multipart/form-data";
 
     public static IEnumerable<string> JsonMimeTypes => ContentType.JSON_CONTENT_HEADERS;
     public static IEnumerable<string> XmlMimeTypes => ContentType.XML_CONTENT_HEADERS;
     public static IEnumerable<string> SupportedMimeTypes => JsonMimeTypes
         .Concat(XmlMimeTypes)
-        .Concat(new[] { OctetStreamMimeType, FormUrlEncodedMimeType, AnyMimeType });
+        .Concat(new[] { OctetStreamMimeType, FormUrlEncodedMimeType, AnyMimeType, MultipartFormDataMimeType });
 
     /// <summary>
     /// Transforms loose formats to their strict variant

--- a/src/Spark.Engine/Extensions/NetCore/IServiceCollectionExtensions.cs
+++ b/src/Spark.Engine/Extensions/NetCore/IServiceCollectionExtensions.cs
@@ -209,21 +209,21 @@ namespace Spark.Engine.Extensions
 
                 if (settings.UseAsynchronousIO)
                 {
-                    options.InputFormatters.Add(new AsyncResourceJsonInputFormatter(new FhirJsonParser(settings.ParserSettings)));
-                    options.InputFormatters.Add(new AsyncResourceXmlInputFormatter(new FhirXmlParser(settings.ParserSettings)));
-                    options.InputFormatters.Add(new BinaryInputFormatter());
-                    options.OutputFormatters.Add(new AsyncResourceJsonOutputFormatter());
-                    options.OutputFormatters.Add(new AsyncResourceXmlOutputFormatter());
-                    options.OutputFormatters.Add(new BinaryOutputFormatter());
+                    options.InputFormatters.Insert(0,new AsyncResourceJsonInputFormatter(new FhirJsonParser(settings.ParserSettings)));
+                    options.InputFormatters.Insert(1,new AsyncResourceXmlInputFormatter(new FhirXmlParser(settings.ParserSettings)));
+                    options.InputFormatters.Insert(2,new BinaryInputFormatter());
+                    options.OutputFormatters.Insert(0,new AsyncResourceJsonOutputFormatter());
+                    options.OutputFormatters.Insert(1,new AsyncResourceXmlOutputFormatter());
+                    options.OutputFormatters.Insert(2,new BinaryOutputFormatter());
                 }
                 else
                 {
-                    options.InputFormatters.Add(new ResourceJsonInputFormatter(new FhirJsonParser(settings.ParserSettings), ArrayPool<char>.Shared));
-                    options.InputFormatters.Add(new ResourceXmlInputFormatter(new FhirXmlParser(settings.ParserSettings)));
-                    options.InputFormatters.Add(new BinaryInputFormatter());
-                    options.OutputFormatters.Add(new ResourceJsonOutputFormatter());
-                    options.OutputFormatters.Add(new ResourceXmlOutputFormatter());
-                    options.OutputFormatters.Add(new BinaryOutputFormatter());
+                    options.InputFormatters.Insert(0,new ResourceJsonInputFormatter(new FhirJsonParser(settings.ParserSettings), ArrayPool<char>.Shared));
+                    options.InputFormatters.Insert(1,new ResourceXmlInputFormatter(new FhirXmlParser(settings.ParserSettings)));
+                    options.InputFormatters.Insert(2,new BinaryInputFormatter());
+                    options.OutputFormatters.Insert(0,new ResourceJsonOutputFormatter());
+                    options.OutputFormatters.Insert(1,new ResourceXmlOutputFormatter());
+                    options.OutputFormatters.Insert(2,new BinaryOutputFormatter());
                 }
 
                 options.RespectBrowserAcceptHeader = true;

--- a/src/Spark.Engine/Filters/UnsupportedMediaTypeFilter.cs
+++ b/src/Spark.Engine/Filters/UnsupportedMediaTypeFilter.cs
@@ -39,7 +39,7 @@ namespace Spark.Engine.Filters
 
             if (context.HttpContext.Request.ContentType != null)
             {
-                if (!FhirMediaType.SupportedMimeTypes.Any(mimeType => context.HttpContext.Request.ContentType.Contains(mimeType)))
+                if (!FhirMediaType.SupportedMimeTypes.Any(mimeType => context.HttpContext.Request.ContentType.StartsWith(mimeType)))
                 {
                     throw Error.UnsupportedMediaType();
                 }

--- a/src/Spark.Engine/Search/Model/ReverseInclude.cs
+++ b/src/Spark.Engine/Search/Model/ReverseInclude.cs
@@ -1,7 +1,7 @@
-﻿/* 
+﻿/*
  * Copyright (c) 2016-2018, Firely <info@fire.ly>
- * Copyright (c) 2021-2024, Incendi <info@incendi.no>
- * 
+ * Copyright (c) 2021-2025, Incendi <info@incendi.no>
+ *
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/Spark.Engine/Service/FhirServiceExtensions/SnapshotPaginationProvider.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/SnapshotPaginationProvider.cs
@@ -1,7 +1,7 @@
-/* 
+/*
  * Copyright (c) 2016-2018, Firely <info@fire.ly>
- * Copyright (c) 2018-2024, Incendi <info@incendi.no>
- * 
+ * Copyright (c) 2018-2025, Incendi <info@incendi.no>
+ *
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/src/Spark.Web.Tests/Controllers/TestController.cs
+++ b/src/Spark.Web.Tests/Controllers/TestController.cs
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2025, Incendi <info@incendi.no>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+using Hl7.Fhir.Model;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Spark.Web.Tests.Models;
+using System;
+using System.IO;
+using System.Text;
+
+namespace Spark.Web.Tests.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class TestController : ControllerBase
+{
+    [Route("test-json")]
+    public IActionResult TestJson(TestJsonDto dto) => Ok(dto.Name);
+
+    [Route("test-file")]
+    public IActionResult TestFile(IFormFile file)
+    {
+        Stream requestStream = file.OpenReadStream();
+        Span<byte> buffer = new(new byte[requestStream.Length]);
+        requestStream.ReadExactly(buffer);
+        string contentAsString = Encoding.UTF8.GetString(buffer);
+        return Ok($"Name: {file.FileName}, Content: {contentAsString}");
+    }
+
+    [Route("test-json-file")]
+    public IActionResult TestJsonFile(TestFileDto dto) => Ok(dto.Other);
+
+    [Route("test-resource")]
+    public IActionResult TestResource(Resource resource) => Ok(resource.Id);
+}

--- a/src/Spark.Web.Tests/Models/TestFileDto.cs
+++ b/src/Spark.Web.Tests/Models/TestFileDto.cs
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2025, Incendi <info@incendi.no>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+using Microsoft.AspNetCore.Http;
+
+namespace Spark.Web.Tests.Models;
+
+public class TestFileDto
+{
+    public required IFormFile File { get; init; }
+    public required string Other { get; init; }
+}

--- a/src/Spark.Web.Tests/Models/TestJsonDto.cs
+++ b/src/Spark.Web.Tests/Models/TestJsonDto.cs
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2025, Incendi <info@incendi.no>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+namespace Spark.Web.Tests.Models;
+
+public class TestJsonDto
+{
+    public required string Name { get; init; }
+}

--- a/src/Spark.Web.Tests/MultiFormatterSupportTest.cs
+++ b/src/Spark.Web.Tests/MultiFormatterSupportTest.cs
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2025, Incendi <info@incendi.no>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+using Hl7.Fhir.Serialization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Spark.Engine;
+using Spark.Engine.Extensions;
+using System;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Spark.Web.Tests;
+
+public class MultiFormatterSupportTest : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public MultiFormatterSupportTest(WebApplicationFactory<Program> factory)
+    {
+        _factory = factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                SparkSettings settings = new()
+                {
+                    Endpoint = new Uri("http://localhost"),
+                    ParserSettings = new ParserSettings { PermissiveParsing = false },
+                    UseAsynchronousIO = true
+                };
+                services.AddFhir(settings);
+                services.AddMvc(options =>
+                {
+                    options.EnableEndpointRouting = false;
+                });
+            });
+
+            builder.Configure(app =>
+            {
+                app.UseRouting();
+                app.UseFhir();
+            });
+        });
+    }
+
+    [Fact]
+    public async Task Post_SampleJson()
+    {
+        HttpClient client = _factory.CreateClient();
+        StringContent content = new("{\"name\":\"test\"}", Encoding.UTF8, "application/json");
+        HttpResponseMessage response = await client.PostAsync("api/test/test-json", content);
+        response.EnsureSuccessStatusCode();
+        string responseString = await response.Content.ReadAsStringAsync();
+        Assert.Equal("test", responseString);
+    }
+
+    [Fact]
+    public async Task Post_SampleFile()
+    {
+        HttpClient client = _factory.CreateClient();
+        MultipartFormDataContent content = new();
+        ByteArrayContent fileContent = new("empty file."u8.ToArray());
+        content.Add(fileContent, "file", "test.txt");
+        HttpResponseMessage response = await client.PostAsync("api/test/test-file", content);
+        response.EnsureSuccessStatusCode();
+        string responseString = await response.Content.ReadAsStringAsync();
+        Assert.Contains("Name: test.txt, Content: empty file.", responseString);
+    }
+
+    [Fact]
+    public async Task Post_JsonFile()
+    {
+        HttpClient client = _factory.CreateClient();
+        MultipartFormDataContent content = new();
+        ByteArrayContent fileContent = new("empty file."u8.ToArray());
+        content.Add(fileContent, "file", "test.txt");
+        content.Add(new StringContent("Test Property"), "other");
+
+        HttpResponseMessage response = await client.PostAsync("api/test/test-json-file", content);
+        response.EnsureSuccessStatusCode();
+        string responseString = await response.Content.ReadAsStringAsync();
+        Assert.Contains("Test Property", responseString);
+    }
+
+    [Fact]
+    public async Task Post_FhirJson()
+    {
+        HttpClient client = _factory.CreateClient();
+        StringContent content = new("{\"resourceType\":\"Basic\",\"id\":\"1\"}", Encoding.UTF8, "application/json");
+        HttpResponseMessage response = await client.PostAsync("api/test/test-resource", content);
+        response.EnsureSuccessStatusCode();
+        string responseString = await response.Content.ReadAsStringAsync();
+        Assert.Equal("1", responseString);
+    }
+
+
+    [Fact]
+    public async Task Post_FhirXml()
+    {
+        HttpClient client = _factory.CreateClient();
+        StringContent content = new("<Basic xmlns=\"http://hl7.org/fhir\"><id value=\"1\"/></Basic>", Encoding.UTF8,
+            "application/xml");
+        HttpResponseMessage response = await client.PostAsync("api/test/test-resource", content);
+        response.EnsureSuccessStatusCode();
+        string responseString = await response.Content.ReadAsStringAsync();
+        Assert.Equal("1", responseString);
+    }
+}

--- a/src/Spark.Web.Tests/Spark.Web.Tests.csproj
+++ b/src/Spark.Web.Tests/Spark.Web.Tests.csproj
@@ -1,0 +1,30 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.18" />
+        <PackageReference Include="coverlet.collector" Version="6.0.4">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.3">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit"/>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Spark.Web\Spark.Web.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Spark.Web/Startup.cs
+++ b/src/Spark.Web/Startup.cs
@@ -112,11 +112,6 @@ public class Startup
         // AddMvc needs to be called since we are using a Home page that is reliant on the full MVC framework
         services.AddMvc(options =>
         {
-            options.InputFormatters.RemoveType<SystemTextJsonInputFormatter>();
-            options.OutputFormatters.RemoveType<SystemTextJsonOutputFormatter>();
-            // We remove StringOutputFormatter to make Swagger happy by not 
-            // showing text/plain in the list of available media types.
-            options.OutputFormatters.RemoveType<StringOutputFormatter>();
             options.EnableEndpointRouting = false;
         });
 


### PR DESCRIPTION
This is a backport of #945 to the `v2-r4/master` branch.

> This enables supports for adding endpoints/controllers for non-FHIR APIs.
> 
> Resolves #819 and #523