### PR TITLE
Engine: Use our own SearchParameter instead of the one from firely sdk

### DIFF
--- a/src/Spark.Engine.Test/Extensions/SearchParameterExtensionsTests.cs
+++ b/src/Spark.Engine.Test/Extensions/SearchParameterExtensionsTests.cs
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-using Hl7.Fhir.Model;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Spark.Engine.Core;
 using Spark.Engine.Extensions;
 using System.Collections.Generic;
 using System.Linq;
@@ -20,7 +20,7 @@ public class SearchParameterExtensionsTests
     {
         SearchParameter sut = new SearchParameter
         {
-            Base = new List<ResourceType?> { ResourceType.Appointment }
+            Base = [VersionIndependentResourceTypesAll.Appointment]
         };
 
         sut.SetPropertyPath(["Appointment.participant.actor"]);
@@ -33,7 +33,7 @@ public class SearchParameterExtensionsTests
     {
         SearchParameter sut = new SearchParameter
         {
-            Base = new List<ResourceType?> { ResourceType.AuditEvent }
+            Base = [VersionIndependentResourceTypesAll.AuditEvent]
         };
         sut.SetPropertyPath(["AuditEvent.participant.reference", "AuditEvent.object.reference"]);
 
@@ -72,7 +72,7 @@ public class SearchParameterExtensionsTests
     {
         SearchParameter sut = new SearchParameter
         {
-            Base = new List<ResourceType?> { ResourceType.Slot }
+            Base = [VersionIndependentResourceTypesAll.Slot]
         };
         sut.SetPropertyPath(["Slot.extension(url=http://foo.com/myextension).valueReference"]);
 

--- a/src/Spark.Engine/Core/FhirModel.cs
+++ b/src/Spark.Engine/Core/FhirModel.cs
@@ -40,7 +40,7 @@ public class FhirModel : IFhirModel
 
     private void LoadSearchParameters(IEnumerable<SearchParamDefinition> searchParameters)
     {
-        _searchParameters = searchParameters.Select(sp => createSearchParameterFromSearchParamDefinition(sp)).ToList();
+        _searchParameters = searchParameters.Select(createSearchParameterFromSearchParamDefinition).ToList();
         LoadGenericSearchParameters();
     }
 
@@ -98,12 +98,14 @@ public class FhirModel : IFhirModel
 
     private SearchParameter createSearchParameterFromSearchParamDefinition(SearchParamDefinition def)
     {
-        var result = new ComparableSearchParameter();
+        var result = new SearchParameter();
         result.Name = def.Name;
         result.Code = def.Name; //CK: SearchParamDefinition has no Code, but in all current SearchParameter resources, name and code are equal.
-        result.Base = new List<ResourceType?> { GetResourceTypeForResourceName(def.Resource) };
+        result.Base = [GetResourceTypeForResourceName(def.Resource)];
         result.Type = def.Type;
-        result.Target = def.Target != null ? def.Target.ToList().Cast<ResourceType?>() : new List<ResourceType?>();
+        result.Target = def.Target == null || def.Target.Length == 0
+            ? []
+            :  GetResourceTypesForResourceNames(def.Target).ToArray();
         result.Description = def.Description;
         // NOTE: This is a fix to handle an issue in firely-net-sdk
         // where the expression 'ConceptMap.source as uri' returns
@@ -135,41 +137,9 @@ public class FhirModel : IFhirModel
 
         //Watch out: SearchParameter is not very good yet with Composite parameters.
         //Therefore we include a reference to the original SearchParamDefinition :-)
-        result.SetOriginalDefinition(def);
+        result.OriginalDefinition = def;
 
         return result;
-    }
-
-    private class ComparableSearchParameter : SearchParameter, IEquatable<ComparableSearchParameter>
-    {
-        public bool Equals(ComparableSearchParameter other)
-        {
-            return string.Equals(Name, other.Name) &&
-                   string.Equals(Code, other.Code) &&
-                   Equals(Base, other.Base) &&
-                   Equals(Type, other.Type) &&
-                   string.Equals(Description, other.Description) &&
-                   string.Equals(Xpath, other.Xpath);
-        }
-
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(null, obj)) return false;
-            if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != this.GetType()) return false;
-            return Equals((ComparableSearchParameter)obj);
-        }
-
-        public override int GetHashCode()
-        {
-            var hashCode = (Name != null ? Name.GetHashCode() : 0);
-            hashCode = (hashCode * 397) ^ (Code != null ? Code.GetHashCode() : 0);
-            hashCode = (hashCode * 397) ^ (Base != null ? Base.GetHashCode() : 0);
-            hashCode = (hashCode * 397) ^ (Type != null ? Type.GetHashCode() : 0);
-            hashCode = (hashCode * 397) ^ (Description != null ? Description.GetHashCode() : 0);
-            hashCode = (hashCode * 397) ^ (Xpath != null ? Xpath.GetHashCode() : 0);
-            return hashCode;
-        }
     }
 
     public List<SearchParameter> SearchParameters
@@ -195,9 +165,14 @@ public class FhirModel : IFhirModel
         return GetTypeForFhirType(name);
     }
 
-    private static ResourceType GetResourceTypeForResourceName(string name)
+    private static VersionIndependentResourceTypesAll GetResourceTypeForResourceName(string name)
     {
-        return (ResourceType)Enum.Parse(typeof(ResourceType), name, true);
+        return Enum.Parse<VersionIndependentResourceTypesAll>(name, true);
+    }
+
+    private static IEnumerable<VersionIndependentResourceTypesAll> GetResourceTypesForResourceNames(ResourceType[] names)
+    {
+        return names?.Select(name => GetResourceTypeForResourceName(name.GetLiteral()));
     }
 
     public IEnumerable<SearchParameter> FindSearchParameters(Type resourceType)
@@ -207,7 +182,7 @@ public class FhirModel : IFhirModel
 
     public IEnumerable<SearchParameter> FindSearchParameters(string resourceName)
     {
-        return SearchParameters.Where(sp => sp.Base.Contains(GetResourceTypeForResourceName(resourceName)) || sp.Base.Any(b => b == ResourceType.Resource));
+        return SearchParameters.Where(sp => sp.Base.Contains(GetResourceTypeForResourceName(resourceName)) || sp.Base.Any(b => b == VersionIndependentResourceTypesAll.Resource));
     }
 
     public SearchParameter FindSearchParameter(Type resourceType, string parameterName)
@@ -228,18 +203,16 @@ public class FhirModel : IFhirModel
         // FIXME: This might be better resolved through a CompartmentDefinition.
         var searchParameters = SearchParameters.Where(searchParameter =>
             searchParameter.Type == SearchParamType.Reference
-            && searchParameter.Target.Contains(ResourceType.Patient)
+            && searchParameter.Target.Contains(VersionIndependentResourceTypesAll.Patient)
             && !searchParameter.Base.Any(IsDefinitionResourceType)
             && searchParameter.Name != "subject");
         var reverseIncludes = new List<string>();
         foreach (SearchParameter searchParameter in searchParameters)
         {
-            foreach (ResourceType? resourceType in searchParameter.Base)
+            foreach (VersionIndependentResourceTypesAll? resourceType in searchParameter.Base)
             {
-                if (!resourceType.HasValue)
-                    continue;
-
-                reverseIncludes.Add($"{resourceType.GetLiteral()}:{searchParameter.Name}");
+                if (resourceType.HasValue)
+                    reverseIncludes.Add($"{resourceType.GetLiteral()}:{searchParameter.Name}");
             }
         }
 
@@ -248,29 +221,29 @@ public class FhirModel : IFhirModel
         _compartments.Add(patientCompartmentInfo);
     }
 
-    private bool IsDefinitionResourceType(ResourceType? resourceType)
+    private bool IsDefinitionResourceType(VersionIndependentResourceTypesAll resourceType)
     {
-        return resourceType.HasValue && DefinitionResourceTypes().Contains(resourceType.Value);
+        return DefinitionResourceTypes().Contains(resourceType);
     }
 
