### PR TITLE
Spark.k8s: add kubernetes setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ curl 'https://raw.githubusercontent.com/FirelyTeam/spark/master/.docker/docker-c
 docker-compose up
 ```
 
+#### Kubernetes
+Deploy Spark to Kubernetes using Helm and k3d. See the [Kubernetes deployment guide](k8s/README.md) for instructions.
+
 ## Versions
 
 #### R4

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,248 @@
+# Running Spark FHIR Server on Kubernetes
+
+Deploy Spark FHIR server with MongoDB to Kubernetes using Helm.
+
+## Quick Start
+
+```bash
+# Install k3d
+# macOS
+brew install k3d
+# Windows (PowerShell)
+winget install k3d
+# Linux
+curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
+
+# Create cluster
+k3d cluster create spark-dev
+
+# Install Spark
+helm install spark ./k8s/helm/spark \
+  --set mongodb.auth.password=devpassword
+
+# Wait for pods to be ready
+kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=spark --timeout=120s
+
+# Access Spark
+kubectl port-forward svc/spark 8080:80
+curl http://localhost:8080/fhir/metadata
+```
+
+## Local Development
+
+### Run full stack in k3d
+
+```bash
+# Check status
+kubectl get pods
+
+# View Spark logs
+kubectl logs -f deployment/spark
+
+# View MongoDB logs
+kubectl logs -f statefulset/spark-mongodb
+
+# Shell into Spark pod
+kubectl exec -it deployment/spark -- /bin/sh
+
+# Shell into MongoDB
+kubectl exec -it spark-mongodb-0 -- mongosh
+
+# Uninstall
+helm uninstall spark
+
+# Delete cluster
+k3d cluster delete spark-dev
+```
+
+### Run MongoDB in k3d, Spark locally
+
+```bash
+# Install Spark without the web deployment
+helm install spark ./k8s/helm/spark \
+  --set mongodb.auth.password=devpassword \
+  --set replicaCount=0
+
+# Port forward MongoDB
+kubectl port-forward svc/spark-mongodb 27017:27017
+
+# Run Spark locally with hot reload
+cd src/Spark.Web
+dotnet watch run
+```
+
+### Build and test local image
+
+```bash
+# Build image
+docker build -t localhost:5000/spark:dev -f .docker/linux/Spark.Dockerfile .
+
+# Create cluster with registry
+k3d cluster create spark-dev --registry-create spark-registry:5000
+
+# Push to local registry
+docker push localhost:5000/spark:dev
+
+# Install with local image
+helm install spark ./k8s/helm/spark \
+  --set image.repository=localhost:5000/spark \
+  --set image.tag=dev \
+  --set mongodb.auth.password=devpassword
+```
+
+## Production
+
+### Prerequisites
+
+- **Traefik** ingress controller
+- **cert-manager** for automatic TLS certificates
+- **ClusterIssuer** e.g., `letsencrypt-prod`
+
+### Deploy with TLS
+
+```bash
+helm install spark ./k8s/helm/spark \
+  --namespace spark --create-namespace \
+  -f k8s/helm/spark/values-production.yaml \
+  --set mongodb.auth.password=$(openssl rand -base64 32) \
+  --set ingress.hosts[0].host=fhir.yourdomain.com \
+  --set ingress.tls[0].secretName=spark-tls \
+  --set ingress.tls[0].hosts[0]=fhir.yourdomain.com \
+  --set spark.endpoint=https://fhir.yourdomain.com/fhir
+```
+
+### DNS Setup
+
+Point your domain to the ingress controller's external IP or load balancer:
+
+```bash
+# Find the external IP/hostname
+kubectl get svc -n <ingress-namespace>  # Look for LoadBalancer type
+
+# Or for hostNetwork ingress, use node IPs
+kubectl get nodes -o wide
+```
+
+Create DNS records:
+- **A Record**: `fhir.yourdomain.com` → `<load-balancer-ip>`
+- **Or CNAME**: `fhir.yourdomain.com` → `<load-balancer-hostname>`
+
+### Verify TLS Certificate
+
+```bash
+# Check certificate status
+kubectl get certificate -n spark
+
+# Check certificate details
+kubectl describe certificate spark-tls -n spark
+```
+
+For production workloads, consider using an **external MongoDB** with proper backup and high availability.
+
+### Gateway API (Traefik with Gateway)
+
+If your cluster uses Traefik with **Gateway API** instead of standard Ingress, you'll need additional configuration.
+
+The Helm chart creates a standard Kubernetes Ingress, but Gateway API requires:
+
+1. **ReferenceGrant** - Allow the Gateway to access the TLS secret:
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: allow-traefik-gateway-spark-tls
+  namespace: spark
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      namespace: traefik
+  to:
+    - group: ""
+      kind: Secret
+      name: spark-tls
+```
+
+2. **Gateway listener** - Add HTTPS listener for your domain:
+
+```bash
+kubectl patch gateway traefik-gateway -n traefik --type=json -p='[
+  {"op": "add", "path": "/spec/listeners/-", "value": {
+    "name": "https-spark",
+    "port": 8443,
+    "protocol": "HTTPS",
+    "hostname": "fhir.yourdomain.com",
+    "tls": {
+      "mode": "Terminate",
+      "certificateRefs": [{"kind": "Secret", "name": "spark-tls", "namespace": "spark"}]
+    },
+    "allowedRoutes": {"namespaces": {"from": "All"}}
+  }}
+]'
+```
+
+3. **HTTPRoute** - Route traffic to Spark:
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: spark
+  namespace: spark
+spec:
+  parentRefs:
+    - name: traefik-gateway
+      namespace: traefik
+      sectionName: https-spark
+  hostnames:
+    - fhir.yourdomain.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: spark
+          port: 80
+```
+
+## Troubleshooting
+
+```bash
+# Check pod status
+kubectl get pods -n spark
+
+# View events
+kubectl get events -n spark --sort-by='.lastTimestamp'
+
+# Describe pod
+kubectl describe pod <pod-name> -n spark
+
+# Test MongoDB connection
+kubectl exec -it spark-mongodb-0 -n spark -- mongosh --eval "db.adminCommand('ping')"
+
+# Check Spark logs
+kubectl logs -f deployment/spark -n spark
+```
+
+### TLS Certificate Issues
+
+If you see "TRAEFIK DEFAULT CERT" instead of your Let's Encrypt certificate:
+
+1. Check if certificate is ready:
+   ```bash
+   kubectl get certificate -n spark
+   ```
+
+2. Verify the secret contains the correct cert:
+   ```bash
+   kubectl get secret spark-tls -n spark -o jsonpath='{.data.tls\.crt}' | \
+     base64 -d | openssl x509 -noout -subject -issuer
+   ```
+
+3. If using Gateway API, ensure ReferenceGrant and HTTPRoute are configured (see Gateway API section above).
+
+## Helm Chart Reference
+
+See [helm/spark/README.md](helm/spark/README.md) for full configuration options.

--- a/k8s/helm/spark/.helmignore
+++ b/k8s/helm/spark/.helmignore
@@ -1,0 +1,18 @@
+# Patterns to ignore when building packages.
+.DS_Store
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+.git
+.gitignore
+.bzr
+.bzrignore
+.hg
+.hgignore
+.svn
+*.tmproj
+.project
+.idea
+*.iml

--- a/k8s/helm/spark/Chart.yaml
+++ b/k8s/helm/spark/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: spark
+description: A Helm chart for Spark FHIR Server - an open source FHIR server for healthcare interoperability
+type: application
+version: 0.1.0
+appVersion: "r4-latest"
+home: https://github.com/FirelyTeam/spark
+sources:
+  - https://github.com/FirelyTeam/spark
+maintainers:
+  - name: FirelyTeam
+    url: https://github.com/FirelyTeam
+keywords:
+  - fhir
+  - healthcare
+  - hl7
+  - interoperability
+  - spark

--- a/k8s/helm/spark/README.md
+++ b/k8s/helm/spark/README.md
@@ -1,0 +1,235 @@
+# Spark FHIR Server Helm Chart
+
+Helm chart for deploying [Spark FHIR Server](https://github.com/FirelyTeam/spark) on Kubernetes.
+
+For getting started and local development, see the [k8s README](../../README.md).
+
+## Prerequisites
+
+- Kubernetes 1.19+
+- Helm 3.2.0+
+- PV provisioner support (if persistence is enabled)
+
+## Installation
+
+```bash
+helm install spark ./k8s/helm/spark \
+  --set mongodb.auth.password=<your-password>
+```
+
+### With Ingress
+
+```bash
+helm install spark ./k8s/helm/spark \
+  --set mongodb.auth.password=<your-password> \
+  --set ingress.enabled=true \
+  --set ingress.hosts[0].host=fhir.example.com \
+  --set spark.endpoint=https://fhir.example.com/fhir
+```
+
+### With TLS (cert-manager + Traefik)
+
+```bash
+helm install spark ./k8s/helm/spark \
+  --namespace spark --create-namespace \
+  --set mongodb.auth.password=<your-password> \
+  --set ingress.enabled=true \
+  --set ingress.hosts[0].host=fhir.example.com \
+  --set ingress.tls[0].secretName=spark-tls \
+  --set ingress.tls[0].hosts[0]=fhir.example.com \
+  --set spark.endpoint=https://fhir.example.com/fhir
+```
+
+### With External MongoDB
+
+```bash
+helm install spark ./k8s/helm/spark \
+  --set mongodb.enabled=false \
+  --set externalMongodb.connectionString="mongodb://user:pass@mongodb.example.com:27017/spark?authSource=admin"
+```
+
+### Uninstall
+
+```bash
+helm uninstall spark
+```
+
+## Configuration
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `replicaCount` | Number of Spark replicas | `1` |
+| `image.repository` | Spark image repository | `sparkfhir/spark` |
+| `image.tag` | Spark image tag | `r4-latest` |
+| `image.pullPolicy` | Image pull policy | `IfNotPresent` |
+| `spark.endpoint` | FHIR endpoint URL | `http://localhost:8080/fhir` |
+| `service.type` | Kubernetes service type | `ClusterIP` |
+| `service.port` | Service port | `80` |
+| `ingress.enabled` | Enable ingress | `false` |
+| `ingress.className` | Ingress class name | `traefik` |
+| `ingress.annotations` | Ingress annotations (e.g., cert-manager) | `{}` |
+| `ingress.hosts[].host` | Ingress hostname | **Required** when enabled |
+| `ingress.tls[].secretName` | TLS secret name | Required for HTTPS |
+| `ingress.tls[].hosts` | Hosts for TLS certificate | Required for HTTPS |
+| `resources.limits.memory` | Memory limit | `1Gi` |
+| `resources.limits.cpu` | CPU limit | `1000m` |
+| `resources.requests.memory` | Memory request | `256Mi` |
+| `resources.requests.cpu` | CPU request | `100m` |
+| `mongodb.enabled` | Deploy MongoDB | `true` |
+| `mongodb.auth.username` | MongoDB username | `spark` |
+| `mongodb.auth.password` | MongoDB password | Required unless `existingSecret` |
+| `mongodb.auth.existingSecret` | Use existing secret for credentials | `""` |
+| `mongodb.auth.existingSecretUsernameKey` | Key for username in secret | `MONGO_INITDB_ROOT_USERNAME` |
+| `mongodb.auth.existingSecretPasswordKey` | Key for password in secret | `MONGO_INITDB_ROOT_PASSWORD` |
+| `mongodb.persistence.enabled` | Enable persistence | `true` |
+| `mongodb.persistence.size` | PVC size | `5Gi` |
+| `mongodb.persistence.storageClass` | Storage class | `""` (default) |
+| `externalMongodb.connectionString` | External MongoDB URI | Required if `mongodb.enabled=false` |
+| `externalMongodb.existingSecret` | Use existing secret for connection string | `""` |
+| `externalMongodb.existingSecretKey` | Key in secret containing connection string | `connectionString` |
+| `extraEnvFrom` | Extra env vars from secrets/configmaps | `[]` |
+| `serviceAccount.create` | Create service account | `false` |
+| `serviceAccount.name` | Service account name | `""` (generated) |
+
+See [values.yaml](values.yaml) for all parameters.
+
+## Extra Environment Variables
+
+Inject additional configuration from secrets or configmaps using `extraEnvFrom`. This is useful for OAuth providers, API keys, or other sensitive settings that override `appsettings.json`.
+
+### Example: GitHub OAuth
+
+```bash
+# Create secret with GitHub OAuth credentials
+kubectl create secret generic spark-github-oauth -n spark \
+  --from-literal=GitHub__ClientId=your-client-id \
+  --from-literal=GitHub__ClientSecret=your-client-secret \
+  --from-literal=GitHub__AdminUsers__0=admin-user-1 \
+  --from-literal=GitHub__AdminUsers__1=admin-user-2
+
+# Deploy with extraEnvFrom
+helm upgrade spark ./k8s/helm/spark \
+  --set 'extraEnvFrom[0].secretRef.name=spark-github-oauth'
+```
+
+For Argo CD, add the parameter:
+```bash
+--helm-set 'extraEnvFrom[0].secretRef.name=spark-github-oauth'
+```
+
+**Note:** Use double underscores (`__`) to represent nested configuration keys. ASP.NET Core automatically maps `GitHub__ClientId` to `GitHub:ClientId`.
+
+## Helm Commands
+
+```bash
+# Lint
+helm lint ./k8s/helm/spark
+
+# Render templates
+helm template spark ./k8s/helm/spark
+
+# Dry run
+helm install spark ./k8s/helm/spark --dry-run --debug
+
+# Upgrade
+helm upgrade spark ./k8s/helm/spark --set mongodb.auth.password=<password>
+```
+
+## Argo CD
+
+Deploy with Argo CD for GitOps-based deployment. **Important:** Never pass passwords directly as Helm parameters - always use Kubernetes secrets.
+
+### Prerequisites
+
+Create secrets before deploying:
+
+```bash
+# Create namespace
+kubectl create namespace spark
+
+# Generate a secure password
+MONGO_PASSWORD=$(openssl rand -base64 24)
+
+# Create MongoDB credentials (used by MongoDB pod)
+kubectl create secret generic spark-mongodb-credentials \
+  --namespace spark \
+  --from-literal=MONGO_INITDB_ROOT_USERNAME=spark \
+  --from-literal=MONGO_INITDB_ROOT_PASSWORD="$MONGO_PASSWORD"
+
+# Create connection string secret (used by Spark to connect)
+# Note: URL-encode special characters in password
+ENCODED_PASSWORD=$(python3 -c "import urllib.parse; print(urllib.parse.quote('$MONGO_PASSWORD', safe=''))")
+kubectl create secret generic spark-mongodb-connection \
+  --namespace spark \
+  --from-literal=connectionString="mongodb://spark:${ENCODED_PASSWORD}@spark-mongodb.spark.svc.cluster.local:27017/spark?authSource=admin"
+```
+
+### Optional: GitHub OAuth
+
+```bash
+kubectl create secret generic spark-github-oauth -n spark \
+  --from-literal=GitHub__ClientId=your-client-id \
+  --from-literal=GitHub__ClientSecret=your-client-secret \
+  --from-literal=GitHub__AdminUsers__0=admin-user-1 \
+  --from-literal=GitHub__AdminUsers__1=admin-user-2
+```
+
+### Deploy with Argo CD CLI
+
+```bash
+argocd app create spark \
+  --repo https://github.com/FirelyTeam/spark.git \
+  --revision r4/master \
+  --path k8s/helm/spark \
+  --dest-server https://kubernetes.default.svc \
+  --dest-namespace spark \
+  --helm-set 'mongodb.auth.existingSecret=spark-mongodb-credentials' \
+  --helm-set 'externalMongodb.existingSecret=spark-mongodb-connection' \
+  --helm-set 'extraEnvFrom[0].secretRef.name=spark-github-oauth' \
+  --helm-set 'spark.endpoint=https://fhir.example.com/fhir' \
+  --sync-policy automated \
+  --self-heal
+```
+
+### Deploy with Application Manifest
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: spark
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/FirelyTeam/spark.git
+    targetRevision: r4/master
+    path: k8s/helm/spark
+    helm:
+      parameters:
+        - name: mongodb.auth.existingSecret
+          value: spark-mongodb-credentials
+        - name: externalMongodb.existingSecret
+          value: spark-mongodb-connection
+        - name: extraEnvFrom[0].secretRef.name
+          value: spark-github-oauth
+        - name: spark.endpoint
+          value: https://fhir.example.com/fhir
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: spark
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+```
+
+### Security Notes
+
+- **Never** pass `mongodb.auth.password` as a Helm parameter in Argo CD - it will be visible in the UI
+- Use `mongodb.auth.existingSecret` for MongoDB pod initialization
+- Use `externalMongodb.existingSecret` for Spark's connection string
+- Use `extraEnvFrom` for additional secrets (OAuth, API keys, etc.)
+- Create all secrets before deploying the Argo CD Application

--- a/k8s/helm/spark/templates/NOTES.txt
+++ b/k8s/helm/spark/templates/NOTES.txt
@@ -1,0 +1,37 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "spark.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "spark.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "spark.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "spark.fullname" . }} 8080:{{ .Values.service.port }}
+  echo "Visit http://localhost:8080/fhir/metadata to verify the installation"
+{{- end }}
+
+2. FHIR Capability Statement:
+   curl http://localhost:8080/fhir/metadata
+
+3. Create a Patient resource:
+   curl -X POST http://localhost:8080/fhir/Patient \
+     -H "Content-Type: application/fhir+json" \
+     -d '{"resourceType": "Patient", "name": [{"family": "Test", "given": ["User"]}]}'
+
+{{- if .Values.mongodb.enabled }}
+
+4. MongoDB is deployed as part of this release.
+   To connect to MongoDB:
+   kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "spark.mongodb.fullname" . }} 27017:27017
+{{- end }}
+
+For more information, visit: https://github.com/FirelyTeam/spark

--- a/k8s/helm/spark/templates/_helpers.tpl
+++ b/k8s/helm/spark/templates/_helpers.tpl
@@ -1,0 +1,110 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "spark.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "spark.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "spark.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "spark.labels" -}}
+helm.sh/chart: {{ include "spark.chart" . }}
+{{ include "spark.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "spark.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "spark.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "spark.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "spark.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+MongoDB full name
+*/}}
+{{- define "spark.mongodb.fullname" -}}
+{{- printf "%s-mongodb" (include "spark.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+MongoDB labels
+*/}}
+{{- define "spark.mongodb.labels" -}}
+helm.sh/chart: {{ include "spark.chart" . }}
+{{ include "spark.mongodb.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+MongoDB selector labels
+*/}}
+{{- define "spark.mongodb.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "spark.mongodb.fullname" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: database
+{{- end }}
+
+{{/*
+MongoDB secret name (uses existingSecret if set, otherwise generated name)
+*/}}
+{{- define "spark.mongodb.secretName" -}}
+{{- if .Values.mongodb.auth.existingSecret }}
+{{- .Values.mongodb.auth.existingSecret }}
+{{- else }}
+{{- printf "%s-credentials" (include "spark.mongodb.fullname" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+MongoDB connection string
+*/}}
+{{- define "spark.mongodb.connectionString" -}}
+{{- if .Values.mongodb.enabled }}
+{{- printf "mongodb://%s:%s@%s.%s.svc.cluster.local:%d/%s?authSource=admin" (.Values.mongodb.auth.username | urlquery) (.Values.mongodb.auth.password | urlquery) (include "spark.mongodb.fullname" .) .Release.Namespace (int .Values.mongodb.port) .Values.mongodb.auth.database }}
+{{- else }}
+{{- if not .Values.externalMongodb.connectionString }}
+{{- fail "externalMongodb.connectionString is required when mongodb.enabled=false" }}
+{{- end }}
+{{- .Values.externalMongodb.connectionString }}
+{{- end }}
+{{- end }}

--- a/k8s/helm/spark/templates/deployment.yaml
+++ b/k8s/helm/spark/templates/deployment.yaml
@@ -1,0 +1,78 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "spark.fullname" . }}
+  labels:
+    {{- include "spark.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "spark.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "spark.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: api
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ include "spark.serviceAccountName" . }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            - name: ASPNETCORE_URLS
+              value: "http://+:8080"
+            - name: SparkSettings__Endpoint
+              value: {{ .Values.spark.endpoint | quote }}
+            - name: StoreSettings__ConnectionString
+              valueFrom:
+                secretKeyRef:
+                  {{- if .Values.externalMongodb.existingSecret }}
+                  name: {{ .Values.externalMongodb.existingSecret }}
+                  key: {{ .Values.externalMongodb.existingSecretKey | default "connectionString" }}
+                  {{- else }}
+                  name: {{ include "spark.fullname" . }}-secrets
+                  key: mongodb-connection-string
+                  {{- end }}
+          {{- with .Values.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/k8s/helm/spark/templates/ingress.yaml
+++ b/k8s/helm/spark/templates/ingress.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.ingress.enabled -}}
+{{- range .Values.ingress.hosts }}
+{{- if not .host }}
+{{- fail "ingress.hosts[].host is required when ingress is enabled. Set it with --set ingress.hosts[0].host=fhir.example.com" }}
+{{- end }}
+{{- end }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "spark.fullname" . }}
+  labels:
+    {{- include "spark.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "spark.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/k8s/helm/spark/templates/mongodb-secret.yaml
+++ b/k8s/helm/spark/templates/mongodb-secret.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.mongodb.enabled }}
+{{- if and (not .Values.mongodb.auth.password) (not .Values.mongodb.auth.existingSecret) }}
+{{- fail "mongodb.auth.password is required. Set it with --set mongodb.auth.password=<your-password> or use mongodb.auth.existingSecret" }}
+{{- end }}
+{{- if not .Values.mongodb.auth.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "spark.mongodb.fullname" . }}-credentials
+  labels:
+    {{- include "spark.mongodb.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{ .Values.mongodb.auth.existingSecretUsernameKey }}: {{ .Values.mongodb.auth.username | quote }}
+  {{ .Values.mongodb.auth.existingSecretPasswordKey }}: {{ .Values.mongodb.auth.password | quote }}
+{{- end }}
+{{- end }}

--- a/k8s/helm/spark/templates/mongodb-service.yaml
+++ b/k8s/helm/spark/templates/mongodb-service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.mongodb.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "spark.mongodb.fullname" . }}
+  labels:
+    {{- include "spark.mongodb.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.mongodb.port }}
+      targetPort: mongodb
+      protocol: TCP
+      name: mongodb
+  selector:
+    {{- include "spark.mongodb.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/k8s/helm/spark/templates/mongodb-statefulset.yaml
+++ b/k8s/helm/spark/templates/mongodb-statefulset.yaml
@@ -1,0 +1,76 @@
+{{- if .Values.mongodb.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "spark.mongodb.fullname" . }}
+  labels:
+    {{- include "spark.mongodb.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "spark.mongodb.fullname" . }}
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "spark.mongodb.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "spark.mongodb.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: mongodb
+          image: "{{ .Values.mongodb.image.repository }}:{{ .Values.mongodb.image.tag }}"
+          imagePullPolicy: {{ .Values.mongodb.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.mongodb.port }}
+              name: mongodb
+          env:
+            - name: MONGO_INITDB_ROOT_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "spark.mongodb.secretName" . }}
+                  key: {{ .Values.mongodb.auth.existingSecretUsernameKey }}
+            - name: MONGO_INITDB_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "spark.mongodb.secretName" . }}
+                  key: {{ .Values.mongodb.auth.existingSecretPasswordKey }}
+          resources:
+            {{- toYaml .Values.mongodb.resources | nindent 12 }}
+          {{- if .Values.mongodb.persistence.enabled }}
+          volumeMounts:
+            - name: mongodb-data
+              mountPath: /data/db
+          {{- end }}
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - mongosh --username "$MONGO_INITDB_ROOT_USERNAME" --password "$MONGO_INITDB_ROOT_PASSWORD" --authenticationDatabase admin --eval "db.adminCommand('ping')"
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - mongosh --username "$MONGO_INITDB_ROOT_USERNAME" --password "$MONGO_INITDB_ROOT_PASSWORD" --authenticationDatabase admin --eval "db.adminCommand('ping')"
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+  {{- if .Values.mongodb.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: mongodb-data
+      spec:
+        accessModes: [ {{ .Values.mongodb.persistence.accessMode | quote }} ]
+        {{- if .Values.mongodb.persistence.storageClass }}
+        storageClassName: {{ .Values.mongodb.persistence.storageClass | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.mongodb.persistence.size }}
+  {{- end }}
+{{- end }}

--- a/k8s/helm/spark/templates/secret.yaml
+++ b/k8s/helm/spark/templates/secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "spark.fullname" . }}-secrets
+  labels:
+    {{- include "spark.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  mongodb-connection-string: {{ include "spark.mongodb.connectionString" . | quote }}

--- a/k8s/helm/spark/templates/service.yaml
+++ b/k8s/helm/spark/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "spark.fullname" . }}
+  labels:
+    {{- include "spark.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "spark.selectorLabels" . | nindent 4 }}

--- a/k8s/helm/spark/templates/serviceaccount.yaml
+++ b/k8s/helm/spark/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "spark.serviceAccountName" . }}
+  labels:
+    {{- include "spark.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/k8s/helm/spark/values-production.yaml
+++ b/k8s/helm/spark/values-production.yaml
@@ -1,0 +1,44 @@
+# Production values for Spark FHIR Server
+#
+# Usage:
+#   helm install spark ./k8s/helm/spark \
+#     --namespace spark --create-namespace \
+#     -f k8s/helm/spark/values-production.yaml \
+#     --set mongodb.auth.password=$(openssl rand -base64 32) \
+#     --set ingress.hosts[0].host=fhir.yourdomain.com \
+#     --set ingress.tls[0].secretName=spark-tls \
+#     --set ingress.tls[0].hosts[0]=fhir.yourdomain.com \
+#     --set spark.endpoint=https://fhir.yourdomain.com/fhir
+
+replicaCount: 2
+
+resources:
+  limits:
+    cpu: 2000m
+    memory: 2Gi
+  requests:
+    cpu: 250m
+    memory: 512Mi
+
+ingress:
+  enabled: true
+  className: traefik
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+  # hosts and tls must be set via --set flags (see usage above)
+
+mongodb:
+  enabled: true
+  auth:
+    username: spark
+    # password must be set via --set flag (see usage above)
+  persistence:
+    enabled: true
+    size: 50Gi
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 2Gi
+    requests:
+      cpu: 250m
+      memory: 512Mi

--- a/k8s/helm/spark/values.yaml
+++ b/k8s/helm/spark/values.yaml
@@ -1,0 +1,175 @@
+# Default values for Spark FHIR Server
+# This is a YAML-formatted file.
+
+# -- Number of Spark replicas
+replicaCount: 1
+
+image:
+  # -- Spark image repository
+  repository: sparkfhir/spark
+  # -- Image pull policy
+  pullPolicy: IfNotPresent
+  # -- Overrides the image tag (default is Chart appVersion)
+  tag: ""
+
+# -- Image pull secrets for private registries
+imagePullSecrets: []
+# -- Override the chart name
+nameOverride: ""
+# -- Override the full release name
+fullnameOverride: ""
+
+spark:
+  # -- FHIR endpoint URL (used in capability statement)
+  endpoint: "http://localhost:8080/fhir"
+
+# -- Extra environment variables from secrets or configmaps
+# Example:
+#   - secretRef:
+#       name: my-secret
+#   - configMapRef:
+#       name: my-configmap
+extraEnvFrom: []
+
+serviceAccount:
+  # -- Create a service account
+  create: false
+  # -- Annotations to add to the service account
+  annotations: {}
+  # -- The name of the service account (generated if not set)
+  name: ""
+
+# -- Pod annotations
+podAnnotations: {}
+
+# -- Pod security context
+podSecurityContext: {}
+  # fsGroup: 2000
+
+# -- Container security context
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  # -- Service type
+  type: ClusterIP
+  # -- Service port
+  port: 80
+
+ingress:
+  # -- Enable ingress
+  enabled: false
+  # -- Ingress class name
+  className: "traefik"
+  # -- Ingress annotations
+  annotations: {}
+    # For TLS with cert-manager:
+    # cert-manager.io/cluster-issuer: letsencrypt-prod
+  # -- Ingress hosts (REQUIRED when ingress.enabled=true)
+  hosts:
+    - host: ""  # Set your domain, e.g., fhir.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  # -- TLS configuration (required for HTTPS)
+  tls: []
+    # - secretName: spark-tls
+    #   hosts:
+    #     - fhir.example.com
+
+resources:
+  limits:
+    cpu: 1000m
+    memory: 1Gi
+  requests:
+    cpu: 100m
+    memory: 256Mi
+
+# -- Liveness probe configuration
+livenessProbe:
+  httpGet:
+    path: /fhir/metadata
+    port: http
+  initialDelaySeconds: 30
+  periodSeconds: 30
+  timeoutSeconds: 10
+
+# -- Readiness probe configuration
+readinessProbe:
+  httpGet:
+    path: /fhir/metadata
+    port: http
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 5
+
+# -- Node selector
+nodeSelector: {}
+
+# -- Tolerations
+tolerations: []
+
+# -- Affinity rules
+affinity: {}
+
+# MongoDB configuration
+mongodb:
+  # -- Enable built-in MongoDB (disable if using external MongoDB)
+  enabled: true
+  
+  image:
+    # -- MongoDB image repository
+    repository: sparkfhir/mongo
+    # -- MongoDB image tag
+    tag: "r4-latest"
+    # -- Image pull policy
+    pullPolicy: IfNotPresent
+  
+  auth:
+    # -- MongoDB root username
+    username: spark
+    # -- MongoDB root password (REQUIRED unless existingSecret is set)
+    password: ""
+    # -- MongoDB database name
+    database: spark
+    # -- Use existing secret for MongoDB credentials (must have MONGO_INITDB_ROOT_USERNAME and MONGO_INITDB_ROOT_PASSWORD keys)
+    existingSecret: ""
+    # -- Key in existingSecret for username
+    existingSecretUsernameKey: "MONGO_INITDB_ROOT_USERNAME"
+    # -- Key in existingSecret for password
+    existingSecretPasswordKey: "MONGO_INITDB_ROOT_PASSWORD"
+  
+  # -- MongoDB service port
+  port: 27017
+  
+  persistence:
+    # -- Enable persistence
+    enabled: true
+    # -- Storage class (empty = default)
+    storageClass: ""
+    # -- PVC access mode
+    accessMode: ReadWriteOnce
+    # -- PVC size
+    size: 5Gi
+  
+  resources:
+    limits:
+      cpu: 500m
+      memory: 1Gi
+    requests:
+      cpu: 100m
+      memory: 256Mi
+
+# External MongoDB (used when mongodb.enabled=false)
+externalMongodb:
+  # -- Full MongoDB connection string (only used if existingSecret is not set)
+  connectionString: ""
+  # -- Use existing secret containing connection string
+  existingSecret: ""
+  # -- Key in existingSecret containing connection string
+  existingSecretKey: "connectionString"

--- a/src/Spark.Web/Settings/appsettings.json
+++ b/src/Spark.Web/Settings/appsettings.json
@@ -3,7 +3,8 @@
         "DefaultConnection": "Data Source=database.db"
     },
     "StoreSettings": {
-        "ConnectionString": "mongodb://localhost:27017/spark"
+        "_comment": "Local development only. Do NOT use these credentials in production.",
+        "ConnectionString": "mongodb://spark:spark@localhost:27017/spark?authSource=admin"
     },
     "SparkSettings": {
         "Endpoint": "https://localhost:5001/fhir"


### PR DESCRIPTION
This change introduces a structured Kubernetes setup for Spark FHIR. MongoDB is configured as a StatefulSet with Service and Secrets for persistent storage and secure configuration. Spark Web is deployed using Deployment, Service, ConfigMap, and Secrets.

This also provides an easy way to spin up a Mongo db database for local development.

This also adds Helm chart for Spark FHIR Server, including templates and configuration files. This makes it possible to get started with testing Spark even faster.