### PR TITLE
Engine: Optimize by serializing directly to bytes

### DIFF
--- a/src/Spark.Engine/Formatters/AsyncResourceJsonOutputFormatter.cs
+++ b/src/Spark.Engine/Formatters/AsyncResourceJsonOutputFormatter.cs
@@ -47,7 +47,7 @@ namespace Spark.Engine.Formatters
                 throw Error.Internal($"Missing required dependency '{nameof(FhirJsonSerializer)}'");
 
             var responseBody = context.HttpContext.Response.Body;
-            var writeBodyString = string.Empty;
+            byte[] writeBuffer = [];
             var summaryType = context.HttpContext.Request.RequestSummary();
 
             if (typeof(FhirResponse).IsAssignableFrom(context.ObjectType))
@@ -59,29 +59,25 @@ namespace Spark.Engine.Formatters
 
                 if (response.Resource != null)
                 {
-                    writeBodyString = serializer.SerializeToString(response.Resource, summaryType);
+                    writeBuffer = await serializer.SerializeToBytesAsync(response.Resource, summaryType);
                 }
             }
             else if (context.ObjectType == typeof(FhirModel.OperationOutcome) || typeof(FhirModel.Resource).IsAssignableFrom(context.ObjectType))
             {
-                if (context.Object != null)
+                if (context.Object is FhirModel.Resource resource)
                 {
-                    writeBodyString = serializer.SerializeToString(context.Object as FhirModel.Resource, summaryType);
+                    writeBuffer = await serializer.SerializeToBytesAsync(resource, summaryType);
                 }
             }
             else if (context.Object is ValidationProblemDetails validationProblems)
             {
                 FhirModel.OperationOutcome outcome = new FhirModel.OperationOutcome();
                 outcome.AddValidationProblems(context.HttpContext.GetResourceType(), (HttpStatusCode)context.HttpContext.Response.StatusCode, validationProblems);
-                writeBodyString = serializer.SerializeToString(outcome, summaryType);
+                writeBuffer = await serializer.SerializeToBytesAsync(outcome, summaryType);
             }
 
-            if (!string.IsNullOrWhiteSpace(writeBodyString))
-            {
-                var writeBuffer = selectedEncoding.GetBytes(writeBodyString);
-                await responseBody.WriteAsync(writeBuffer, 0, writeBuffer.Length);
-                await responseBody.FlushAsync();
-            }
+            await responseBody.WriteAsync(writeBuffer);
+            await responseBody.FlushAsync();
         }
     }
 }

--- a/src/Spark.Engine/Formatters/AsyncResourceXmlOutputFormatter.cs
+++ b/src/Spark.Engine/Formatters/AsyncResourceXmlOutputFormatter.cs
@@ -48,7 +48,7 @@ public class AsyncResourceXmlOutputFormatter : TextOutputFormatter
             throw Error.Internal($"Missing required dependency '{nameof(FhirXmlSerializer)}'");
 
         var responseBody = context.HttpContext.Response.Body;
-        var writeBodyString = string.Empty;
+        byte[] writeBuffer = [];
         var summaryType = context.HttpContext.Request.RequestSummary();
 
         if (typeof(FhirResponse).IsAssignableFrom(context.ObjectType))
@@ -60,28 +60,24 @@ public class AsyncResourceXmlOutputFormatter : TextOutputFormatter
 
             if (response.Resource != null)
             {
-                writeBodyString = serializer.SerializeToString(response.Resource, summaryType);
+                writeBuffer = await serializer.SerializeToBytesAsync(response.Resource, summaryType);
             }
         }
         else if (context.ObjectType == typeof(FhirModel.OperationOutcome) || typeof(FhirModel.Resource).IsAssignableFrom(context.ObjectType))
         {
             if (context.Object != null)
             {
-                writeBodyString = serializer.SerializeToString(context.Object as FhirModel.Resource, summaryType);
+                writeBuffer = await serializer.SerializeToBytesAsync(context.Object as FhirModel.Resource, summaryType);
             }
         }
         else if (context.Object is ValidationProblemDetails validationProblems)
         {
             FhirModel.OperationOutcome outcome = new FhirModel.OperationOutcome();
             outcome.AddValidationProblems(context.HttpContext.GetResourceType(), (HttpStatusCode)context.HttpContext.Response.StatusCode, validationProblems);
-            writeBodyString = serializer.SerializeToString(outcome, summaryType);
+            writeBuffer = await serializer.SerializeToBytesAsync(outcome, summaryType);
         }
 
-        if (!string.IsNullOrWhiteSpace(writeBodyString))
-        {
-            var writeBuffer = selectedEncoding.GetBytes(writeBodyString);
-            await responseBody.WriteAsync(writeBuffer, 0, writeBuffer.Length);
-            await responseBody.FlushAsync();
-        }
+        await responseBody.WriteAsync(writeBuffer);
+        await responseBody.FlushAsync();
     }
 }

--- a/src/Spark.Engine/Formatters/BinaryOutputFormatter.cs
+++ b/src/Spark.Engine/Formatters/BinaryOutputFormatter.cs
@@ -10,7 +10,6 @@ using Microsoft.AspNetCore.Mvc.Formatters;
 using Spark.Engine.Core;
 using Spark.Engine.Extensions;
 using System;
-using System.IO;
 using System.Threading.Tasks;
 
 namespace Spark.Engine.Formatters;
@@ -46,8 +45,10 @@ public class BinaryOutputFormatter : OutputFormatter
             context.HttpContext.Response.Headers.Append(HttpHeaderName.CONTENT_DISPOSITION, "attachment");
             context.HttpContext.Response.ContentType = binary.ContentType;
 
-            Stream stream = new MemoryStream(binary.Data);
-            await stream.CopyToAsync(context.HttpContext.Response.Body);
+            var responseBody = context.HttpContext.Response.Body;
+            byte[] writeBuffer = binary.Data;
+            await responseBody.WriteAsync(writeBuffer);
+            await responseBody.FlushAsync();
         }
     }
 }


### PR DESCRIPTION
Avoid serializing to string before converting that string to bytes. Also prefer the 'Memory'-based overload of 'WriteAsync()'.