-    private static IEnumerable<ResourceType> DefinitionResourceTypes()
+    private static IEnumerable<VersionIndependentResourceTypesAll> DefinitionResourceTypes()
     {
         return new[]
         {
-            ResourceType.ActivityDefinition,
-            ResourceType.DeviceDefinition,
-            ResourceType.CompartmentDefinition,
-            ResourceType.EventDefinition,
-            ResourceType.GraphDefinition,
-            ResourceType.MessageDefinition,
-            ResourceType.ObservationDefinition,
-            ResourceType.OperationDefinition,
-            ResourceType.PlanDefinition,
-            ResourceType.ResearchDefinition,
-            ResourceType.SpecimenDefinition,
-            ResourceType.StructureDefinition,
-            ResourceType.ChargeItemDefinition,
-            ResourceType.ResearchElementDefinition
+            VersionIndependentResourceTypesAll.ActivityDefinition,
+            VersionIndependentResourceTypesAll.DeviceDefinition,
+            VersionIndependentResourceTypesAll.CompartmentDefinition,
+            VersionIndependentResourceTypesAll.EventDefinition,
+            VersionIndependentResourceTypesAll.GraphDefinition,
+            VersionIndependentResourceTypesAll.MessageDefinition,
+            VersionIndependentResourceTypesAll.ObservationDefinition,
+            VersionIndependentResourceTypesAll.OperationDefinition,
+            VersionIndependentResourceTypesAll.PlanDefinition,
+            VersionIndependentResourceTypesAll.ResearchDefinition,
+            VersionIndependentResourceTypesAll.SpecimenDefinition,
+            VersionIndependentResourceTypesAll.StructureDefinition,
+            VersionIndependentResourceTypesAll.ChargeItemDefinition,
+            VersionIndependentResourceTypesAll.ResearchElementDefinition
         };
     }
 

--- a/src/Spark.Engine/Core/IFhirModel.cs
+++ b/src/Spark.Engine/Core/IFhirModel.cs
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-using Hl7.Fhir.Model;
 using Spark.Engine.Model;
 using System;
 using System.Collections.Generic;

--- a/src/Spark.Engine/Core/SearchParameter.cs
+++ b/src/Spark.Engine/Core/SearchParameter.cs
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2025, Incendi <info@incendi.no>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+using Hl7.Fhir.Model;
+using System;
+
+namespace Spark.Engine.Core;
+
+public class SearchParameter : IEquatable<SearchParameter>
+{
+    public string Name { get; set; }
+    public string Code { get; set; }
+    public VersionIndependentResourceTypesAll[] Base { get; set; }
+    public SearchParamType? Type { get; set; }
+    public VersionIndependentResourceTypesAll[] Target { get; set; }
+    public string Description { get; set; }
+    public string Expression { get; set; }
+    public string Xpath { get; set; }
+    // FIXME: This is still part of Hl7.Fhir.R4 assembly and need to be replaces somehow.
+    public ModelInfo.SearchParamDefinition OriginalDefinition  { get; set; }
+
+    public bool Equals(SearchParameter other)
+    {
+        return string.Equals(Name, other.Name) &&
+               string.Equals(Code, other.Code) &&
+               Equals(Base, other.Base) &&
+               Equals(Type, other.Type) &&
+               string.Equals(Description, other.Description) &&
+               string.Equals(Xpath, other.Xpath);
+    }
+
+    public override bool Equals(object obj)
+    {
+        if (ReferenceEquals(null, obj)) return false;
+        if (ReferenceEquals(this, obj)) return true;
+        if (obj.GetType() != this.GetType()) return false;
+        return Equals((SearchParameter)obj);
+    }
+
+    public override int GetHashCode()
+    {
+        var hashCode = (Name != null ? Name.GetHashCode() : 0);
+        hashCode = (hashCode * 397) ^ (Code != null ? Code.GetHashCode() : 0);
+        hashCode = (hashCode * 397) ^ (Base != null ? Base.GetHashCode() : 0);
+        hashCode = (hashCode * 397) ^ (Type != null ? Type.GetHashCode() : 0);
+        hashCode = (hashCode * 397) ^ (Description != null ? Description.GetHashCode() : 0);
+        hashCode = (hashCode * 397) ^ (Xpath != null ? Xpath.GetHashCode() : 0);
+        return hashCode;
+    }
+}

