### PR TITLE
docker+ci: Optimize Dockerfile for faster builds with layer caching

### DIFF
--- a/.docker/linux/Mongo.Dockerfile
+++ b/.docker/linux/Mongo.Dockerfile
@@ -1,3 +1,7 @@
-﻿FROM mongo
+﻿
+FROM mongo:8.2.2
+
 COPY .docker/linux/r4.archive.gz /home/
 COPY .docker/linux/mongorestore.sh /docker-entrypoint-initdb.d/
+
+RUN chmod +x /docker-entrypoint-initdb.d/mongorestore.sh

--- a/.docker/linux/Spark.Dockerfile
+++ b/.docker/linux/Spark.Dockerfile
@@ -6,66 +6,41 @@ WORKDIR /app
 ENV ASPNETCORE_URLS=http://+:80
 
 
-# in this stage we install the build tools since we dont really need to reinstall them unless the base image changes.
 FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine AS build-deps
 
-# install node.js and npm for frontend.
 RUN apk add --no-cache nodejs npm
 
-# Separate npm install from npm build
-# package.json and package-lock.json change less frequently than source code. we do this to cache the layer across most code changes.
+
 FROM build-deps AS npm-restore
 
 WORKDIR /src/Spark.Web/ClientApp
 
-# to make sure the layer "fails" if dependencies are updated.
 COPY ["./src/Spark.Web/ClientApp/package.json", "./"]
 COPY ["./src/Spark.Web/ClientApp/package-lock.json", "./"]
 
-# we use 'npm ci' instead of 'npm install'
-# Faster than npm install
-# fra nett "Purpose: Designed for clean, consistent, and reproducible builds, 
-#especially in automated environments like Continuous Integration/Continuous Deployment (CI/CD) pipelines."
 RUN npm ci
 
 
-# Separate NuGet restore from build
-# .csproj files change less often than source code.
 FROM build-deps AS dotnet-restore
 
 WORKDIR /src
 
-# Copy Directory.Build.props first. contains shared build settings
-# required for restore to work (maybe haha)
 COPY ["./Directory.Build.props", "../Directory.Build.props"]
-
-# Copy .csproj files needed for restore
-# correct order
 COPY ["./src/Spark.Engine/Spark.Engine.csproj", "Spark.Engine/Spark.Engine.csproj"]
 COPY ["./src/Spark.Mongo/Spark.Mongo.csproj", "Spark.Mongo/Spark.Mongo.csproj"]
 COPY ["./src/Spark.Web/Spark.Web.csproj", "Spark.Web/Spark.Web.csproj"]
 
-# The slow operation restore output is cached.
 RUN dotnet restore "Spark.Web/Spark.Web.csproj"
 
 
-#####
-# under here we start building the actual application
-#####
-
-# This stage compiles the application. it will be invalidated on any code change. benefits from cached npm and NuGet packages from previous stages.
 FROM dotnet-restore AS build
 
 WORKDIR /src
 
-# copy cached node_modules from npm-restore stage
-# we don't need to run 'npm ci' again. just reuse the cached modules
 COPY --from=npm-restore /src/Spark.Web/ClientApp/node_modules ./Spark.Web/ClientApp/node_modules
 
-# copy frontend source files
 COPY ["./src/Spark.Web/ClientApp/", "Spark.Web/ClientApp/"]
 
-# this is the part that gets updated most often i think. so it's copied last
 COPY ["./src/Spark.Engine/", "Spark.Engine/"]
 COPY ["./src/Spark.Mongo/", "Spark.Mongo/"]
 COPY ["./src/Spark.Web/", "Spark.Web/"]
@@ -74,11 +49,10 @@ COPY ["./src/Spark-Legacy/Examples/", "Spark-Legacy/Examples/"]
 
 FROM build AS publish
 
-RUN dotnet publish "Spark.Web/Spark.Web.csproj" -c Release -o /app/publish --no-restore
+
+RUN dotnet publish "Spark.Web/Spark.Web.csproj" -c Release -o /app/publish --no-restore -p:NpmCiDone=true
 
 
-# final
-# no SDK, no source code
 FROM base AS final
 
 WORKDIR /app

--- a/.docker/linux/Spark.Dockerfile
+++ b/.docker/linux/Spark.Dockerfile
@@ -1,28 +1,88 @@
 FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine AS base
+
 RUN apk add --no-cache icu-libs
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
 WORKDIR /app
 ENV ASPNETCORE_URLS=http://+:80
 
-FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine AS build
+
+# in this stage we install the build tools since we dont really need to reinstall them unless the base image changes.
+FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine AS build-deps
+
+# install node.js and npm for frontend.
 RUN apk add --no-cache nodejs npm
 
