### PR TITLE
Engine: Move SearchParameter from Core to Model namespace

### DIFF
--- a/Documentation/MigrateFromv2Tov3.md
+++ b/Documentation/MigrateFromv2Tov3.md
@@ -18,11 +18,11 @@ We now target `net8.0`, `net9.0`, and `net10.0`. `netstandard2.0` and `net472` t
 
 ### Method and property signature changes
 - `Validate.HasResourceType(IKey, ResourceType)` has been changed to `Validate.HasResourceType(IKey, string)`
-- `List<Hl7.Fhir.Model.SearchParameter> IFhirModel.SearchParameters` has been changed to `IReadOnlyListList<Spark.Engine.Core.SearchParameter> IFhirModel.SearchParameters`
-- `IEnumerable<Hl7.Fhir.Model.SearchParameter> IFhirModel.FindSearchParameters(Type)` has been changed to `List<Spark.Engine.Core.SearchParameter> IFhirModel.FindSearchParameters(Type)`
-- `IEnumerable<Hl7.Fhir.Model.SearchParameter> IFhirModel.FindSearchParameters(string)` has been changed to `List<Spark.Engine.Core.SearchParameter> IFhirModel.FindSearchParameters(string)`
-- `IEnumerable<Hl7.Fhir.Model.SearchParameter> IFhirModel.FindSearchParameters(Type, string)` has been changed to `List<Spark.Engine.Core.SearchParameter> IFhirModel.FindSearchParameters(Type, string)`
-- `IEnumerable<Hl7.Fhir.Model.SearchParameter> IFhirModel.FindSearchParameters(string, string)` has been changed to `List<Spark.Engine.Core.SearchParameter> IFhirModel.FindSearchParameters(string, string)`
+- `List<Hl7.Fhir.Model.SearchParameter> IFhirModel.SearchParameters` has been changed to `IReadOnlyListList<Spark.Engine.Model.SearchParameter> IFhirModel.SearchParameters`
+- `IEnumerable<Hl7.Fhir.Model.SearchParameter> IFhirModel.FindSearchParameters(Type)` has been changed to `List<Spark.Engine.Model.SearchParameter> IFhirModel.FindSearchParameters(Type)`
+- `IEnumerable<Hl7.Fhir.Model.SearchParameter> IFhirModel.FindSearchParameters(string)` has been changed to `List<Spark.Engine.Model.SearchParameter> IFhirModel.FindSearchParameters(string)`
+- `IEnumerable<Hl7.Fhir.Model.SearchParameter> IFhirModel.FindSearchParameters(Type, string)` has been changed to `List<Spark.Engine.Model.SearchParameter> IFhirModel.FindSearchParameters(Type, string)`
+- `IEnumerable<Hl7.Fhir.Model.SearchParameter> IFhirModel.FindSearchParameters(string, string)` has been changed to `List<Spark.Engine.Model.SearchParameter> IFhirModel.FindSearchParameters(string, string)`
 
 ### Removed classes and interfaces
 - `ResourceVisitor` (`Spark.Engine.Core`)

--- a/src/Spark.Engine.Test/Extensions/SearchParameterExtensionsTests.cs
+++ b/src/Spark.Engine.Test/Extensions/SearchParameterExtensionsTests.cs
@@ -7,6 +7,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Spark.Engine.Core;
 using Spark.Engine.Extensions;
+using Spark.Engine.Model;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/src/Spark.Engine/Core/FhirModel.cs
+++ b/src/Spark.Engine/Core/FhirModel.cs
@@ -13,6 +13,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using static Hl7.Fhir.Model.ModelInfo;
+using SearchParameter = Spark.Engine.Model.SearchParameter;
 
 namespace Spark.Engine.Core;
 

--- a/src/Spark.Engine/Extensions/SearchParameterExtensions.cs
+++ b/src/Spark.Engine/Extensions/SearchParameterExtensions.cs
@@ -11,7 +11,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Hl7.Fhir.Rest;
-using SearchParameter = Spark.Engine.Core.SearchParameter;
+using SearchParameter = Spark.Engine.Model.SearchParameter;
 
 namespace Spark.Engine.Extensions;
 

--- a/src/Spark.Engine/Model/SearchParameter.cs
+++ b/src/Spark.Engine/Model/SearchParameter.cs
@@ -5,9 +5,10 @@
  */
 
 using Hl7.Fhir.Model;
+using Spark.Engine.Core;
 using System;
 
-namespace Spark.Engine.Core;
+namespace Spark.Engine.Model;
 
 public class SearchParameter : IEquatable<SearchParameter>
 {

--- a/src/Spark.Engine/Model/VersionIndependentResourceTypesAll.cs
+++ b/src/Spark.Engine/Model/VersionIndependentResourceTypesAll.cs
@@ -29,7 +29,7 @@
 
 using Hl7.Fhir.Utility;
 
-namespace Spark.Engine.Core;
+namespace Spark.Engine.Model;
 
 public enum VersionIndependentResourceTypesAll
   {

--- a/src/Spark.Engine/Service/FhirServiceExtensions/IndexService.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/IndexService.cs
@@ -21,7 +21,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using SearchParameter = Spark.Engine.Core.SearchParameter;
+using SearchParameter = Spark.Engine.Model.SearchParameter;
 using Task = System.Threading.Tasks.Task;
 
 namespace Spark.Engine.Service.FhirServiceExtensions;


### PR DESCRIPTION
Moves SearchParameter from Spark.Engine.Core to Spark.Engine.Model.