--- a/src/Spark.Engine/Core/VersionIndependentResourceTypesAll.cs
+++ b/src/Spark.Engine/Core/VersionIndependentResourceTypesAll.cs
@@ -1,0 +1,1254 @@
+/*
+  Copyright (c) 2011+, HL7, Inc.
+  All rights reserved.
+  
+  Redistribution and use in source and binary forms, with or without modification, 
+  are permitted provided that the following conditions are met:
+  
+   * Redistributions of source code must retain the above copyright notice, this 
+     list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above copyright notice, 
+     this list of conditions and the following disclaimer in the documentation 
+     and/or other materials provided with the distribution.
+   * Neither the name of HL7 nor the names of its contributors may be used to 
+     endorse or promote products derived from this software without specific 
+     prior written permission.
+  
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+  POSSIBILITY OF SUCH DAMAGE.
+  
+*/
+
+using Hl7.Fhir.Utility;
+
+namespace Spark.Engine.Core;
+
+public enum VersionIndependentResourceTypesAll
+  {
+    /// <summary>
+    /// A financial tool for tracking value accrued for a particular purpose.  In the healthcare field, used to track charges for a patient, cost centers, etc.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("Account"), Description("Account")]
+    Account,
+    /// <summary>
+    /// This resource allows for the definition of some activity to be performed, independent of a particular patient, practitioner, or other performance context.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("ActivityDefinition"), Description("ActivityDefinition")]
+    ActivityDefinition,
+    /// <summary>
+    /// The ActorDefinition resource is used to describe an actor - a human or an application that plays a role in data exchange, and that may have obligations associated with the role the actor plays.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("ActorDefinition"), Description("ActorDefinition")]
+    ActorDefinition,
+    /// <summary>
+    /// A medicinal product in the final form which is suitable for administering to a patient (after any mixing of multiple components, dissolution etc. has been performed).
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("AdministrableProductDefinition"), Description("AdministrableProductDefinition")]
+    AdministrableProductDefinition,
+    /// <summary>
+    /// An event (i.e. any change to current patient status) that may be related to unintended effects on a patient or research participant. The unintended effects may require additional monitoring, treatment, hospitalization, or may result in death. The AdverseEvent resource also extends to potential or avoided events that could have had such effects. There are two major domains where the AdverseEvent resource is expected to be used. One is in clinical care reported adverse events and the other is in reporting adverse events in clinical  research trial management.  Adverse events can be reported by healthcare providers, patients, caregivers or by medical products manufacturers.  Given the differences between these two concepts, we recommend consulting the domain specific implementation guides when implementing the AdverseEvent Resource. The implementation guides include specific extensions, value sets and constraints.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("AdverseEvent"), Description("AdverseEvent")]
+    AdverseEvent,
+    /// <summary>
+    /// Risk of harmful or undesirable, physiological response which is unique to an individual and associated with exposure to a substance.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("AllergyIntolerance"), Description("AllergyIntolerance")]
+    AllergyIntolerance,
+    /// <summary>
+    /// A booking of a healthcare event among patient(s), practitioner(s), related person(s) and/or device(s) for a specific date/time. This may result in one or more Encounter(s).
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("Appointment"), Description("Appointment")]
+    Appointment,
+    /// <summary>
+    /// A reply to an appointment request for a patient and/or practitioner(s), such as a confirmation or rejection.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("AppointmentResponse"), Description("AppointmentResponse")]
+    AppointmentResponse,
+    /// <summary>
+    /// This Resource provides one or more comments, classifiers or ratings about a Resource and supports attribution and rights management metadata for the added content.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("ArtifactAssessment"), Description("ArtifactAssessment")]
+    ArtifactAssessment,
+    /// <summary>
+    /// A record of an event relevant for purposes such as operations, privacy, security, maintenance, and performance analysis.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("AuditEvent"), Description("AuditEvent")]
+    AuditEvent,
+    /// <summary>
+    /// Basic is used for handling concepts not yet defined in FHIR, narrative-only resources that don't map to an existing resource, and custom resources not appropriate for inclusion in the FHIR specification.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("Basic"), Description("Basic")]
+    Basic,
+    /// <summary>
+    /// A resource that represents the data of a single raw artifact as digital content accessible in its native format.  A Binary resource can contain any content, whether text, image, pdf, zip archive, etc.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("Binary"), Description("Binary")]
+    Binary,
+    /// <summary>
+    /// A biological material originating from a biological entity intended to be transplanted or infused into another (possibly the same) biological entity.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("BiologicallyDerivedProduct"), Description("BiologicallyDerivedProduct")]
+    BiologicallyDerivedProduct,
+    /// <summary>
+    /// A record of dispensation of a biologically derived product.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("BiologicallyDerivedProductDispense"), Description("BiologicallyDerivedProductDispense")]
+    BiologicallyDerivedProductDispense,
+    /// <summary>
+    /// Record details about an anatomical structure.  This resource may be used when a coded concept does not provide the necessary detail needed for the use case.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("BodyStructure"), Description("BodyStructure")]
+    BodyStructure,
+    /// <summary>
+    /// A container for a collection of resources.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("Bundle"), Description("Bundle")]
+    Bundle,
+    /// <summary>
+    /// Common Interface declaration for conformance and knowledge artifact resources.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("CanonicalResource"), Description("CanonicalResource")]
+    CanonicalResource,
+    /// <summary>
+    /// A Capability Statement documents a set of capabilities (behaviors) of a FHIR Server or Client for a particular version of FHIR that may be used as a statement of actual server functionality or a statement of required or desired server implementation.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("CapabilityStatement"), Description("CapabilityStatement")]
+    CapabilityStatement,
+    /// <summary>
+    /// Describes the intention of how one or more practitioners intend to deliver care for a particular patient, group or community for a period of time, possibly limited to care for a specific condition or set of conditions.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("CarePlan"), Description("CarePlan")]
+    CarePlan,
+    /// <summary>
+    /// The Care Team includes all the people and organizations who plan to participate in the coordination and delivery of care.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("CareTeam"), Description("CareTeam")]
+    CareTeam,
+    /// <summary>
+    /// The resource ChargeItem describes the provision of healthcare provider products for a certain patient, therefore referring not only to the product, but containing in addition details of the provision, like date, time, amounts and participating organizations and persons. Main Usage of the ChargeItem is to enable the billing process and internal cost allocation.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("ChargeItem"), Description("ChargeItem")]
+    ChargeItem,
+    /// <summary>
+    /// The ChargeItemDefinition resource provides the properties that apply to the (billing) codes necessary to calculate costs and prices. The properties may differ largely depending on type and realm, therefore this resource gives only a rough structure and requires profiling for each type of billing code system.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("ChargeItemDefinition"), Description("ChargeItemDefinition")]
+    ChargeItemDefinition,
+    /// <summary>
+    /// The Citation Resource enables reference to any knowledge artifact for purposes of identification and attribution. The Citation Resource supports existing reference structures and developing publication practices such as versioning, expressing complex contributorship roles, and referencing computable resources.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("Citation"), Description("Citation")]
+    Citation,
+    /// <summary>
+    /// A provider issued list of professional services and products which have been provided, or are to be provided, to a patient which is sent to an insurer for reimbursement.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("Claim"), Description("Claim")]
+    Claim,
+    /// <summary>
+    /// This resource provides the adjudication details from the processing of a Claim resource.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("ClaimResponse"), Description("ClaimResponse")]
+    ClaimResponse,
+    /// <summary>
+    /// A record of a clinical assessment performed to determine what problem(s) may affect the patient and before planning the treatments or management strategies that are best to manage a patient's condition. Assessments are often 1:1 with a clinical consultation / encounter,  but this varies greatly depending on the clinical workflow. This resource is called \"ClinicalImpression\" rather than \"ClinicalAssessment\" to avoid confusion with the recording of assessment tools such as Apgar score.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("ClinicalImpression"), Description("ClinicalImpression")]
+    ClinicalImpression,
+    /// <summary>
+    /// A single issue - either an indication, contraindication, interaction or an undesirable effect for a medicinal product, medication, device or procedure.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("ClinicalUseDefinition"), Description("ClinicalUseDefinition")]
+    ClinicalUseDefinition,
+    /// <summary>
+    /// The CodeSystem resource is used to declare the existence of and describe a code system or code system supplement and its key properties, and optionally define a part or all of its content.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("CodeSystem"), Description("CodeSystem")]
+    CodeSystem,
+    /// <summary>
+    /// A clinical or business level record of information being transmitted or shared; e.g. an alert that was sent to a responsible provider, a public health agency communication to a provider/reporter in response to a case report for a reportable condition.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("Communication"), Description("Communication")]
+    Communication,
+    /// <summary>
+    /// A request to convey information; e.g. the CDS system proposes that an alert be sent to a responsible provider, the CDS system proposes that the public health agency be notified about a reportable condition.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("CommunicationRequest"), Description("CommunicationRequest")]
+    CommunicationRequest,
+    /// <summary>
+    /// A compartment definition that defines how resources are accessed on a server.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("CompartmentDefinition"), Description("CompartmentDefinition")]
+    CompartmentDefinition,
+    /// <summary>
+    /// A set of healthcare-related information that is assembled together into a single logical package that provides a single coherent statement of meaning, establishes its own context and that has clinical attestation with regard to who is making the statement. A Composition defines the structure and narrative content necessary for a document. However, a Composition alone does not constitute a document. Rather, the Composition must be the first entry in a Bundle where Bundle.type=document, and any other resources referenced from Composition must be included as subsequent entries in the Bundle (for example Patient, Practitioner, Encounter, etc.).
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("Composition"), Description("Composition")]
+    Composition,
+    /// <summary>
+    /// A statement of relationships from one set of concepts to one or more other concepts - either concepts in code systems, or data element/data element concepts, or classes in class models.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("ConceptMap"), Description("ConceptMap")]
+    ConceptMap,
+    /// <summary>
+    /// A clinical condition, problem, diagnosis, or other event, situation, issue, or clinical concept that has risen to a level of concern.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("Condition"), Description("Condition")]
+    Condition,
+    /// <summary>
+    /// A definition of a condition and information relevant to managing it.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("ConditionDefinition"), Description("ConditionDefinition")]
+    ConditionDefinition,
+    /// <summary>
+    /// A record of a healthcare consumer’s  choices  or choices made on their behalf by a third party, which permits or denies identified recipient(s) or recipient role(s) to perform one or more actions within a given policy context, for specific purposes and periods of time.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("Consent"), Description("Consent")]
+    Consent,
+    /// <summary>
+    /// Legally enforceable, formally recorded unilateral or bilateral directive i.e., a policy or agreement.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("Contract"), Description("Contract")]
+    Contract,
+    /// <summary>
+    /// Financial instrument which may be used to reimburse or pay for health care products and services. Includes both insurance and self-payment.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("Coverage"), Description("Coverage")]
+    Coverage,
+    /// <summary>
+    /// The CoverageEligibilityRequest provides patient and insurance coverage information to an insurer for them to respond, in the form of an CoverageEligibilityResponse, with information regarding whether the stated coverage is valid and in-force and optionally to provide the insurance details of the policy.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("CoverageEligibilityRequest"), Description("CoverageEligibilityRequest")]
+    CoverageEligibilityRequest,
+    /// <summary>
+    /// This resource provides eligibility and plan details from the processing of an CoverageEligibilityRequest resource.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("CoverageEligibilityResponse"), Description("CoverageEligibilityResponse")]
+    CoverageEligibilityResponse,
+    /// <summary>
+    /// Indicates an actual or potential clinical issue with or between one or more active or proposed clinical actions for a patient; e.g. Drug-drug interaction, Ineffective treatment frequency, Procedure-condition conflict, gaps in care, etc.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("DetectedIssue"), Description("DetectedIssue")]
+    DetectedIssue,
+    /// <summary>
+    /// This resource describes the properties (regulated, has real time clock, etc.), adminstrative (manufacturer name, model number, serial number, firmware, etc.), and type (knee replacement, blood pressure cuff, MRI, etc.) of a physical unit (these values do not change much within a given module, for example the serail number, manufacturer name, and model number). An actual unit may consist of several modules in a distinct hierarchy and these are represented by multiple Device resources and bound through the 'parent' element.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("Device"), Description("Device")]
+    Device,
+    /// <summary>
+    /// A record of association of a device.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("DeviceAssociation"), Description("DeviceAssociation")]
+    DeviceAssociation,
+    /// <summary>
+    /// This is a specialized resource that defines the characteristics and capabilities of a device.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("DeviceDefinition"), Description("DeviceDefinition")]
+    DeviceDefinition,
+    /// <summary>
+    /// Indicates that a device is to be or has been dispensed for a named person/patient.  This includes a description of the product (supply) provided and the instructions for using the device.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("DeviceDispense"), Description("DeviceDispense")]
+    DeviceDispense,
+    /// <summary>
+    /// Describes a measurement, calculation or setting capability of a device.  The DeviceMetric resource is derived from the ISO/IEEE 11073-10201 Domain Information Model standard, but is more widely applicable.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("DeviceMetric"), Description("DeviceMetric")]
+    DeviceMetric,
+    /// <summary>
+    /// Represents a request a device to be provided to a specific patient. The device may be an implantable device to be subsequently implanted, or an external assistive device, such as a walker, to be delivered and subsequently be used.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("DeviceRequest"), Description("DeviceRequest")]
+    DeviceRequest,
+    /// <summary>
+    /// A record of a device being used by a patient where the record is the result of a report from the patient or a clinician.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("DeviceUsage"), Description("DeviceUsage")]
+    DeviceUsage,
+    /// <summary>
+    /// The findings and interpretation of diagnostic tests performed on patients, groups of patients, products, substances, devices, and locations, and/or specimens derived from these. The report includes clinical context such as requesting provider information, and some mix of atomic results, images, textual and coded interpretations, and formatted representation of diagnostic reports. The report also includes non-clinical context such as batch analysis and stability reporting of products and substances.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("DiagnosticReport"), Description("DiagnosticReport")]
+    DiagnosticReport,
+    /// <summary>
+    /// A reference to a document of any kind for any purpose. While the term “document” implies a more narrow focus, for this resource this “document” encompasses *any* serialized object with a mime-type, it includes formal patient-centric documents (CDA), clinical notes, scanned paper, non-patient specific documents like policy text, as well as a photo, video, or audio recording acquired or used in healthcare.  The DocumentReference resource provides metadata about the document so that the document can be discovered and managed.  The actual content may be inline base64 encoded data or provided by direct reference.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("DocumentReference"), Description("DocumentReference")]
+    DocumentReference,
+    /// <summary>
+    /// A resource that includes narrative, extensions, and contained resources.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("DomainResource"), Description("DomainResource")]
+    DomainResource,
+    /// <summary>
+    /// An interaction between healthcare provider(s), and/or patient(s) for the purpose of providing healthcare service(s) or assessing the health status of patient(s).
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("Encounter"), Description("Encounter")]
+    Encounter,
+    /// <summary>
+    /// A record of significant events/milestones key data throughout the history of an Encounter
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("EncounterHistory"), Description("EncounterHistory")]
+    EncounterHistory,
+    /// <summary>
+    /// The technical details of an endpoint that can be used for electronic services, such as for web services providing XDS.b, a REST endpoint for another FHIR server, or a s/Mime email address. This may include any security context information.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("Endpoint"), Description("Endpoint")]
+    Endpoint,
+    /// <summary>
+    /// This resource provides the insurance enrollment details to the insurer regarding a specified coverage.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("EnrollmentRequest"), Description("EnrollmentRequest")]
+    EnrollmentRequest,
+    /// <summary>
+    /// This resource provides enrollment and plan details from the processing of an EnrollmentRequest resource.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("EnrollmentResponse"), Description("EnrollmentResponse")]
+    EnrollmentResponse,
+    /// <summary>
+    /// An association between a patient and an organization / healthcare provider(s) during which time encounters may occur. The managing organization assumes a level of responsibility for the patient during this time.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("EpisodeOfCare"), Description("EpisodeOfCare")]
+    EpisodeOfCare,
+    /// <summary>
+    /// The EventDefinition resource provides a reusable description of when a particular event can occur.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("EventDefinition"), Description("EventDefinition")]
+    EventDefinition,
+    /// <summary>
+    /// The Evidence Resource provides a machine-interpretable expression of an evidence concept including the evidence variables (e.g., population, exposures/interventions, comparators, outcomes, measured variables, confounding variables), the statistics, and the certainty of this evidence.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("Evidence"), Description("Evidence")]
+    Evidence,
+    /// <summary>
+    /// The EvidenceReport Resource is a specialized container for a collection of resources and codeable concepts, adapted to support compositions of Evidence, EvidenceVariable, and Citation resources and related concepts.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("EvidenceReport"), Description("EvidenceReport")]
+    EvidenceReport,
+    /// <summary>
+    /// The EvidenceVariable resource describes an element that knowledge (Evidence) is about.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("EvidenceVariable"), Description("EvidenceVariable")]
+    EvidenceVariable,
+    /// <summary>
+    /// A walkthrough of a workflow showing the interaction between systems and the instances shared, possibly including the evolution of instances over time.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("ExampleScenario"), Description("ExampleScenario")]
+    ExampleScenario,
+    /// <summary>
+    /// This resource provides: the claim details; adjudication details from the processing of a Claim; and optionally account balance information, for informing the subscriber of the benefits provided.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("ExplanationOfBenefit"), Description("ExplanationOfBenefit")]
+    ExplanationOfBenefit,
+    /// <summary>
+    /// Significant health conditions for a person related to the patient relevant in the context of care for the patient.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("FamilyMemberHistory"), Description("FamilyMemberHistory")]
+    FamilyMemberHistory,
+    /// <summary>
+    /// Prospective warnings of potential issues when providing care to the patient.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("Flag"), Description("Flag")]
+    Flag,
+    /// <summary>
+    /// This resource describes a product or service that is available through a program and includes the conditions and constraints of availability.  All of the information in this resource is specific to the inclusion of the item in the formulary and is not inherent to the item itself.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("FormularyItem"), Description("FormularyItem")]
+    FormularyItem,
+    /// <summary>
+    /// A set of analyses performed to analyze and generate genomic data.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("GenomicStudy"), Description("GenomicStudy")]
+    GenomicStudy,
+    /// <summary>
+    /// Describes the intended objective(s) for a patient, group or organization care, for example, weight loss, restoring an activity of daily living, obtaining herd immunity via immunization, meeting a process improvement objective, etc.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("Goal"), Description("Goal")]
+    Goal,
+    /// <summary>
+    /// A formal computable definition of a graph of resources - that is, a coherent set of resources that form a graph by following references. The Graph Definition resource defines a set and makes rules about the set.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("GraphDefinition"), Description("GraphDefinition")]
+    GraphDefinition,
+    /// <summary>
+    /// Represents a defined collection of entities that may be discussed or acted upon collectively but which are not expected to act collectively, and are not formally or legally recognized; i.e. a collection of entities that isn't an Organization.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("Group"), Description("Group")]
+    Group,
+    /// <summary>
+    /// A guidance response is the formal response to a guidance request, including any output parameters returned by the evaluation, as well as the description of any proposed actions to be taken.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("GuidanceResponse"), Description("GuidanceResponse")]
+    GuidanceResponse,
+    /// <summary>
+    /// The details of a healthcare service available at a location or in a catalog.  In the case where there is a hierarchy of services (for example, Lab -&gt; Pathology -&gt; Wound Cultures), this can be represented using a set of linked HealthcareServices.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("HealthcareService"), Description("HealthcareService")]
+    HealthcareService,
+    /// <summary>
+    /// A selection of DICOM SOP instances and/or frames within a single Study and Series. This might include additional specifics such as an image region, an Observation UID or a Segmentation Number, allowing linkage to an Observation Resource or transferring this information along with the ImagingStudy Resource.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("ImagingSelection"), Description("ImagingSelection")]
+    ImagingSelection,
+    /// <summary>
+    /// Representation of the content produced in a DICOM imaging study. A study comprises a set of series, each of which includes a set of Service-Object Pair Instances (SOP Instances - images or other data) acquired or produced in a common context.  A series is of only one modality (e.g. X-ray, CT, MR, ultrasound), but a study may have multiple series of different modalities.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("ImagingStudy"), Description("ImagingStudy")]
+    ImagingStudy,
+    /// <summary>
+    /// Describes the event of a patient being administered a vaccine or a record of an immunization as reported by a patient, a clinician or another party.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("Immunization"), Description("Immunization")]
+    Immunization,
+    /// <summary>
+    /// Describes a comparison of an immunization event against published recommendations to determine if the administration is \"valid\" in relation to those  recommendations.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("ImmunizationEvaluation"), Description("ImmunizationEvaluation")]
+    ImmunizationEvaluation,
+    /// <summary>
+    /// A patient's point-in-time set of recommendations (i.e. forecasting) according to a published schedule with optional supporting justification.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("ImmunizationRecommendation"), Description("ImmunizationRecommendation")]
+    ImmunizationRecommendation,
+    /// <summary>
+    /// A set of rules of how a particular interoperability or standards problem is solved - typically through the use of FHIR resources. This resource is used to gather all the parts of an implementation guide into a logical whole and to publish a computable definition of all the parts.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("ImplementationGuide"), Description("ImplementationGuide")]
+    ImplementationGuide,
+    /// <summary>
+    /// An ingredient of a manufactured item or pharmaceutical product.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("Ingredient"), Description("Ingredient")]
+    Ingredient,
+    /// <summary>
+    /// Details of a Health Insurance product/plan provided by an organization.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("InsurancePlan"), Description("InsurancePlan")]
+    InsurancePlan,
+    /// <summary>
+    /// functional description of an inventory item used in inventory and supply-related workflows.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("InventoryItem"), Description("InventoryItem")]
+    InventoryItem,
+    /// <summary>
+    /// A report of inventory or stock items.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("InventoryReport"), Description("InventoryReport")]
+    InventoryReport,
+    /// <summary>
+    /// Invoice containing collected ChargeItems from an Account with calculated individual and total price for Billing purpose.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("Invoice"), Description("Invoice")]
+    Invoice,
+    /// <summary>
+    /// The Library resource is a general-purpose container for knowledge asset definitions. It can be used to describe and expose existing knowledge assets such as logic libraries and information model descriptions, as well as to describe a collection of knowledge assets.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("Library"), Description("Library")]
+    Library,
+    /// <summary>
+    /// Identifies two or more records (resource instances) that refer to the same real-world \"occurrence\".
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("Linkage"), Description("Linkage")]
+    Linkage,
+    /// <summary>
+    /// A List is a curated collection of resources, for things such as problem lists, allergy lists, facility list, organization list, etc.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("List"), Description("List")]
+    List,
+    /// <summary>
+    /// Details and position information for a place where services are provided and resources and participants may be stored, found, contained, or accommodated.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("Location"), Description("Location")]
+    Location,
+    /// <summary>
+    /// The definition and characteristics of a medicinal manufactured item, such as a tablet or capsule, as contained in a packaged medicinal product.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("ManufacturedItemDefinition"), Description("ManufacturedItemDefinition")]
+    ManufacturedItemDefinition,
+    /// <summary>
+    /// The Measure resource provides the definition of a quality measure.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("Measure"), Description("Measure")]
+    Measure,
+    /// <summary>
+    /// The MeasureReport resource contains the results of the calculation of a measure; and optionally a reference to the resources involved in that calculation.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("MeasureReport"), Description("MeasureReport")]
+    MeasureReport,
+    /// <summary>
+    /// This resource is primarily used for the identification and definition of a medication, including ingredients, for the purposes of prescribing, dispensing, and administering a medication as well as for making statements about medication use.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("Medication"), Description("Medication")]
+    Medication,
+    /// <summary>
+    /// Describes the event of a patient consuming or otherwise being administered a medication.  This may be as simple as swallowing a tablet or it may be a long running infusion. Related resources tie this event to the authorizing prescription, and the specific encounter between patient and health care practitioner. This event can also be used to record waste using a status of not-done and the appropriate statusReason.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("MedicationAdministration"), Description("MedicationAdministration")]
+    MedicationAdministration,
+    /// <summary>
+    /// Indicates that a medication product is to be or has been dispensed for a named person/patient.  This includes a description of the medication product (supply) provided and the instructions for administering the medication.  The medication dispense is the result of a pharmacy system responding to a medication order.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("MedicationDispense"), Description("MedicationDispense")]
+    MedicationDispense,
+    /// <summary>
+    /// Information about a medication that is used to support knowledge.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("MedicationKnowledge"), Description("MedicationKnowledge")]
+    MedicationKnowledge,
+    /// <summary>
+    /// An order or request for both supply of the medication and the instructions for administration of the medication to a patient. The resource is called \"MedicationRequest\" rather than \"MedicationPrescription\" or \"MedicationOrder\" to generalize the use across inpatient and outpatient settings, including care plans, etc., and to harmonize with workflow patterns.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("MedicationRequest"), Description("MedicationRequest")]
+    MedicationRequest,
+    /// <summary>
+    /// A record of a medication that is being consumed by a patient.   A MedicationStatement may indicate that the patient may be taking the medication now or has taken the medication in the past or will be taking the medication in the future.  The source of this information can be the patient, significant other (such as a family member or spouse), or a clinician.  A common scenario where this information is captured is during the history taking process during a patient visit or stay.   The medication information may come from sources such as the patient's memory, from a prescription bottle,  or from a list of medications the patient, clinician or other party maintains. The primary difference between a medicationstatement and a medicationadministration is that the medication administration has complete administration information and is based on actual administration information from the person who administered the medication.  A medicationstatement is often, if not always, less specific.  There is no required date/time when the medication was administered, in fact we only know that a source has reported the patient is taking this medication, where details such as time, quantity, or rate or even medication product may be incomplete or missing or less precise.  As stated earlier, the Medication Statement information may come from the patient's memory, from a prescription bottle or from a list of medications the patient, clinician or other party maintains.  Medication administration is more formal and is not missing detailed information.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("MedicationStatement"), Description("MedicationStatement")]
+    MedicationStatement,
+    /// <summary>
+    /// Detailed definition of a medicinal product, typically for uses other than direct patient care (e.g. regulatory use, drug catalogs, to support prescribing, adverse events management etc.).
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("MedicinalProductDefinition"), Description("MedicinalProductDefinition")]
+    MedicinalProductDefinition,
+    /// <summary>
+    /// Defines the characteristics of a message that can be shared between systems, including the type of event that initiates the message, the content to be transmitted and what response(s), if any, are permitted.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("MessageDefinition"), Description("MessageDefinition")]
+    MessageDefinition,
+    /// <summary>
+    /// The header for a message exchange that is either requesting or responding to an action.  The reference(s) that are the subject of the action as well as other information related to the action are typically transmitted in a bundle in which the MessageHeader resource instance is the first resource in the bundle.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("MessageHeader"), Description("MessageHeader")]
+    MessageHeader,
+    /// <summary>
+    /// Common Interface declaration for conformance and knowledge artifact resources.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("MetadataResource"), Description("MetadataResource")]
+    MetadataResource,
+    /// <summary>
+    /// Representation of a molecular sequence.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("MolecularSequence"), Description("MolecularSequence")]
+    MolecularSequence,
+    /// <summary>
+    /// A curated namespace that issues unique symbols within that namespace for the identification of concepts, people, devices, etc.  Represents a \"System\" used within the Identifier and Coding data types.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("NamingSystem"), Description("NamingSystem")]
+    NamingSystem,
+    /// <summary>
+    /// A record of food or fluid that is being consumed by a patient.  A NutritionIntake may indicate that the patient may be consuming the food or fluid now or has consumed the food or fluid in the past.  The source of this information can be the patient, significant other (such as a family member or spouse), or a clinician.  A common scenario where this information is captured is during the history taking process during a patient visit or stay or through an app that tracks food or fluids consumed.   The consumption information may come from sources such as the patient's memory, from a nutrition label,  or from a clinician documenting observed intake.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("NutritionIntake"), Description("NutritionIntake")]
+    NutritionIntake,
+    /// <summary>
+    /// A request to supply a diet, formula feeding (enteral) or oral nutritional supplement to a patient/resident.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("NutritionOrder"), Description("NutritionOrder")]
+    NutritionOrder,
+    /// <summary>
+    /// A food or supplement that is consumed by patients.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("NutritionProduct"), Description("NutritionProduct")]
+    NutritionProduct,
+    /// <summary>
+    /// Measurements and simple assertions made about a patient, device or other subject.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("Observation"), Description("Observation")]
+    Observation,
+    /// <summary>
+    /// Set of definitional characteristics for a kind of observation or measurement produced or consumed by an orderable health care service.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("ObservationDefinition"), Description("ObservationDefinition")]
+    ObservationDefinition,
+    /// <summary>
+    /// A formal computable definition of an operation (on the RESTful interface) or a named query (using the search interaction).
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("OperationDefinition"), Description("OperationDefinition")]
+    OperationDefinition,
+    /// <summary>
+    /// A collection of error, warning, or information messages that result from a system action.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("OperationOutcome"), Description("OperationOutcome")]
+    OperationOutcome,
+    /// <summary>
+    /// A formally or informally recognized grouping of people or organizations formed for the purpose of achieving some form of collective action.  Includes companies, institutions, corporations, departments, community groups, healthcare practice groups, payer/insurer, etc.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("Organization"), Description("Organization")]
+    Organization,
+    /// <summary>
+    /// Defines an affiliation/assotiation/relationship between 2 distinct organizations, that is not a part-of relationship/sub-division relationship.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("OrganizationAffiliation"), Description("OrganizationAffiliation")]
+    OrganizationAffiliation,
+    /// <summary>
+    /// A medically related item or items, in a container or package.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("PackagedProductDefinition"), Description("PackagedProductDefinition")]
+    PackagedProductDefinition,
+    /// <summary>
+    /// This resource is used to pass information into and back from an operation (whether invoked directly from REST or within a messaging environment).  It is not persisted or allowed to be referenced by other resources except as described in the definition of the Parameters resource.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("Parameters"), Description("Parameters")]
+    Parameters,
+    /// <summary>
+    /// Demographics and other administrative information about an individual or animal receiving care or other health-related services.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("Patient"), Description("Patient")]
+    Patient,
+    /// <summary>
+    /// This resource provides the status of the payment for goods and services rendered, and the request and response resource references.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("PaymentNotice"), Description("PaymentNotice")]
+    PaymentNotice,
+    /// <summary>
+    /// This resource provides the details including amount of a payment and allocates the payment items being paid.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("PaymentReconciliation"), Description("PaymentReconciliation")]
+    PaymentReconciliation,
+    /// <summary>
+    /// Permission resource holds access rules for a given data and context.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("Permission"), Description("Permission")]
+    Permission,
+    /// <summary>
+    /// Demographics and administrative information about a person independent of a specific health-related context.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("Person"), Description("Person")]
+    Person,
+    /// <summary>
+    /// This resource allows for the definition of various types of plans as a sharable, consumable, and executable artifact. The resource is general enough to support the description of a broad range of clinical and non-clinical artifacts such as clinical decision support rules, order sets, protocols, and drug quality specifications.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("PlanDefinition"), Description("PlanDefinition")]
+    PlanDefinition,
+    /// <summary>
+    /// A person who is directly or indirectly involved in the provisioning of healthcare or related services.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("Practitioner"), Description("Practitioner")]
+    Practitioner,
+    /// <summary>
+    /// A specific set of Roles/Locations/specialties/services that a practitioner may perform, or has performed at an organization during a period of time.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("PractitionerRole"), Description("PractitionerRole")]
+    PractitionerRole,
+    /// <summary>
+    /// An action that is or was performed on or for a patient, practitioner, device, organization, or location. For example, this can be a physical intervention on a patient like an operation, or less invasive like long term services, counseling, or hypnotherapy.  This can be a quality or safety inspection for a location, organization, or device.  This can be an accreditation procedure on a practitioner for licensing.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("Procedure"), Description("Procedure")]
+    Procedure,
+    /// <summary>
+    /// Provenance of a resource is a record that describes entities and processes involved in producing and delivering or otherwise influencing that resource. Provenance provides a critical foundation for assessing authenticity, enabling trust, and allowing reproducibility. Provenance assertions are a form of contextual metadata and can themselves become important records with their own provenance. Provenance statement indicates clinical significance in terms of confidence in authenticity, reliability, and trustworthiness, integrity, and stage in lifecycle (e.g. Document Completion - has the artifact been legally authenticated), all of which may impact security, privacy, and trust policies.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("Provenance"), Description("Provenance")]
+    Provenance,
+    /// <summary>
+    /// A structured set of questions intended to guide the collection of answers from end-users. Questionnaires provide detailed control over order, presentation, phraseology and grouping to allow coherent, consistent data collection.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("Questionnaire"), Description("Questionnaire")]
+    Questionnaire,
+    /// <summary>
+    /// A structured set of questions and their answers. The questions are ordered and grouped into coherent subsets, corresponding to the structure of the grouping of the questionnaire being responded to.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("QuestionnaireResponse"), Description("QuestionnaireResponse")]
+    QuestionnaireResponse,
+    /// <summary>
+    /// Regulatory approval, clearance or licencing related to a regulated product, treatment, facility or activity that is cited in a guidance, regulation, rule or legislative act. An example is Market Authorization relating to a Medicinal Product.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("RegulatedAuthorization"), Description("RegulatedAuthorization")]
+    RegulatedAuthorization,
+    /// <summary>
+    /// Information about a person that is involved in a patient's health or the care for a patient, but who is not the target of healthcare, nor has a formal responsibility in the care process.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("RelatedPerson"), Description("RelatedPerson")]
+    RelatedPerson,
+    /// <summary>
+    /// A set of related requests that can be used to capture intended activities that have inter-dependencies such as \"give this medication after that one\".
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("RequestOrchestration"), Description("RequestOrchestration")]
+    RequestOrchestration,
+    /// <summary>
+    /// The Requirements resource is used to describe an actor - a human or an application that plays a role in data exchange, and that may have obligations associated with the role the actor plays.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("Requirements"), Description("Requirements")]
+    Requirements,
+    /// <summary>
+    /// A scientific study of nature that sometimes includes processes involved in health and disease. For example, clinical trials are research studies that involve people. These studies may be related to new ways to screen, prevent, diagnose, and treat disease. They may also study certain outcomes and certain groups of people by looking at data collected in the past or future.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("ResearchStudy"), Description("ResearchStudy")]
+    ResearchStudy,
+    /// <summary>
+    /// A ResearchSubject is a participant or object which is the recipient of investigative activities in a research study.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("ResearchSubject"), Description("ResearchSubject")]
+    ResearchSubject,
+    /// <summary>
+    /// This is the base resource type for everything.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("Resource"), Description("Resource")]
+    Resource,
+    /// <summary>
+    /// An assessment of the likely outcome(s) for a patient or other subject as well as the likelihood of each outcome.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("RiskAssessment"), Description("RiskAssessment")]
+    RiskAssessment,
+    /// <summary>
+    /// A container for slots of time that may be available for booking appointments.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("Schedule"), Description("Schedule")]
+    Schedule,
+    /// <summary>
+    /// A search parameter that defines a named search item that can be used to search/filter on a resource.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("SearchParameter"), Description("SearchParameter")]
+    SearchParameter,
+    /// <summary>
+    /// A record of a request for service such as diagnostic investigations, treatments, or operations to be performed.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("ServiceRequest"), Description("ServiceRequest")]
+    ServiceRequest,
+    /// <summary>
+    /// A slot of time on a schedule that may be available for booking appointments.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("Slot"), Description("Slot")]
+    Slot,
+    /// <summary>
+    /// A sample to be used for analysis.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("Specimen"), Description("Specimen")]
+    Specimen,
+    /// <summary>
+    /// A kind of specimen with associated set of requirements.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("SpecimenDefinition"), Description("SpecimenDefinition")]
+    SpecimenDefinition,
+    /// <summary>
+    /// A definition of a FHIR structure. This resource is used to describe the underlying resources, data types defined in FHIR, and also for describing extensions and constraints on resources and data types.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("StructureDefinition"), Description("StructureDefinition")]
+    StructureDefinition,
+    /// <summary>
+    /// A Map of relationships between 2 structures that can be used to transform data.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("StructureMap"), Description("StructureMap")]
+    StructureMap,
+    /// <summary>
+    /// The subscription resource describes a particular client's request to be notified about a SubscriptionTopic.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("Subscription"), Description("Subscription")]
+    Subscription,
+    /// <summary>
+    /// The SubscriptionStatus resource describes the state of a Subscription during notifications. It is not persisted.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("SubscriptionStatus"), Description("SubscriptionStatus")]
+    SubscriptionStatus,
+    /// <summary>
+    /// Describes a stream of resource state changes identified by trigger criteria and annotated with labels useful to filter projections from this topic.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("SubscriptionTopic"), Description("SubscriptionTopic")]
+    SubscriptionTopic,
+    /// <summary>
+    /// A homogeneous material with a definite composition.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("Substance"), Description("Substance")]
+    Substance,
+    /// <summary>
+    /// The detailed description of a substance, typically at a level beyond what is used for prescribing.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("SubstanceDefinition"), Description("SubstanceDefinition")]
+    SubstanceDefinition,
+    /// <summary>
+    /// Nucleic acids are defined by three distinct elements: the base, sugar and linkage. Individual substance/moiety IDs will be created for each of these elements. The nucleotide sequence will be always entered in the 5’-3’ direction.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("SubstanceNucleicAcid"), Description("SubstanceNucleicAcid")]
+    SubstanceNucleicAcid,
+    /// <summary>
+    /// Properties of a substance specific to it being a polymer.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("SubstancePolymer"), Description("SubstancePolymer")]
+    SubstancePolymer,
+    /// <summary>
+    /// A SubstanceProtein is defined as a single unit of a linear amino acid sequence, or a combination of subunits that are either covalently linked or have a defined invariant stoichiometric relationship. This includes all synthetic, recombinant and purified SubstanceProteins of defined sequence, whether the use is therapeutic or prophylactic. This set of elements will be used to describe albumins, coagulation factors, cytokines, growth factors, peptide/SubstanceProtein hormones, enzymes, toxins, toxoids, recombinant vaccines, and immunomodulators.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("SubstanceProtein"), Description("SubstanceProtein")]
+    SubstanceProtein,
+    /// <summary>
+    /// Todo.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("SubstanceReferenceInformation"), Description("SubstanceReferenceInformation")]
+    SubstanceReferenceInformation,
+    /// <summary>
+    /// Source material shall capture information on the taxonomic and anatomical origins as well as the fraction of a material that can result in or can be modified to form a substance. This set of data elements shall be used to define polymer substances isolated from biological matrices. Taxonomic and anatomical origins shall be described using a controlled vocabulary as required. This information is captured for naturally derived polymers ( . starch) and structurally diverse substances. For Organisms belonging to the Kingdom Plantae the Substance level defines the fresh material of a single species or infraspecies, the Herbal Drug and the Herbal preparation. For Herbal preparations, the fraction information will be captured at the Substance information level and additional information for herbal extracts will be captured at the Specified Substance Group 1 information level. See for further explanation the Substance Class: Structurally Diverse and the herbal annex.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("SubstanceSourceMaterial"), Description("SubstanceSourceMaterial")]
+    SubstanceSourceMaterial,
+    /// <summary>
+    /// Record of delivery of what is supplied.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("SupplyDelivery"), Description("SupplyDelivery")]
+    SupplyDelivery,
+    /// <summary>
+    /// A record of a non-patient specific request for a medication, substance, device, certain types of biologically derived product, and nutrition product used in the healthcare setting.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("SupplyRequest"), Description("SupplyRequest")]
+    SupplyRequest,
+    /// <summary>
+    /// A task to be performed.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("Task"), Description("Task")]
+    Task,
+    /// <summary>
+    /// A TerminologyCapabilities resource documents a set of capabilities (behaviors) of a FHIR Terminology Server that may be used as a statement of actual server functionality or a statement of required or desired server implementation.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("TerminologyCapabilities"), Description("TerminologyCapabilities")]
+    TerminologyCapabilities,
+    /// <summary>
+    /// A plan for executing testing on an artifact or specifications
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("TestPlan"), Description("TestPlan")]
+    TestPlan,
+    /// <summary>
+    /// A summary of information based on the results of executing a TestScript.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("TestReport"), Description("TestReport")]
+    TestReport,
+    /// <summary>
+    /// A structured set of tests against a FHIR server or client implementation to determine compliance against the FHIR specification.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("TestScript"), Description("TestScript")]
+    TestScript,
+    /// <summary>
+    /// Record of transport.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("Transport"), Description("Transport")]
+    Transport,
+    /// <summary>
+    /// A ValueSet resource instance specifies a set of codes drawn from one or more code systems, intended for use in a particular context. Value sets link between [[[CodeSystem]]] definitions and their use in [coded elements](terminologies.html).
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("ValueSet"), Description("ValueSet")]
+    ValueSet,
+    /// <summary>
+    /// Describes validation requirements, source(s), status and dates for one or more elements.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("VerificationResult"), Description("VerificationResult")]
+    VerificationResult,
+    /// <summary>
+    /// An authorization for the provision of glasses and/or contact lenses to a patient.
+    /// (system: http://hl7.org/fhir/fhir-types)
+    /// </summary>
+    [EnumLiteral("VisionPrescription"), Description("VisionPrescription")]
+    VisionPrescription,
+    /// <summary>
+    /// BodySite
+    /// (system: http://hl7.org/fhir/fhir-old-types)
+    /// </summary>
+    [EnumLiteral("BodySite", "http://hl7.org/fhir/fhir-old-types"), Description("BodySite")]
+    BodySite,
+    /// <summary>
+    /// CatalogEntry
+    /// (system: http://hl7.org/fhir/fhir-old-types)
+    /// </summary>
+    [EnumLiteral("CatalogEntry", "http://hl7.org/fhir/fhir-old-types"), Description("CatalogEntry")]
+    CatalogEntry,
+    /// <summary>
+    /// Conformance
+    /// (system: http://hl7.org/fhir/fhir-old-types)
+    /// </summary>
+    [EnumLiteral("Conformance", "http://hl7.org/fhir/fhir-old-types"), Description("Conformance")]
+    Conformance,
+    /// <summary>
+    /// DataElement
+    /// (system: http://hl7.org/fhir/fhir-old-types)
+    /// </summary>
+    [EnumLiteral("DataElement", "http://hl7.org/fhir/fhir-old-types"), Description("DataElement")]
+    DataElement,
+    /// <summary>
+    /// DeviceComponent
+    /// (system: http://hl7.org/fhir/fhir-old-types)
+    /// </summary>
+    [EnumLiteral("DeviceComponent", "http://hl7.org/fhir/fhir-old-types"), Description("DeviceComponent")]
+    DeviceComponent,
+    /// <summary>
+    /// DeviceUseRequest
+    /// (system: http://hl7.org/fhir/fhir-old-types)
+    /// </summary>
+    [EnumLiteral("DeviceUseRequest", "http://hl7.org/fhir/fhir-old-types"), Description("DeviceUseRequest")]
+    DeviceUseRequest,
+    /// <summary>
+    /// DeviceUseStatement
+    /// (system: http://hl7.org/fhir/fhir-old-types)
+    /// </summary>
+    [EnumLiteral("DeviceUseStatement", "http://hl7.org/fhir/fhir-old-types"), Description("DeviceUseStatement")]
+    DeviceUseStatement,
+    /// <summary>
+    /// DiagnosticOrder
+    /// (system: http://hl7.org/fhir/fhir-old-types)
+    /// </summary>
+    [EnumLiteral("DiagnosticOrder", "http://hl7.org/fhir/fhir-old-types"), Description("DiagnosticOrder")]
+    DiagnosticOrder,
+    /// <summary>
+    /// DocumentManifest
+    /// (system: http://hl7.org/fhir/fhir-old-types)
+    /// </summary>
+    [EnumLiteral("DocumentManifest", "http://hl7.org/fhir/fhir-old-types"), Description("DocumentManifest")]
+    DocumentManifest,
+    /// <summary>
+    /// EffectEvidenceSynthesis
+    /// (system: http://hl7.org/fhir/fhir-old-types)
+    /// </summary>
+    [EnumLiteral("EffectEvidenceSynthesis", "http://hl7.org/fhir/fhir-old-types"), Description("EffectEvidenceSynthesis")]
+    EffectEvidenceSynthesis,
+    /// <summary>
+    /// EligibilityRequest
+    /// (system: http://hl7.org/fhir/fhir-old-types)
+    /// </summary>
+    [EnumLiteral("EligibilityRequest", "http://hl7.org/fhir/fhir-old-types"), Description("EligibilityRequest")]
+    EligibilityRequest,
+    /// <summary>
+    /// EligibilityResponse
+    /// (system: http://hl7.org/fhir/fhir-old-types)
+    /// </summary>
+    [EnumLiteral("EligibilityResponse", "http://hl7.org/fhir/fhir-old-types"), Description("EligibilityResponse")]
+    EligibilityResponse,
+    /// <summary>
+    /// ExpansionProfile
+    /// (system: http://hl7.org/fhir/fhir-old-types)
+    /// </summary>
+    [EnumLiteral("ExpansionProfile", "http://hl7.org/fhir/fhir-old-types"), Description("ExpansionProfile")]
+    ExpansionProfile,
+    /// <summary>
+    /// ImagingManifest
+    /// (system: http://hl7.org/fhir/fhir-old-types)
+    /// </summary>
+    [EnumLiteral("ImagingManifest", "http://hl7.org/fhir/fhir-old-types"), Description("ImagingManifest")]
+    ImagingManifest,
+    /// <summary>
+    /// ImagingObjectSelection
+    /// (system: http://hl7.org/fhir/fhir-old-types)
+    /// </summary>
+    [EnumLiteral("ImagingObjectSelection", "http://hl7.org/fhir/fhir-old-types"), Description("ImagingObjectSelection")]
+    ImagingObjectSelection,
+    /// <summary>
+    /// Media
+    /// (system: http://hl7.org/fhir/fhir-old-types)
+    /// </summary>
+    [EnumLiteral("Media", "http://hl7.org/fhir/fhir-old-types"), Description("Media")]
+    Media,
+    /// <summary>
+    /// MedicationOrder
+    /// (system: http://hl7.org/fhir/fhir-old-types)
+    /// </summary>
+    [EnumLiteral("MedicationOrder", "http://hl7.org/fhir/fhir-old-types"), Description("MedicationOrder")]
+    MedicationOrder,
+    /// <summary>
+    /// MedicationUsage
+    /// (system: http://hl7.org/fhir/fhir-old-types)
+    /// </summary>
+    [EnumLiteral("MedicationUsage", "http://hl7.org/fhir/fhir-old-types"), Description("MedicationUsage")]
+    MedicationUsage,
+    /// <summary>
+    /// MedicinalProduct
+    /// (system: http://hl7.org/fhir/fhir-old-types)
+    /// </summary>
+    [EnumLiteral("MedicinalProduct", "http://hl7.org/fhir/fhir-old-types"), Description("MedicinalProduct")]
+    MedicinalProduct,
+    /// <summary>
+    /// MedicinalProductAuthorization
+    /// (system: http://hl7.org/fhir/fhir-old-types)
+    /// </summary>
+    [EnumLiteral("MedicinalProductAuthorization", "http://hl7.org/fhir/fhir-old-types"), Description("MedicinalProductAuthorization")]
+    MedicinalProductAuthorization,
+    /// <summary>
+    /// MedicinalProductContraindication
+    /// (system: http://hl7.org/fhir/fhir-old-types)
+    /// </summary>
+    [EnumLiteral("MedicinalProductContraindication", "http://hl7.org/fhir/fhir-old-types"), Description("MedicinalProductContraindication")]
+    MedicinalProductContraindication,
+    /// <summary>
+    /// MedicinalProductIndication
+    /// (system: http://hl7.org/fhir/fhir-old-types)
+    /// </summary>
+    [EnumLiteral("MedicinalProductIndication", "http://hl7.org/fhir/fhir-old-types"), Description("MedicinalProductIndication")]
+    MedicinalProductIndication,
+    /// <summary>
+    /// MedicinalProductIngredient
+    /// (system: http://hl7.org/fhir/fhir-old-types)
+    /// </summary>
+    [EnumLiteral("MedicinalProductIngredient", "http://hl7.org/fhir/fhir-old-types"), Description("MedicinalProductIngredient")]
+    MedicinalProductIngredient,
+    /// <summary>
+    /// MedicinalProductInteraction
+    /// (system: http://hl7.org/fhir/fhir-old-types)
+    /// </summary>
+    [EnumLiteral("MedicinalProductInteraction", "http://hl7.org/fhir/fhir-old-types"), Description("MedicinalProductInteraction")]
+    MedicinalProductInteraction,
+    /// <summary>
+    /// MedicinalProductManufactured
+    /// (system: http://hl7.org/fhir/fhir-old-types)
+    /// </summary>
+    [EnumLiteral("MedicinalProductManufactured", "http://hl7.org/fhir/fhir-old-types"), Description("MedicinalProductManufactured")]
+    MedicinalProductManufactured,
+    /// <summary>
+    /// MedicinalProductPackaged
+    /// (system: http://hl7.org/fhir/fhir-old-types)
+    /// </summary>
+    [EnumLiteral("MedicinalProductPackaged", "http://hl7.org/fhir/fhir-old-types"), Description("MedicinalProductPackaged")]
+    MedicinalProductPackaged,
+    /// <summary>
+    /// MedicinalProductPharmaceutical
+    /// (system: http://hl7.org/fhir/fhir-old-types)
+    /// </summary>
+    [EnumLiteral("MedicinalProductPharmaceutical", "http://hl7.org/fhir/fhir-old-types"), Description("MedicinalProductPharmaceutical")]
+    MedicinalProductPharmaceutical,
+    /// <summary>
+    /// MedicinalProductUndesirableEffect
+    /// (system: http://hl7.org/fhir/fhir-old-types)
+    /// </summary>
+    [EnumLiteral("MedicinalProductUndesirableEffect", "http://hl7.org/fhir/fhir-old-types"), Description("MedicinalProductUndesirableEffect")]
+    MedicinalProductUndesirableEffect,
+    /// <summary>
+    /// Order
+    /// (system: http://hl7.org/fhir/fhir-old-types)
+    /// </summary>
+    [EnumLiteral("Order", "http://hl7.org/fhir/fhir-old-types"), Description("Order")]
+    Order,
+    /// <summary>
+    /// OrderResponse
+    /// (system: http://hl7.org/fhir/fhir-old-types)
+    /// </summary>
+    [EnumLiteral("OrderResponse", "http://hl7.org/fhir/fhir-old-types"), Description("OrderResponse")]
+    OrderResponse,
+    /// <summary>
+    /// ProcedureRequest
+    /// (system: http://hl7.org/fhir/fhir-old-types)
+    /// </summary>
+    [EnumLiteral("ProcedureRequest", "http://hl7.org/fhir/fhir-old-types"), Description("ProcedureRequest")]
+    ProcedureRequest,
+    /// <summary>
+    /// ProcessRequest
+    /// (system: http://hl7.org/fhir/fhir-old-types)
+    /// </summary>
+    [EnumLiteral("ProcessRequest", "http://hl7.org/fhir/fhir-old-types"), Description("ProcessRequest")]
+    ProcessRequest,
+    /// <summary>
+    /// ProcessResponse
+    /// (system: http://hl7.org/fhir/fhir-old-types)
+    /// </summary>
+    [EnumLiteral("ProcessResponse", "http://hl7.org/fhir/fhir-old-types"), Description("ProcessResponse")]
+    ProcessResponse,
+    /// <summary>
+    /// ReferralRequest
+    /// (system: http://hl7.org/fhir/fhir-old-types)
+    /// </summary>
+    [EnumLiteral("ReferralRequest", "http://hl7.org/fhir/fhir-old-types"), Description("ReferralRequest")]
+    ReferralRequest,
+    /// <summary>
+    /// RequestGroup
+    /// (system: http://hl7.org/fhir/fhir-old-types)
+    /// </summary>
+    [EnumLiteral("RequestGroup", "http://hl7.org/fhir/fhir-old-types"), Description("RequestGroup")]
+    RequestGroup,
+    /// <summary>
+    /// ResearchDefinition
+    /// (system: http://hl7.org/fhir/fhir-old-types)
+    /// </summary>
+    [EnumLiteral("ResearchDefinition", "http://hl7.org/fhir/fhir-old-types"), Description("ResearchDefinition")]
+    ResearchDefinition,
+    /// <summary>
+    /// ResearchElementDefinition
+    /// (system: http://hl7.org/fhir/fhir-old-types)
+    /// </summary>
+    [EnumLiteral("ResearchElementDefinition", "http://hl7.org/fhir/fhir-old-types"), Description("ResearchElementDefinition")]
+    ResearchElementDefinition,
+    /// <summary>
+    /// RiskEvidenceSynthesis
+    /// (system: http://hl7.org/fhir/fhir-old-types)
+    /// </summary>
+    [EnumLiteral("RiskEvidenceSynthesis", "http://hl7.org/fhir/fhir-old-types"), Description("RiskEvidenceSynthesis")]
+    RiskEvidenceSynthesis,
+    /// <summary>
+    /// Sequence
+    /// (system: http://hl7.org/fhir/fhir-old-types)
+    /// </summary>
+    [EnumLiteral("Sequence", "http://hl7.org/fhir/fhir-old-types"), Description("Sequence")]
+    Sequence,
+    /// <summary>
+    /// ServiceDefinition
+    /// (system: http://hl7.org/fhir/fhir-old-types)
+    /// </summary>
+    [EnumLiteral("ServiceDefinition", "http://hl7.org/fhir/fhir-old-types"), Description("ServiceDefinition")]
+    ServiceDefinition,
+    /// <summary>
+    /// SubstanceSpecification
+    /// (system: http://hl7.org/fhir/fhir-old-types)
+    /// </summary>
+    [EnumLiteral("SubstanceSpecification", "http://hl7.org/fhir/fhir-old-types"), Description("SubstanceSpecification")]
+    SubstanceSpecification,
+  }