+# Separate npm install from npm build
+# package.json and package-lock.json change less frequently than source code. we do this to cache the layer across most code changes.
+FROM build-deps AS npm-restore
+
+WORKDIR /src/Spark.Web/ClientApp
+
+# to make sure the layer "fails" if dependencies are updated.
+COPY ["./src/Spark.Web/ClientApp/package.json", "./"]
+COPY ["./src/Spark.Web/ClientApp/package-lock.json", "./"]
+
+# we use 'npm ci' instead of 'npm install'
+# Faster than npm install
+# fra nett "Purpose: Designed for clean, consistent, and reproducible builds, 
+#especially in automated environments like Continuous Integration/Continuous Deployment (CI/CD) pipelines."
+RUN npm ci
+
+
+# Separate NuGet restore from build
+# .csproj files change less often than source code.
+FROM build-deps AS dotnet-restore
+
 WORKDIR /src
+
+# Copy Directory.Build.props first. contains shared build settings
+# required for restore to work (maybe haha)
 COPY ["./Directory.Build.props", "../Directory.Build.props"]
-COPY ["./src/Spark.Web/Spark.Web.csproj", "Spark.Web/Spark.Web.csproj"]
+
+# Copy .csproj files needed for restore
+# correct order
 COPY ["./src/Spark.Engine/Spark.Engine.csproj", "Spark.Engine/Spark.Engine.csproj"]
 COPY ["./src/Spark.Mongo/Spark.Mongo.csproj", "Spark.Mongo/Spark.Mongo.csproj"]
-RUN dotnet restore "/src/Spark.Web/Spark.Web.csproj"
-COPY ./src .
+COPY ["./src/Spark.Web/Spark.Web.csproj", "Spark.Web/Spark.Web.csproj"]
+
+# The slow operation restore output is cached.
+RUN dotnet restore "Spark.Web/Spark.Web.csproj"
+
+
+#####
+# under here we start building the actual application
+#####
+
+# This stage compiles the application. it will be invalidated on any code change. benefits from cached npm and NuGet packages from previous stages.
+FROM dotnet-restore AS build
 
 WORKDIR /src
-RUN dotnet build "/src/Spark.Web/Spark.Web.csproj" -c Release -o /app
+
+# copy cached node_modules from npm-restore stage
+# we don't need to run 'npm ci' again. just reuse the cached modules
+COPY --from=npm-restore /src/Spark.Web/ClientApp/node_modules ./Spark.Web/ClientApp/node_modules
+
+# copy frontend source files
+COPY ["./src/Spark.Web/ClientApp/", "Spark.Web/ClientApp/"]
+
+# this is the part that gets updated most often i think. so it's copied last
+COPY ["./src/Spark.Engine/", "Spark.Engine/"]
+COPY ["./src/Spark.Mongo/", "Spark.Mongo/"]
+COPY ["./src/Spark.Web/", "Spark.Web/"]
+COPY ["./src/Spark-Legacy/Examples/", "Spark-Legacy/Examples/"]
+
 
 FROM build AS publish
-RUN dotnet publish "/src/Spark.Web/Spark.Web.csproj" -c Release -o /app
 
+RUN dotnet publish "Spark.Web/Spark.Web.csproj" -c Release -o /app/publish --no-restore
+
+
+# final
+# no SDK, no source code
 FROM base AS final
+
 WORKDIR /app
-COPY --from=publish /app .
+
+COPY --from=publish /app/publish .
 
 ENTRYPOINT ["dotnet", "Spark.Web.dll"]

--- a/.github/workflows/docker_image_linux.yml
+++ b/.github/workflows/docker_image_linux.yml
@@ -11,24 +11,54 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
+      
+      # Set up QEMU for cross-platform builds (ARM64 emulation on AMD64 runner)
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      
+      # Set up Docker Buildx for multi-platform builds
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      
       - name: Login to DockerHub Registry
-        run: echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      
       - name: Get the version
         id: vars
