### PR TITLE
Auth: Add OAuth 2.0 foundation with OpenIddict

### DIFF
--- a/.docker/linux/Spark.Dockerfile
+++ b/.docker/linux/Spark.Dockerfile
@@ -26,6 +26,7 @@ FROM build-deps AS dotnet-restore
 WORKDIR /src
 
 COPY ["./Directory.Build.props", "../Directory.Build.props"]
+COPY ["./src/Spark.Auth/Spark.Auth.csproj", "Spark.Auth/Spark.Auth.csproj"]
 COPY ["./src/Spark.Engine/Spark.Engine.csproj", "Spark.Engine/Spark.Engine.csproj"]
 COPY ["./src/Spark.Mongo/Spark.Mongo.csproj", "Spark.Mongo/Spark.Mongo.csproj"]
 COPY ["./src/Spark.Web/Spark.Web.csproj", "Spark.Web/Spark.Web.csproj"]
@@ -41,6 +42,7 @@ COPY --from=npm-restore /src/Spark.Web/app/node_modules ./Spark.Web/app/node_mod
 
 COPY ["./src/Spark.Web/app/", "Spark.Web/app/"]
 
+COPY ["./src/Spark.Auth/", "Spark.Auth/"]
 COPY ["./src/Spark.Engine/", "Spark.Engine/"]
 COPY ["./src/Spark.Mongo/", "Spark.Mongo/"]
 COPY ["./src/Spark.Web/", "Spark.Web/"]

--- a/.gitignore
+++ b/.gitignore
@@ -238,3 +238,6 @@ NDependOut/
 src/Spark/libmongocrypt.dylib
 src/Spark/libmongocrypt.so
 src/Spark/mongocrypt.dll
+
+# certs
+certs/