--- a/src/Spark.Engine/Extensions/SearchParameterExtensions.cs
+++ b/src/Spark.Engine/Extensions/SearchParameterExtensions.cs
@@ -6,12 +6,12 @@
  */
 
 using Hl7.Fhir.Utility;
-using Hl7.Fhir.Model;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Hl7.Fhir.Rest;
+using SearchParameter = Spark.Engine.Core.SearchParameter;
 
 namespace Spark.Engine.Extensions;
 
@@ -71,16 +71,6 @@ public static class SearchParameterExtensions
         {
             return new string[] { };
         }
-    }
-
-    public static ModelInfo.SearchParamDefinition GetOriginalDefinition(this SearchParameter searchParameter)
-    {
-        return searchParameter.Annotation<ModelInfo.SearchParamDefinition>();
-    }
-
-    public static void SetOriginalDefinition(this SearchParameter searchParameter, ModelInfo.SearchParamDefinition definition)
-    {
-        searchParameter.AddAnnotation(definition);
     }
 
     public static SearchParams AddAll(this SearchParams self, List<Tuple<string, string>> @params)

--- a/src/Spark.Engine/Service/FhirServiceExtensions/IndexService.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/IndexService.cs
@@ -21,6 +21,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using SearchParameter = Spark.Engine.Core.SearchParameter;
 using Task = System.Threading.Tasks.Task;
 
 namespace Spark.Engine.Service.FhirServiceExtensions;

--- a/src/Spark.Mongo/Search/Searcher/MongoSearcher.cs
+++ b/src/Spark.Mongo/Search/Searcher/MongoSearcher.cs
@@ -594,7 +594,7 @@ public class MongoSearcher
     private (string, SortOrder) NormalizeSortItem(string resourceType, (string, SortOrder) sortItem)
     {
         ModelInfo.SearchParamDefinition definition =
-            _fhirModel.FindSearchParameter(resourceType, sortItem.Item1)?.GetOriginalDefinition();
+            _fhirModel.FindSearchParameter(resourceType, sortItem.Item1)?.OriginalDefinition;
 
         if (definition?.Type == SearchParamType.Token)
         {
@@ -692,7 +692,7 @@ public class MongoSearcher
 
         var result = true;
 
-        var spDef = sp.GetOriginalDefinition();
+        var spDef = sp.OriginalDefinition;
 
         if (spDef != null)
         {


### PR DESCRIPTION
This replaces the SearchParameter we have been using from the firely-net-sdk with our homegrown SearchParameter. That SearchParameter is also the one from the FHIR standard which is not ideal when we want to consolidate as much code across the FHIR standards into one library.