-        run: echo ::set-output name=tag::$(echo ${GITHUB_REF:10})
-      - name: Build the tagged Spark Docker image
-        run: docker build . --file .docker/linux/Spark.Dockerfile 
-          -t ${{ secrets.DOCKERHUB_ORGANIZATION }}/spark:${{steps.vars.outputs.tag}}
-          -t ${{ secrets.DOCKERHUB_ORGANIZATION }}/spark:r4-latest
-          -t ${{ secrets.DOCKERHUB_ORGANIZATION_2 }}/spark:${{steps.vars.outputs.tag}}
-          -t ${{ secrets.DOCKERHUB_ORGANIZATION_2 }}/spark:r4-latest
-      - name: Push the tagged Spark Docker image
-        run: docker push --all-tags ${{ secrets.DOCKERHUB_ORGANIZATION }}/spark
-      - name: Build the tagged Mongo Docker image
-        run: docker build . --file .docker/linux/Mongo.Dockerfile 
-          -t ${{ secrets.DOCKERHUB_ORGANIZATION }}/mongo:${{steps.vars.outputs.tag}}
-          -t ${{ secrets.DOCKERHUB_ORGANIZATION }}/mongo:r4-latest
-          -t ${{ secrets.DOCKERHUB_ORGANIZATION_2 }}/mongo:${{steps.vars.outputs.tag}}
-          -t ${{ secrets.DOCKERHUB_ORGANIZATION_2 }}/mongo:r4-latest
-      - name: Push the tagged Mongo Docker image
-        run: docker push --all-tags ${{ secrets.DOCKERHUB_ORGANIZATION }}/mongo
+        run: echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+      
+      # Build and push multi-arch Spark image
+      - name: Build and push Spark Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: .docker/linux/Spark.Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ secrets.DOCKERHUB_ORGANIZATION }}/spark:${{ steps.vars.outputs.tag }}
+            ${{ secrets.DOCKERHUB_ORGANIZATION }}/spark:r4-latest
+            ${{ secrets.DOCKERHUB_ORGANIZATION_2 }}/spark:${{ steps.vars.outputs.tag }}
+            ${{ secrets.DOCKERHUB_ORGANIZATION_2 }}/spark:r4-latest
+          # Cache layers
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      
+      # Build and push multi-arch image
+      - name: Build and push Mongo Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: .docker/linux/Mongo.Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ secrets.DOCKERHUB_ORGANIZATION }}/mongo:${{ steps.vars.outputs.tag }}
+            ${{ secrets.DOCKERHUB_ORGANIZATION }}/mongo:r4-latest
+            ${{ secrets.DOCKERHUB_ORGANIZATION_2 }}/mongo:${{ steps.vars.outputs.tag }}
+            ${{ secrets.DOCKERHUB_ORGANIZATION_2 }}/mongo:r4-latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/src/Spark.Web/Spark.Web.csproj
+++ b/src/Spark.Web/Spark.Web.csproj
@@ -35,11 +35,11 @@
 
   <!-- Build front-end assets before compilation -->
   <Target Name="BuildClientAssets" BeforeTargets="BeforeBuild" Condition="'$(Configuration)' == 'Release'">
-    <Exec Command="npm ci" WorkingDirectory="ClientApp" />
+    <Exec Command="npm ci" WorkingDirectory="ClientApp" Condition="'$(NpmCiDone)' != 'true'" />
     <Exec Command="npm run build" WorkingDirectory="ClientApp" />
   </Target>
   <Target Name="BuildClientAssetsDev" BeforeTargets="BeforeBuild" Condition="'$(Configuration)' == 'Debug'">
-    <Exec Command="npm ci" WorkingDirectory="ClientApp" />
+    <Exec Command="npm ci" WorkingDirectory="ClientApp" Condition="'$(NpmCiDone)' != 'true'" />
     <Exec Command="npm run build:dev" WorkingDirectory="ClientApp" />
   </Target>
   <!-- Clean front-end assets  -->


### PR DESCRIPTION
This PR refactors the [Spark.Dockerfile](https://github.com/FirelyTeam/spark/blob/r4/master/.docker/linux/Spark.Dockerfile), [Spark.Web.csproj](https://github.com/FirelyTeam/spark/blob/r4/master/src/Spark.Web/Spark.Web.csproj) to improve Docker build times.
[docker_image_linux.yml ](https://github.com/FirelyTeam/spark/blob/r4/master/.github/workflows/docker_image_linux.yml) was updated to be able to build docker images for arm64 and amd64 architecture.

for the docker file this was done:
- Separated dependency restoration into distinct stages (npm-restore and dotnet-restore)
- Reordered COPY instructions to maximize cache hits. Source code changes no longer invalidate the dependency cache
- Added --no-restore flag to the publish step to avoid redundant NuGet restore
- Reused cached node_modules from the npm-restore stage instead of reinstalling
- Added **-p:NpmCiDone=true** flag to dotnet publish to skip redundant npm ci in the csproj

for the spark.web.csproj file this was done:
- Added NpmCiDone condition to the npm ci command: **Condition="'$(NpmCiDone)' != 'true'"**
- When **NpmCiDone=true** is passed (from Docker), npm ci is skipped since node_modules already exists
- Local development remains unaffected. npm ci still runs normally when building outside Docker