--- a/Spark.sln
+++ b/Spark.sln
@@ -94,6 +94,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ADR", "ADR", "{B8801E70-5B1
 		Documentation\ADR\0003-SMART.md = Documentation\ADR\0003-SMART.md
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Spark.Auth", "src\Spark.Auth\Spark.Auth.csproj", "{90AFD227-CC6D-489D-89AB-46FAF3CF4FA3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -124,6 +126,10 @@ Global
 		{DFC6C41A-7545-4256-8A2C-CBD6EC43541E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DFC6C41A-7545-4256-8A2C-CBD6EC43541E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DFC6C41A-7545-4256-8A2C-CBD6EC43541E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{90AFD227-CC6D-489D-89AB-46FAF3CF4FA3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{90AFD227-CC6D-489D-89AB-46FAF3CF4FA3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{90AFD227-CC6D-489D-89AB-46FAF3CF4FA3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{90AFD227-CC6D-489D-89AB-46FAF3CF4FA3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -138,6 +144,7 @@ Global
 		{C6DB166C-ACF5-4AEF-A99A-C201CCD91736} = {073444E3-56AE-4904-8EBD-DED0F9B54499}
 		{977F2FE5-C232-4F93-AA0A-73DB85A20879} = {073444E3-56AE-4904-8EBD-DED0F9B54499}
 		{B8801E70-5B13-4970-B285-B8DD952B9602} = {C6DB166C-ACF5-4AEF-A99A-C201CCD91736}
+		{90AFD227-CC6D-489D-89AB-46FAF3CF4FA3} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B5F4527D-CCCF-4487-9E2D-D324DF3552E8}

--- a/src/Spark.Auth/Controllers/AuthorizationController.cs
+++ b/src/Spark.Auth/Controllers/AuthorizationController.cs
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2026, Incendi <info@incendi.no>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using OpenIddict.Abstractions;
+using OpenIddict.Server.AspNetCore;
+using static OpenIddict.Abstractions.OpenIddictConstants;
+
+namespace Spark.Auth.Controllers;
+
+[ApiController]
+public class AuthorizationController : ControllerBase
+{
+    private readonly IOpenIddictApplicationManager _applicationManager;
+    private readonly IAuthenticationSchemeProvider _authenticationSchemeProvider;
+
+    public AuthorizationController(
+        IOpenIddictApplicationManager applicationManager,
+        IAuthenticationSchemeProvider authenticationSchemeProvider)
+    {
+        _applicationManager = applicationManager;
+        _authenticationSchemeProvider = authenticationSchemeProvider;
+    }
+
+    [HttpGet("~/connect/authorize")]
+    [HttpPost("~/connect/authorize")]
+    public async Task<IActionResult> Authorize()
+    {
+        var request = HttpContext.GetOpenIddictServerRequest()
+            ?? throw new InvalidOperationException("The OpenID Connect request cannot be retrieved.");
+
+        // Try to retrieve the user principal stored in the authentication cookie.
+        var result = await HttpContext.AuthenticateAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+
+        if (!result.Succeeded)
+        {
+            return await ChallengeInteractiveLoginAsync();
+        }
+
+        var identity = CreateUserIdentity(result.Principal!, request.GetScopes());
+
+        return SignIn(new ClaimsPrincipal(identity), OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
+    }
+
+    [HttpPost("~/connect/token")]
+    public async Task<IActionResult> Exchange()
+    {
+        var request = HttpContext.GetOpenIddictServerRequest()
+            ?? throw new InvalidOperationException("The OpenID Connect request cannot be retrieved.");
+
+        if (request.IsClientCredentialsGrantType())
+        {
+            var application = await _applicationManager.FindByClientIdAsync(request.ClientId!)
+                ?? throw new InvalidOperationException("The application details cannot be found.");
+
+            var identity = new ClaimsIdentity(
+                OpenIddictServerAspNetCoreDefaults.AuthenticationScheme,
+                Claims.Name, Claims.Role);
+
+            identity.SetClaim(Claims.Subject, await _applicationManager.GetClientIdAsync(application));
+            identity.SetClaim(Claims.Name, await _applicationManager.GetDisplayNameAsync(application));
+
+            identity.SetScopes(request.GetScopes());
+            identity.SetDestinations(static claim => [Destinations.AccessToken]);
+
+            return SignIn(new ClaimsPrincipal(identity), OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
+        }
+
+        if (request.IsAuthorizationCodeGrantType() || request.IsRefreshTokenGrantType())
+        {
+            var principal = (await HttpContext.AuthenticateAsync(OpenIddictServerAspNetCoreDefaults.AuthenticationScheme)).Principal
+                ?? throw new InvalidOperationException("The authorization code or refresh token is no longer valid.");
+
+            return SignIn(principal, OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
+        }
+
+        throw new InvalidOperationException("The specified grant type is not supported.");
+    }
+
+    [HttpGet("~/connect/endsession")]
+    [HttpPost("~/connect/endsession")]
+    public async Task<IActionResult> EndSession()
+    {
+        await HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+
+        return SignOut(
+            authenticationSchemes: OpenIddictServerAspNetCoreDefaults.AuthenticationScheme,
+            properties: new AuthenticationProperties { RedirectUri = "/" });
+    }
+
+    private async Task<IActionResult> ChallengeInteractiveLoginAsync()
+    {
+        var challengeScheme = await _authenticationSchemeProvider.GetDefaultChallengeSchemeAsync();
+        if (challengeScheme is null || string.Equals(challengeScheme.Name, CookieAuthenticationDefaults.AuthenticationScheme, StringComparison.Ordinal))
+        {
+            return BadRequest(new
+            {
+                error = Errors.InvalidRequest,
+                error_description = "Interactive login is not configured for the authorization endpoint. Configure GitHub OAuth or use client_credentials."
+            });
+        }
+
+        return Challenge(
+            authenticationSchemes: challengeScheme.Name,
+            properties: new AuthenticationProperties
+            {
+                RedirectUri = Request.PathBase + Request.Path + QueryString.Create(
+                    Request.HasFormContentType ? Request.Form.ToList() : Request.Query.ToList())
+            });
+    }
+
+    private static ClaimsIdentity CreateUserIdentity(ClaimsPrincipal principal, IEnumerable<string> scopes)
+    {
+        var claims = new List<Claim>
+        {
+            new(Claims.Subject, principal.FindFirstValue(ClaimTypes.NameIdentifier)
+                ?? principal.FindFirstValue(ClaimTypes.Name)
+                ?? throw new InvalidOperationException("The user identifier cannot be found.")),
+            new(Claims.Name, principal.FindFirstValue(ClaimTypes.Name) ?? ""),
+        };
+
+        var email = principal.FindFirstValue(ClaimTypes.Email);
+        if (!string.IsNullOrEmpty(email))
+        {
+            claims.Add(new Claim(Claims.Email, email));
+        }
+
+        var identity = new ClaimsIdentity(claims, OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
+        identity.SetScopes(scopes);
+        identity.SetDestinations(GetClaimDestinations);
+        return identity;
+    }
+
+    private static IEnumerable<string> GetClaimDestinations(Claim claim)
+    {
+        // Include identity claims in id_token only when corresponding OIDC scopes were granted.
+        if (claim.Type == Claims.Name && claim.Subject?.HasScope(Scopes.Profile) is true)
+            return [Destinations.AccessToken, Destinations.IdentityToken];
+
+        if (claim.Type == Claims.Email && claim.Subject?.HasScope(Scopes.Email) is true)
+            return [Destinations.AccessToken, Destinations.IdentityToken];
+
+        return [Destinations.AccessToken];
+    }
+}

--- a/src/Spark.Auth/Controllers/SmartConfigurationController.cs
+++ b/src/Spark.Auth/Controllers/SmartConfigurationController.cs
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026, Incendi <info@incendi.no>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+using System;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using System.Text.Json.Serialization;
+
+namespace Spark.Auth.Controllers;
+
+/// <summary>
+/// Serves the SMART App Launch configuration document.
+/// See: https://build.fhir.org/ig/HL7/smart-app-launch/conformance.html
+/// </summary>
+[ApiController]
+public class SmartConfigurationController : ControllerBase
+{
+    private readonly IConfiguration _configuration;
+
+    public SmartConfigurationController(IConfiguration configuration)
+    {
+        _configuration = configuration;
+    }
+
+    [HttpGet("~/.well-known/smart-configuration")]
+    public IActionResult GetConfiguration()
+    {
+        var baseUrl = ResolvePublicBaseUrl();
+
+        return Ok(new SmartConfigurationResponse
+        {
+            Issuer = baseUrl,
+            AuthorizationEndpoint = $"{baseUrl}/connect/authorize",
+            TokenEndpoint = $"{baseUrl}/connect/token",
+            TokenEndpointAuthMethodsSupported = ["client_secret_post", "client_secret_basic"],
+            GrantTypesSupported = ["authorization_code", "client_credentials"],
+            ScopesSupported = ["openid", "email", "profile", "offline_access"],
+            ResponseTypesSupported = ["code"],
+            Capabilities = ["launch-standalone", "client-confidential-symmetric"],
+            CodeChallengeMethodsSupported = ["S256"],
+        });
+    }
+
+    private string ResolvePublicBaseUrl()
+    {
+        var endpoint = _configuration["SparkSettings:Endpoint"];
+        if (Uri.TryCreate(endpoint, UriKind.Absolute, out var endpointUri))
+        {
+            var basePath = endpointUri.AbsolutePath.TrimEnd('/');
+            if (basePath.EndsWith("/fhir", StringComparison.OrdinalIgnoreCase))
+            {
+                basePath = basePath[..^5];
+            }
+
+            return $"{endpointUri.Scheme}://{endpointUri.Authority}{basePath}";
+        }
+
+        return $"{Request.Scheme}://{Request.Host}{Request.PathBase}";
+    }
+
+    private sealed class SmartConfigurationResponse
+    {
+        [JsonPropertyName("issuer")]
+        public string Issuer { get; init; } = string.Empty;
+
+        [JsonPropertyName("authorization_endpoint")]
+        public string AuthorizationEndpoint { get; init; } = string.Empty;
+
+        [JsonPropertyName("token_endpoint")]
+        public string TokenEndpoint { get; init; } = string.Empty;
+
+        [JsonPropertyName("token_endpoint_auth_methods_supported")]
+        public string[] TokenEndpointAuthMethodsSupported { get; init; } = [];
+
+        [JsonPropertyName("grant_types_supported")]
+        public string[] GrantTypesSupported { get; init; } = [];
+
+        [JsonPropertyName("scopes_supported")]
+        public string[] ScopesSupported { get; init; } = [];
+
+        [JsonPropertyName("response_types_supported")]
+        public string[] ResponseTypesSupported { get; init; } = [];
+
+        [JsonPropertyName("capabilities")]
+        public string[] Capabilities { get; init; } = [];
+
+        [JsonPropertyName("code_challenge_methods_supported")]
+        public string[] CodeChallengeMethodsSupported { get; init; } = [];
+    }
+}

--- a/src/Spark.Auth/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Spark.Auth/Extensions/IServiceCollectionExtensions.cs
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026, Incendi <info@incendi.no>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+using Microsoft.Extensions.DependencyInjection;
+using MongoDB.Driver;
+using Spark.Auth.Workers;
+
+namespace Spark.Auth.Extensions;
+
+public static class IServiceCollectionExtensions
+{
+    public static IServiceCollection AddSparkAuth(this IServiceCollection services, SmartAuthSettings settings, string mongoConnectionString)
+    {
+        services.Configure<SmartAuthSettings>(options =>
+        {
+            options.Enabled = settings.Enabled;
+            options.Clients = settings.Clients;
+        });
+
+        services.AddOpenIddict()
+            .AddCore(options =>
+            {
+                options.UseMongoDb()
+                    .UseDatabase(new MongoClient(mongoConnectionString)
+                        .GetDatabase(MongoUrl.Create(mongoConnectionString).DatabaseName));
+            })
+            .AddServer(options =>
+            {
+                options
+                    .SetAuthorizationEndpointUris("connect/authorize")
+                    .SetTokenEndpointUris("connect/token")
+                    .SetEndSessionEndpointUris("connect/endsession");
+
+                options
+                    .AllowAuthorizationCodeFlow()
+                    .AllowClientCredentialsFlow()
+                    .AllowRefreshTokenFlow();
+
+                // Register signing and encryption credentials for development.
+                // In production, use .AddSigningCertificate() and .AddEncryptionCertificate().
+                options
+                    .AddDevelopmentEncryptionCertificate()
+                    .AddDevelopmentSigningCertificate();
+
+                options
+                    .UseAspNetCore()
+                    .EnableAuthorizationEndpointPassthrough()
+                    .EnableTokenEndpointPassthrough()
+                    .EnableEndSessionEndpointPassthrough();
+            })
+            .AddValidation(options =>
+            {
+                options.UseLocalServer();
+                options.UseAspNetCore();
+            });
+
+        services.AddHostedService<ClientSyncWorker>();
+
+        return services;
+    }
+}

--- a/src/Spark.Auth/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Spark.Auth/Extensions/IServiceCollectionExtensions.cs
@@ -4,20 +4,29 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+using System;
+using System.IO;
+using System.Security.Cryptography.X509Certificates;
 using Microsoft.Extensions.DependencyInjection;
 using MongoDB.Driver;
+using OpenIddict.Server;
 using Spark.Auth.Workers;
 
 namespace Spark.Auth.Extensions;
 
 public static class IServiceCollectionExtensions
 {
-    public static IServiceCollection AddSparkAuth(this IServiceCollection services, SmartAuthSettings settings, string mongoConnectionString)
+    public static IServiceCollection AddSparkAuth(
+        this IServiceCollection services,
+        SmartAuthSettings settings,
+        string mongoConnectionString,
+        bool useDevelopmentCertificates)
     {
         services.Configure<SmartAuthSettings>(options =>
         {
             options.Enabled = settings.Enabled;
             options.Clients = settings.Clients;
+            options.Endpoints = settings.Endpoints;
         });
 
         services.AddOpenIddict()
@@ -27,30 +36,7 @@ public static class IServiceCollectionExtensions
                     .UseDatabase(new MongoClient(mongoConnectionString)
                         .GetDatabase(MongoUrl.Create(mongoConnectionString).DatabaseName));
             })
-            .AddServer(options =>
-            {
-                options
-                    .SetAuthorizationEndpointUris("connect/authorize")
-                    .SetTokenEndpointUris("connect/token")
-                    .SetEndSessionEndpointUris("connect/endsession");
-
-                options
-                    .AllowAuthorizationCodeFlow()
-                    .AllowClientCredentialsFlow()
-                    .AllowRefreshTokenFlow();
-
-                // Register signing and encryption credentials for development.
-                // In production, use .AddSigningCertificate() and .AddEncryptionCertificate().
-                options
-                    .AddDevelopmentEncryptionCertificate()
-                    .AddDevelopmentSigningCertificate();
-
-                options
-                    .UseAspNetCore()
-                    .EnableAuthorizationEndpointPassthrough()
-                    .EnableTokenEndpointPassthrough()
-                    .EnableEndSessionEndpointPassthrough();
-            })
+            .AddServer(options => ConfigureOpenIdServer(options, settings, useDevelopmentCertificates))
             .AddValidation(options =>
             {
                 options.UseLocalServer();
@@ -60,5 +46,83 @@ public static class IServiceCollectionExtensions
         services.AddHostedService<ClientSyncWorker>();
 
         return services;
+    }
+
+    private static void ConfigureOpenIdServer(OpenIddictServerBuilder options, SmartAuthSettings settings, bool useDevelopmentCertificates)
+    {
+        var endpointSettings = settings.Endpoints ?? new SmartAuthEndpointSettings();
+
+        options
+            .SetAuthorizationEndpointUris(NormalizeAndValidateEndpointPath(
+                endpointSettings.AuthorizationEndpointPath,
+                "SmartAuth:Endpoints:AuthorizationEndpointPath"))
+            .SetTokenEndpointUris(NormalizeAndValidateEndpointPath(
+                endpointSettings.TokenEndpointPath,
+                "SmartAuth:Endpoints:TokenEndpointPath"))
+            .SetEndSessionEndpointUris(NormalizeAndValidateEndpointPath(
+                endpointSettings.EndSessionEndpointPath,
+                "SmartAuth:Endpoints:EndSessionEndpointPath"))
+            .AllowAuthorizationCodeFlow()
+            .AllowClientCredentialsFlow()
+            .AllowRefreshTokenFlow();
+
+        ConfigureTokenCertificates(options, settings, useDevelopmentCertificates);
+
+        options
+            .UseAspNetCore()
+            .EnableAuthorizationEndpointPassthrough()
+            .EnableTokenEndpointPassthrough()
+            .EnableEndSessionEndpointPassthrough();
+    }
+
+    private static void ConfigureTokenCertificates(OpenIddictServerBuilder options, SmartAuthSettings settings, bool useDevelopmentCertificates)
+    {
+        if (useDevelopmentCertificates)
+        {
+            options
+                .AddDevelopmentEncryptionCertificate()
+                .AddDevelopmentSigningCertificate();
+
+            return;
+        }
+
+        var signingCertificate = LoadCertificate(
+            settings.Certificates.SigningCertificatePath,
+            settings.Certificates.SigningCertificatePassword,
+            "SmartAuth:Certificates:SigningCertificatePath");
+
+        var encryptionCertificate = LoadCertificate(
+            settings.Certificates.EncryptionCertificatePath,
+            settings.Certificates.EncryptionCertificatePassword,
+            "SmartAuth:Certificates:EncryptionCertificatePath");
+
+        options
+            .AddSigningCertificate(signingCertificate)
+            .AddEncryptionCertificate(encryptionCertificate);
+    }
+
+    private static X509Certificate2 LoadCertificate(string path, string password, string settingName)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            throw new InvalidOperationException($"Missing required configuration value: {settingName}.");
+        }
+
+        if (!File.Exists(path))
+        {
+            throw new InvalidOperationException($"Certificate file not found at configured path '{path}' ({settingName}).");
+        }
+
+        return X509CertificateLoader.LoadPkcs12FromFile(path, password, X509KeyStorageFlags.EphemeralKeySet);
+    }
+
+    private static string NormalizeAndValidateEndpointPath(string configuredPath, string settingName)
+    {
+        if (string.IsNullOrWhiteSpace(configuredPath))
+        {
+            throw new InvalidOperationException($"Invalid endpoint path in {settingName}. Value cannot be empty or whitespace.");
+        }
+
+        return configuredPath.Trim().TrimStart('/');
     }
 }

--- a/src/Spark.Auth/README.md
+++ b/src/Spark.Auth/README.md
@@ -1,0 +1,49 @@
+# Spark.Auth
+
+OpenIddict-based OAuth 2.0 / OpenID Connect authorization server for Spark FHIR Server.
+
+## Quick Start
+
+### 1. Enable in appsettings.json
+
+Enable the SMART on FHIR authorization server and define clients in `appsettings.json`.
+
+### 2. Run the server
+
+Clients defined in config are automatically created in MongoDB on startup if they don't already exist.
+
+### 3. Endpoints
+
+| Endpoint | URL |
+| --- | --- |
+| Authorization | `GET /connect/authorize` |
+| Token | `POST /connect/token` |
+| End Session | `GET /connect/endsession` |
+| Discovery | `GET /.well-known/openid-configuration` |
+| SMART Configuration | `GET /.well-known/smart-configuration` |
+
+### 4. Test with client credentials
+
+```bash
+curl -X POST https://localhost:5001/connect/token \
+  -d grant_type=client_credentials \
+  -d client_id=smart-app \
+  -d client_secret=SET_VIA_USER_SECRETS_OR_ENV
+```
+
+## Client Configuration
+
+| Property | Required | Default | Description |
+| --- | --- | --- | --- |
+| `ClientId` | Yes | | OAuth client identifier |
+| `ClientSecret` | No | | Client secret (omit for public clients) |
+| `DisplayName` | No | ClientId | Human-readable name |
+| `RedirectUris` | No | `[]` | Allowed redirect URIs |
+| `PostLogoutRedirectUris` | No | `[]` | Allowed post-logout redirect URIs |
+| `Scopes` | No | `[]` | Permitted scopes (`openid`, `email`, `profile`, `offline_access`, `roles`, or custom) |
+| `GrantTypes` | No | `[]` | Permitted grants (`authorization_code`, `client_credentials`, `refresh_token`) |
+| `RequirePkce` | No | `true` | Require PKCE for authorization code flow |
+
+## Architecture
+
+See [ADR-0003](../../Documentation/ADR/0003-SMART.md) for design decisions and roadmap toward SMART on FHIR support.

--- a/src/Spark.Auth/README.md
+++ b/src/Spark.Auth/README.md
@@ -8,6 +8,41 @@ OpenIddict-based OAuth 2.0 / OpenID Connect authorization server for Spark FHIR 
 
 Enable the SMART on FHIR authorization server and define clients in `appsettings.json`.
 
+For production (non-Development environment), also configure signing and encryption certificates:
+
+```json
+{
+  "SmartAuth": {
+    "Enabled": true,
+    "AuthConnectionString": "mongodb://localhost:27017/spark-auth",
+    "Certificates": {
+      "SigningCertificatePath": "/path/to/signing.pfx",
+      "SigningCertificatePassword": "<password>",
+      "EncryptionCertificatePath": "/path/to/encryption.pfx",
+      "EncryptionCertificatePassword": "<password>"
+    }
+  }
+}
+```
+
+`SmartAuth:AuthConnectionString` is optional. If omitted, Spark.Auth uses `StoreSettings:ConnectionString`.
+
+Optional endpoint overrides:
+
+```json
+{
+  "SmartAuth": {
+    "Endpoints": {
+      "AuthorizationEndpointPath": "connect/authorize",
+      "TokenEndpointPath": "connect/token",
+      "EndSessionEndpointPath": "connect/endsession"
+    }
+  }
+}
+```
+
+If omitted, Spark.Auth uses `connect/authorize`, `connect/token`, and `connect/endsession`.
+
 ### 2. Run the server
 
 Clients defined in config are automatically created in MongoDB on startup if they don't already exist.
@@ -43,6 +78,21 @@ curl -X POST https://localhost:5001/connect/token \
 | `Scopes` | No | `[]` | Permitted scopes (`openid`, `email`, `profile`, `offline_access`, `roles`, or custom) |
 | `GrantTypes` | No | `[]` | Permitted grants (`authorization_code`, `client_credentials`, `refresh_token`) |
 | `RequirePkce` | No | `true` | Require PKCE for authorization code flow |
+
+## Certificate setup
+
+Development uses OpenIddict development certificates automatically. In non-Development environments, Spark.Auth requires configured PFX certificates for signing and encryption.
+
+Quick OpenSSL setup:
+
+```bash
+openssl req -x509 -newkey rsa:2048 -keyout signing.key -out signing.crt -days 365 -nodes -subj "/CN=Spark FHIR Signing"
+openssl pkcs12 -export -out signing.pfx -inkey signing.key -in signing.crt -passout pass:changeit
+openssl req -x509 -newkey rsa:2048 -keyout encryption.key -out encryption.crt -days 365 -nodes -subj "/CN=Spark FHIR Encryption"
+openssl pkcs12 -export -out encryption.pfx -inkey encryption.key -in encryption.crt -passout pass:changeit
+```
+
+Then set `SmartAuth:Certificates:*Path` and `*Password` to these `.pfx` files. Keep cert files/passwords out of source control.
 
 ## Architecture
 

--- a/src/Spark.Auth/SmartAuthSettings.cs
+++ b/src/Spark.Auth/SmartAuthSettings.cs
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026, Incendi <info@incendi.no>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+using System;
+using System.Collections.Generic;
+
+namespace Spark.Auth;
+
+public class SmartAuthSettings
+{
+    public bool Enabled { get; set; }
+    public List<ClientDefinition> Clients { get; set; } = [];
+}
+
+public class ClientDefinition
+{
+    public string ClientId { get; set; } = "";
+    public string ClientSecret { get; set; } = "";
+    public string DisplayName { get; set; } = "";
+    public List<string> RedirectUris { get; set; } = [];
+    public List<string> PostLogoutRedirectUris { get; set; } = [];
+    public List<string> Scopes { get; set; } = [];
+    public List<string> GrantTypes { get; set; } = [];
+    public bool RequirePkce { get; set; } = true;
+}

--- a/src/Spark.Auth/SmartAuthSettings.cs
+++ b/src/Spark.Auth/SmartAuthSettings.cs
@@ -12,7 +12,25 @@ namespace Spark.Auth;
 public class SmartAuthSettings
 {
     public bool Enabled { get; set; }
+    public required string AuthConnectionString { get; set; }
     public List<ClientDefinition> Clients { get; set; } = [];
+    public SmartAuthEndpointSettings Endpoints { get; set; } = new();
+    public SmartAuthCertificateSettings Certificates { get; set; } = new();
+}
+
+public class SmartAuthEndpointSettings
+{
+    public string AuthorizationEndpointPath { get; set; } = "connect/authorize";
+    public string TokenEndpointPath { get; set; } = "connect/token";
+    public string EndSessionEndpointPath { get; set; } = "connect/endsession";
+}
+
+public class SmartAuthCertificateSettings
+{
+    public string SigningCertificatePath { get; set; } = "";
+    public string SigningCertificatePassword { get; set; } = "";
+    public string EncryptionCertificatePath { get; set; } = "";
+    public string EncryptionCertificatePassword { get; set; } = "";
 }
 
 public class ClientDefinition

--- a/src/Spark.Auth/Spark.Auth.csproj
+++ b/src/Spark.Auth/Spark.Auth.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFrameworks>net10.0</TargetFrameworks>
+        <LangVersion>latest</LangVersion>
+        <Description>Spark FHIR Authorization Server</Description>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="OpenIddict.AspNetCore" Version="7.2.0" />
+        <PackageReference Include="OpenIddict.MongoDb" Version="7.2.0" />
+    </ItemGroup>
+
+</Project>

--- a/src/Spark.Auth/Workers/ClientSyncWorker.cs
+++ b/src/Spark.Auth/Workers/ClientSyncWorker.cs
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2026, Incendi <info@incendi.no>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using OpenIddict.Abstractions;
+using static OpenIddict.Abstractions.OpenIddictConstants;
+
+namespace Spark.Auth.Workers;
+
+/// <summary>
+/// Syncs client applications defined in SmartAuth:Clients with the store on startup.
+/// Creates missing clients; existing clients are left unchanged.
+/// </summary>
+public class ClientSyncWorker : IHostedService
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly SmartAuthSettings _settings;
+    private readonly ILogger<ClientSyncWorker> _logger;
+
+    public ClientSyncWorker(
+        IServiceProvider serviceProvider,
+        IOptions<SmartAuthSettings> settings,
+        ILogger<ClientSyncWorker> logger)
+    {
+        _serviceProvider = serviceProvider;
+        _settings = settings.Value;
+        _logger = logger;
+    }
+
+    private static readonly HashSet<string> BuiltInScopes = ["openid", "email", "profile", "roles"];
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        if (_settings.Clients.Count == 0) return;
+
+        await using var serviceScope = _serviceProvider.CreateAsyncScope();
+        var manager = serviceScope.ServiceProvider.GetRequiredService<IOpenIddictApplicationManager>();
+        var scopeManager = serviceScope.ServiceProvider.GetRequiredService<IOpenIddictScopeManager>();
+
+        // Register custom scopes that don't already exist
+        var customScopes = _settings.Clients
+            .SelectMany(c => c.Scopes)
+            .Where(s => !BuiltInScopes.Contains(s))
+            .Distinct();
+
+        foreach (var scope in customScopes)
+        {
+            if (await scopeManager.FindByNameAsync(scope, cancellationToken) is null)
+            {
+                await scopeManager.CreateAsync(new OpenIddictScopeDescriptor { Name = scope }, cancellationToken);
+            }
+        }
+
+        foreach (var client in _settings.Clients)
+        {
+            if (await manager.FindByClientIdAsync(client.ClientId, cancellationToken) is not null)
+                continue;
+
+            var redirectUris = new List<Uri>();
+            var hasInvalidRedirectUri = false;
+            foreach (var value in client.RedirectUris)
+            {
+                if (Uri.TryCreate(value, UriKind.Absolute, out var parsed))
+                {
+                    redirectUris.Add(parsed);
+                    continue;
+                }
+
+                _logger.LogError("Skipping SmartAuth client {ClientId}: invalid RedirectUri '{RedirectUri}'.", client.ClientId, value);
+                hasInvalidRedirectUri = true;
+            }
+
+            var postLogoutRedirectUris = new List<Uri>();
+            var hasInvalidPostLogoutRedirectUri = false;
+            foreach (var value in client.PostLogoutRedirectUris)
+            {
+                if (Uri.TryCreate(value, UriKind.Absolute, out var parsed))
+                {
+                    postLogoutRedirectUris.Add(parsed);
+                    continue;
+                }
+
+                _logger.LogError("Skipping SmartAuth client {ClientId}: invalid PostLogoutRedirectUri '{PostLogoutRedirectUri}'.", client.ClientId, value);
+                hasInvalidPostLogoutRedirectUri = true;
+            }
+
+            if (hasInvalidRedirectUri || hasInvalidPostLogoutRedirectUri)
+                continue;
+
+            var descriptor = new OpenIddictApplicationDescriptor
+            {
+                ClientId = client.ClientId,
+                ClientSecret = client.ClientSecret,
+                DisplayName = client.DisplayName ?? client.ClientId,
+                ConsentType = ConsentTypes.Explicit,
+            };
+
+            foreach (var uri in redirectUris)
+                descriptor.RedirectUris.Add(uri);
+
+            foreach (var uri in postLogoutRedirectUris)
+                descriptor.PostLogoutRedirectUris.Add(uri);
+
+            // Standard endpoint permissions
+            descriptor.Permissions.Add(Permissions.Endpoints.Authorization);
+            descriptor.Permissions.Add(Permissions.Endpoints.Token);
+            descriptor.Permissions.Add(Permissions.Endpoints.EndSession);
+            descriptor.Permissions.Add(Permissions.ResponseTypes.Code);
+
+            // Grant type permissions
+            foreach (var grantType in client.GrantTypes)
+            {
+                var permission = grantType switch
+                {
+                    "authorization_code" => Permissions.GrantTypes.AuthorizationCode,
+                    "client_credentials" => Permissions.GrantTypes.ClientCredentials,
+                    "refresh_token" => Permissions.GrantTypes.RefreshToken,
+                    _ => Permissions.Prefixes.GrantType + grantType,
+                };
+                descriptor.Permissions.Add(permission);
+            }
+
+            // Scope permissions
+            foreach (var scope in client.Scopes)
+            {
+                var permission = scope switch
+                {
+                    "email" => Permissions.Scopes.Email,
+                    "profile" => Permissions.Scopes.Profile,
+                    "roles" => Permissions.Scopes.Roles,
+                    _ => Permissions.Prefixes.Scope + scope,
+                };
+                descriptor.Permissions.Add(permission);
+            }
+
+            if (client.RequirePkce)
+                descriptor.Requirements.Add(Requirements.Features.ProofKeyForCodeExchange);
+
+            await manager.CreateAsync(descriptor, cancellationToken);
+        }
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/Spark.Web.Tests/AuthorizationControllerTests.cs
+++ b/src/Spark.Web.Tests/AuthorizationControllerTests.cs
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2026, Incendi <info@incendi.no>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+using System;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using OpenIddict.Abstractions;
+using OpenIddict.Server;
+using OpenIddict.Server.AspNetCore;
+using Spark.Auth.Controllers;
+using static OpenIddict.Abstractions.OpenIddictConstants;
+
+namespace Spark.Web.Tests;
+
+public class AuthorizationControllerTests
+{
+    [Fact]
+    public async Task Authorize_ReturnsInvalidRequest_WhenNoInteractiveChallengeSchemeIsConfigured()
+    {
+        var services = CreateServices(configureAuthentication: options =>
+        {
+            options.DefaultScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+        });
+
+        var controller = CreateController(services);
+
+        var result = await controller.Authorize();
+
+        var badRequest = Assert.IsType<BadRequestObjectResult>(result);
+        var json = JsonSerializer.Serialize(badRequest.Value);
+        Assert.Contains(Errors.InvalidRequest, json, StringComparison.Ordinal);
+        Assert.Contains("Interactive login is not configured", json, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Authorize_ChallengesDefaultExternalScheme_WhenInteractiveProviderIsConfigured()
+    {
+        var services = CreateServices(configureAuthentication: options =>
+        {
+            options.DefaultScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+            options.DefaultChallengeScheme = "GitHub";
+        }, addInteractiveScheme: true);
+
+        var controller = CreateController(services);
+
+        var result = await controller.Authorize();
+
+        var challenge = Assert.IsType<ChallengeResult>(result);
+        Assert.Contains("GitHub", challenge.AuthenticationSchemes);
+    }
+
+    private static AuthorizationController CreateController(ServiceProvider services)
+    {
+        var appManager = new Mock<IOpenIddictApplicationManager>(MockBehavior.Strict);
+        var schemeProvider = services.GetRequiredService<IAuthenticationSchemeProvider>();
+
+        var controller = new AuthorizationController(appManager.Object, schemeProvider)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = CreateHttpContext(services)
+            }
+        };
+
+        return controller;
+    }
+
+    private static DefaultHttpContext CreateHttpContext(ServiceProvider services)
+    {
+        var context = new DefaultHttpContext
+        {
+            RequestServices = services
+        };
+
+        context.Request.Path = "/connect/authorize";
+        context.Request.Scheme = "https";
+        context.Request.Host = new HostString("localhost", 5001);
+
+        var transaction = new OpenIddictServerTransaction
+        {
+            Request = new OpenIddictRequest
+            {
+                ClientId = "smart-app",
+                ResponseType = ResponseTypes.Code,
+                Scope = Scopes.OpenId
+            }
+        };
+
+        context.Features.Set(new OpenIddictServerAspNetCoreFeature
+        {
+            Transaction = transaction
+        });
+
+        return context;
+    }
+
+    private static ServiceProvider CreateServices(Action<AuthenticationOptions> configureAuthentication, bool addInteractiveScheme = false)
+    {
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddLogging();
+
+        var builder = serviceCollection
+            .AddAuthentication(configureAuthentication)
+            .AddCookie(CookieAuthenticationDefaults.AuthenticationScheme);
+
+        if (addInteractiveScheme)
+        {
+            builder.AddScheme<AuthenticationSchemeOptions, NoResultAuthHandler>("GitHub", _ => { });
+        }
+
+        return serviceCollection.BuildServiceProvider();
+    }
+
+    private sealed class NoResultAuthHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+    {
+        public NoResultAuthHandler(
+            IOptionsMonitor<AuthenticationSchemeOptions> options,
+            ILoggerFactory logger,
+            System.Text.Encodings.Web.UrlEncoder encoder)
+            : base(options, logger, encoder)
+        {
+        }
+
+        protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+            => Task.FromResult(AuthenticateResult.NoResult());
+    }
+}

--- a/src/Spark.Web.Tests/Spark.Web.Tests.csproj
+++ b/src/Spark.Web.Tests/Spark.Web.Tests.csproj
@@ -7,6 +7,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.1" />
+        <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="coverlet.collector" Version="6.0.4" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
         <PackageReference Include="MSTest.TestFramework" Version="4.0.2" />

--- a/src/Spark.Web/Settings/appsettings.json
+++ b/src/Spark.Web/Settings/appsettings.json
@@ -12,6 +12,12 @@
     },
     "SmartAuth": {
         "Enabled": false,
+        "Certificates": {
+            "SigningCertificatePath": "",
+            "SigningCertificatePassword": "",
+            "EncryptionCertificatePath": "",
+            "EncryptionCertificatePassword": ""
+        },
         "Clients": [
             {
                 "ClientId": "smart-app",

--- a/src/Spark.Web/Settings/appsettings.json
+++ b/src/Spark.Web/Settings/appsettings.json
@@ -10,6 +10,21 @@
         "ClientSecret": "",
         "AdminUsers": ["your-github-username"]
     },
+    "SmartAuth": {
+        "Enabled": false,
+        "Clients": [
+            {
+                "ClientId": "smart-app",
+                "ClientSecret": "",
+                "DisplayName": "SMART App",
+                "RedirectUris": ["https://localhost:5001/callback"],
+                "PostLogoutRedirectUris": ["https://localhost:5001/"],
+                "Scopes": ["openid", "email", "profile", "offline_access"],
+                "GrantTypes": ["authorization_code", "refresh_token"],
+                "RequirePkce": true
+            }
+        ]
+    },
     "ExamplesSettings": {
         "FilePath": "Examples/R4/examples.zip"
     },

--- a/src/Spark.Web/Spark.Web.csproj
+++ b/src/Spark.Web/Spark.Web.csproj
@@ -12,6 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Spark.Auth\Spark.Auth.csproj" />
     <ProjectReference Include="..\Spark.Engine\Spark.Engine.csproj" />
     <ProjectReference Include="..\Spark.Mongo\Spark.Mongo.csproj" />
   </ItemGroup>

--- a/src/Spark.Web/Startup.cs
+++ b/src/Spark.Web/Startup.cs
@@ -31,9 +31,12 @@ namespace Spark.Web;
 
 public class Startup
 {
-    public Startup(IConfiguration configuration)
+    private readonly IWebHostEnvironment _environment;
+
+    public Startup(IConfiguration configuration, IWebHostEnvironment environment)
     {
         Configuration = configuration;
+        _environment = environment;
     }
 
     public IConfiguration Configuration { get; }
@@ -123,13 +126,7 @@ public class Startup
                 policy.AllowAnyHeader();
             }));
 
-        // SMART on FHIR authorization (optional)
-        var smartAuthSettings = new SmartAuthSettings();
-        Configuration.Bind("SmartAuth", smartAuthSettings);
-        if (smartAuthSettings.Enabled)
-        {
-            services.AddSparkAuth(smartAuthSettings, storeSettings.ConnectionString);
-        }
+        ConfigureSmartAuth(services, storeSettings);
 
         // Sets up the MongoDB store
         services.AddMongoFhirStore(storeSettings);
@@ -151,6 +148,30 @@ public class Startup
         });
 
         services.AddSignalR();
+    }
+
+    private void ConfigureSmartAuth(IServiceCollection services, StoreSettings storeSettings)
+    {
+        // SMART on FHIR authorization (optional)
+        // Defaults to StoreSettings.ConnectionString unless SmartAuth:AuthConnectionString overrides it.
+        // Endpoint paths can be optionally overridden via SmartAuth:Endpoints:* settings.
+        var smartAuthSettings = new SmartAuthSettings
+        {
+            AuthConnectionString = storeSettings.ConnectionString
+        };
+        Configuration.Bind("SmartAuth", smartAuthSettings);
+        
+        if (!smartAuthSettings.Enabled)
+        {
+            return;
+        }
+
+        var useDevelopmentCertificates = _environment.IsDevelopment();
+
+        services.AddSparkAuth(
+            settings: smartAuthSettings,
+            mongoConnectionString: smartAuthSettings.AuthConnectionString,
+            useDevelopmentCertificates: useDevelopmentCertificates);
     }
 
     // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/src/Spark.Web/Startup.cs
+++ b/src/Spark.Web/Startup.cs
@@ -19,6 +19,8 @@ using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi;
 using Spark.Engine;
 using Spark.Engine.Extensions;
+using Spark.Auth;
+using Spark.Auth.Extensions;
 using Spark.Mongo.Extensions;
 using Spark.Web.Hubs;
 using Spark.Web.Models.Config;
@@ -120,6 +122,14 @@ public class Startup
                 policy.AllowAnyMethod();
                 policy.AllowAnyHeader();
             }));
+
+        // SMART on FHIR authorization (optional)
+        var smartAuthSettings = new SmartAuthSettings();
+        Configuration.Bind("SmartAuth", smartAuthSettings);
+        if (smartAuthSettings.Enabled)
+        {
+            services.AddSparkAuth(smartAuthSettings, storeSettings.ConnectionString);
+        }
 
         // Sets up the MongoDB store
         services.AddMongoFhirStore(storeSettings);


### PR DESCRIPTION
Introduce the Spark.Auth project implementing the authorization foundation described in ADR-0003. Includes OpenIddict integration with MongoDB, client seeding, token endpoints, SMART configuration discovery, and optioonal wiring via SmartAuth settings in Spark.Web.