### PR TITLE
Engine+Mongo: Introduce background indexing mode

### DIFF
--- a/Documentation/ADR/0004-BackgroundIndexService.md
+++ b/Documentation/ADR/0004-BackgroundIndexService.md
@@ -1,7 +1,7 @@
 # ADR-0004: Background IndexService via Durable Outbox Queue
 
 ## Status
-Draft
+Accepted
 
 ## Context
 `IndexService.ProcessAsync()` is currently called synchronously inside the HTTP request
@@ -71,8 +71,16 @@ outbox queue backed by a MongoDB `indexqueue` collection and a background worker
 - A new `IIndexQueue` interface provides `EnqueueAsync`, `ClaimNextAsync`,
   `AcknowledgeAsync`, and `NackAsync` operations.
 - `MongoIndexQueue` implements `IIndexQueue` using the `indexqueue` collection.
-- `EnqueueAsync` is called from `ResourceStorageService` after a successful resource store
-  (and, once ADR 0001 is implemented, inside the same MongoDB transaction).
+- `EnqueueAsync` is called from a new `IndexQueueEnqueueListener : IServiceListener`,
+  which participates in the existing `ServiceListener` chain. This preserves the
+  `IServiceListener` pattern and allows operators to switch between synchronous indexing
+  (`SearchService`) and background indexing (`IndexQueueEnqueueListener`) by swapping a
+  single DI registration, without modifying any storage code.
+- The existing `ServiceListener.InformAsync()` call and the `IServiceListener` /
+  `SearchService` wiring are fully preserved. `IndexQueueEnqueueListener` is a drop-in
+  replacement for `SearchService` in the listener registration. The DI swap to activate
+  background indexing will be opt-in (controlled by a configuration flag) so operators can
+  choose synchronous vs. background indexing per deployment.
 - `IndexWorker : BackgroundService` runs on every Spark node and polls `ClaimNextAsync()`
   in a loop. `ClaimNextAsync()` is a single atomic `FindOneAndUpdate` that transitions an
   entry from `pending` to `processing` and stamps it with the claiming node's `WorkerId`.
@@ -81,8 +89,9 @@ outbox queue backed by a MongoDB `indexqueue` collection and a background worker
   reclaimed by the next available worker (crash recovery).
 - Failed entries are retried up to a configurable maximum; after that they transition to
   `status=failed` and are logged for operator attention.
-- `ServiceListener.InformAsync()` is removed from the synchronous write path for
-  indexing. The `IServiceListener` / `SearchService` wiring is preserved for future use.
+- Once ADR 0001 is implemented, both `IndexQueueEnqueueListener` and `SearchService` will
+  participate in the same MongoDB transaction as `resources` and `counters`, completing
+  the transactional outbox pattern regardless of which indexing mode is active.
 
 ## Consequences
 

--- a/Documentation/BackgroundIndexing.md
+++ b/Documentation/BackgroundIndexing.md
@@ -1,0 +1,93 @@
+# Background Indexing
+
+> [!IMPORTANT]
+> **Experimental feature — use with caution.**
+> Background indexing is not yet recommended for production use. It introduces eventual
+> consistency between writes and search results, which may cause unexpected behaviour in
+> deployments that rely on immediate read-your-writes consistency on the search index.
+
+## Overview
+
+By default Spark processes search index updates synchronously in the HTTP request path:
+every write waits for indexing to complete before returning a response. Background indexing
+decouples this work by enqueuing index updates in a durable MongoDB `indexqueue` collection
+and processing them in a `BackgroundService` worker (`IndexWorker`) that runs on each Spark
+node.
+
+The main benefit is reduced write latency. The trade-off is that search results are
+eventually consistent — a resource may not appear in search results immediately after a
+successful write.
+
+## Configuration
+
+Background indexing is controlled by the `IndexingMode` property of the `Experimental`
+settings group in `SparkSettings`:
+
+```json
+{
+  "SparkSettings": {
+    "Experimental": {
+      "IndexingMode": "Background"
+    }
+  }
+}
+```
+
+Or via environment variable (useful for Docker / Kubernetes deployments):
+
+```
+SparkSettings__Experimental__IndexingMode=Background
+```
+
+The default value is `Synchronous`. Set it to `Background` to enable background indexing.
+
+The index queue behaviour can be tuned via `StoreSettings.IndexQueue`:
+
+```json
+{
+  "StoreSettings": {
+    "IndexQueue": {
+      "PollInterval": "00:00:00.020",
+      "LeaseTimeout": "00:05:00",
+      "MaxAttempts": 5
+    }
+  }
+}
+```
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `PollInterval` | 20 ms | How often `IndexWorker` polls for new queue entries. |
+| `LeaseTimeout` | 5 min | How long a claimed entry may be held before it is reclaimed by another worker (crash recovery). |
+| `MaxAttempts` | 5 | Maximum number of processing attempts before an entry is marked `failed`. |
+
+## Eventual Consistency Trade-offs
+
+Operators must evaluate the following before enabling background indexing:
+
+- **Conditional writes** — `conditional create`, `conditional update`, and `conditional delete`
+  resolve their match criteria via the search index. If a conflicting resource was written
+  within the last index-poll cycle, the condition may resolve against a stale index.
+- **Search immediately after write** — clients that write a resource and immediately search
+  for it may transiently receive zero or incomplete results.
+- **Automated test suites** — any test that asserts search result counts or presence
+  immediately after a write must either add retry/polling logic or be run against a
+  `Synchronous`-mode instance.
+
+## Multi-node Deployments
+
+Each Spark node runs its own `IndexWorker`. Claims are atomic (`FindOneAndUpdate`) so only
+one node processes any given queue entry. If a node crashes mid-processing, the entry is
+automatically reclaimed after `LeaseTimeout` by another node.
+
+## Monitoring
+
+- Entries that exhaust `MaxAttempts` are marked `status=failed` in the `indexqueue`
+  collection and logged by `IndexWorker`. Operator intervention is required to re-process
+  or discard them.
+- Monitor the depth of the `indexqueue` collection. A growing queue indicates that the
+  worker cannot keep up with the write rate, or that the worker is stopped.
+
+## See Also
+
+- [ADR 0004 — Background IndexService via Durable Outbox Queue](ADR/0004-BackgroundIndexService.md)

--- a/Documentation/MigrateFromv2Tov3.md
+++ b/Documentation/MigrateFromv2Tov3.md
@@ -5,6 +5,15 @@ We now target `net8.0`, `net9.0`, and `net10.0`. `netstandard2.0` and `net472` t
 
 ### New classes and interfaces
 - `FhirResponse<T>` wraps a `FhirResponse`, with the generic parameter representing the FHIR resource type.
+- `IIndexQueue` (`Spark.Engine.Store.Interfaces`) — interface for durable index queue operations: `EnqueueAsync`, `ClaimNextAsync`, `AcknowledgeAsync`, `NackAsync`.
+- `IndexQueueEntry` (`Spark.Engine.Core`) — model returned by `IIndexQueue.ClaimNextAsync`; carries the `Entry`, attempt count, and last error.
+- `IndexQueueSettings` (`Spark.Engine.Store`) — configuration for index queue behavior: `LeaseTimeout`, `MaxAttempts`, `PollInterval`. Exposed as `StoreSettings.IndexQueue`.
+- `MongoIndexQueue` (`Spark.Mongo.Store`) — MongoDB implementation of `IIndexQueue` backed by the `indexqueue` collection.
+- `IndexWorker` (`Spark.Engine.Service`) — `BackgroundService` that polls `IIndexQueue` and drains pending entries via `IIndexService`. Registered automatically when `SparkSettings.Experimental.IndexingMode = Background`.
+- `IndexServiceListener` (`Spark.Engine.Service`) — `IServiceListener` that processes search index updates synchronously in the HTTP request path. Registered by default (`IndexingMode = Synchronous`).
+- `IndexQueueEnqueueListener` (`Spark.Engine.Service`) — `IServiceListener` that enqueues write events onto `IIndexQueue` for asynchronous background processing. Registered when `IndexingMode = Background`.
+- `ExperimentalSettings` (`Spark.Engine`) — groups experimental settings under `SparkSettings.Experimental`. Currently exposes `IndexingMode`.
+- `IndexingMode` (`Spark.Engine`) — enum that controls the indexing strategy: `Synchronous` (default) or `Background`. Accessed via `SparkSettings.Experimental.IndexingMode`.
 
 ### IFhirService, FhirServiceBase and FhirService changes
 - New generic methods:
@@ -18,6 +27,10 @@ We now target `net8.0`, `net9.0`, and `net10.0`. `netstandard2.0` and `net472` t
 
 ### Method and property signature changes
 - `Validate.HasResourceType(IKey, ResourceType)` has been changed to `Validate.HasResourceType(IKey, string)`
+- `SearchService` no longer implements `IServiceListener`; it now only implements `ISearchService`. Code that registered or resolved `SearchService` as `IServiceListener` must be updated.
+- `SearchService` constructor no longer accepts `IIndexService`; the signature changed from `SearchService(ILocalhost, IFhirModel, IFhirIndex, IIndexService)` to `SearchService(ILocalhost, IFhirModel, IFhirIndex)`.
+- `SparkSettings` has a new property `ExperimentalSettings Experimental { get; set; }` (default `new ExperimentalSettings()`).
+- `StoreSettings` has a new property `IndexQueueSettings IndexQueue { get; set; }` (defaults to `new IndexQueueSettings()`).
 - `List<Hl7.Fhir.Model.SearchParameter> IFhirModel.SearchParameters` has been changed to `IReadOnlyListList<Spark.Engine.Model.SearchParameter> IFhirModel.SearchParameters`
 - `IEnumerable<Hl7.Fhir.Model.SearchParameter> IFhirModel.FindSearchParameters(Type)` has been changed to `List<Spark.Engine.Model.SearchParameter> IFhirModel.FindSearchParameters(Type)`
 - `IEnumerable<Hl7.Fhir.Model.SearchParameter> IFhirModel.FindSearchParameters(string)` has been changed to `List<Spark.Engine.Model.SearchParameter> IFhirModel.FindSearchParameters(string)`
@@ -82,8 +95,9 @@ We now target `net8.0`, `net9.0`, and `net10.0`. `netstandard2.0` and `net472` t
 
 ### Changes to extension methods
 - `AddFhirFacade(this IServiceCollection, Action<SparkOptions>)` now returns `IMvcBuilder` instead of `IMvcCoreBuilder`.
-- `AddFhir(this IServiceCollection, SparkSettings, Action<MvcOptions>)` now returns `IMvcBuilder` instead of `IMvcCoreBuilder`.
+- `AddFhir(this IServiceCollection, SparkSettings, Action<MvcOptions>)` now returns `IMvcBuilder` instead of `IMvcCoreBuilder`. It also conditionally registers `IndexServiceListener` (default, `IndexingMode.Synchronous`) or `IndexQueueEnqueueListener` + `IndexWorker` (opt-in, `IndexingMode.Background`) based on `SparkSettings.Experimental.IndexingMode`.
 - `AddFhirFormatters(this IServiceCollection, SparkSettings, Action<MvcOptions>` now returns `IMvcBuilder` instead of `IMvcCoreBuilder`.
+- `AddMongoFhirStore(this IServiceCollection, StoreSettings)` now always registers `IndexQueueSettings` (sourced from `StoreSettings.IndexQueue`) and `IIndexQueue → MongoIndexQueue`.
 
 ### Namespace changes
 - `Spark.Search.ChoiceValue` moved to `Spark.Engine.Search.ChoiceValue`

--- a/Spark.sln
+++ b/Spark.sln
@@ -75,6 +75,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentat
 		Documentation\UsingSpark.md = Documentation\UsingSpark.md
 		Documentation\MigrateFromv1Tov2.md = Documentation\MigrateFromv1Tov2.md
 		Documentation\MigrateFromv2Tov3.md = Documentation\MigrateFromv2Tov3.md
+		Documentation\BackgroundIndexing.md = Documentation\BackgroundIndexing.md
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "scripts", "scripts", "{977F2FE5-C232-4F93-AA0A-73DB85A20879}"

--- a/src/Spark.Engine.Test/Service/IndexQueueEnqueueListenerTests.cs
+++ b/src/Spark.Engine.Test/Service/IndexQueueEnqueueListenerTests.cs
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026, Incendi <info@incendi.no>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Hl7.Fhir.Model;
+using Moq;
+using Spark.Engine.Core;
+using Spark.Engine.Service;
+using Spark.Engine.Store.Interfaces;
+using Xunit;
+using Task = System.Threading.Tasks.Task;
+
+namespace Spark.Engine.Test.Service;
+
+public class IndexQueueEnqueueListenerTests
+{
+    [Fact]
+    public async Task InformAsync_ForwardsEntryToIndexQueue()
+    {
+        var mockQueue = new Mock<IIndexQueue>();
+        var entry = Entry.POST(new Key("http://localhost/", "Patient", "p1", null), new Patient { Id = "p1" });
+        var listener = new IndexQueueEnqueueListener(mockQueue.Object);
+
+        await listener.InformAsync(new Uri("http://localhost/Patient/p1"), entry);
+
+        mockQueue.Verify(q => q.EnqueueAsync(entry, It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/src/Spark.Engine.Test/Service/IndexWorkerTests.cs
+++ b/src/Spark.Engine.Test/Service/IndexWorkerTests.cs
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2026, Incendi <info@incendi.no>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Hl7.Fhir.Model;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Spark.Engine.Core;
+using Spark.Engine.Service;
+using Spark.Engine.Store;
+using Spark.Engine.Store.Interfaces;
+using Xunit;
+using Task = System.Threading.Tasks.Task;
+
+namespace Spark.Engine.Test.Service;
+
+public class IndexWorkerTests
+{
+    private readonly Mock<IIndexQueue> _indexQueueMock = new();
+    private readonly Mock<IIndexService> _indexServiceMock = new();
+    private readonly IndexQueueSettings _settings = new() { PollInterval = TimeSpan.FromMilliseconds(1) };
+
+    private IndexWorker CreateWorker() =>
+        new(_indexQueueMock.Object, _indexServiceMock.Object,
+            NullLogger<IndexWorker>.Instance, _settings);
+
+    /// <summary>
+    /// Configures ClaimNextAsync to return <paramref name="first"/> on the first call,
+    /// then block indefinitely (until canceled) on subsequent calls.
+    /// </summary>
+    private void SetupClaimSequence(IndexQueueEntry first)
+    {
+        int calls = 0;
+        _indexQueueMock.Setup(indexQueue => indexQueue.ClaimNextAsync(It.IsAny<CancellationToken>()))
+            .Returns<CancellationToken>(async ct =>
+            {
+                if (Interlocked.Increment(ref calls) == 1)
+                    return first;
+                await Task.Delay(Timeout.Infinite, ct).ConfigureAwait(false);
+                return null;
+            });
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenEntryAvailable_ProcessesAndAcknowledges()
+    {
+        var entry = new IndexQueueEntry { Id = "e1", Entry = Entry.POST(new Key("http://localhost/", "Patient", "p1", null), new Patient()) };
+        SetupClaimSequence(entry);
+        
+        // Signal when AcknowledgeAsync is called so the test doesn't rely on timing
+        var ackSignal = new TaskCompletionSource();
+        _indexQueueMock.Setup(indexQueue => indexQueue.AcknowledgeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Callback(() => ackSignal.TrySetResult());
+
+        var worker = CreateWorker();
+        await worker.StartAsync(CancellationToken.None);
+        await ackSignal.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await worker.StopAsync(CancellationToken.None);
+
+        _indexServiceMock.Verify(indexService => indexService.ProcessAsync(entry.Entry), Times.Once);
+        _indexQueueMock.Verify(indexQueue => indexQueue.AcknowledgeAsync("e1", It.IsAny<CancellationToken>()), Times.Once);
+        _indexQueueMock.Verify(indexQueue => indexQueue.NackAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenProcessingFails_CallsNackWithEntryIdAndError()
+    {
+        var entry = new IndexQueueEntry { Id = "e2", Entry = Entry.POST(new Key("http://localhost/", "Patient", "p2", null), new Patient()) };
+        SetupClaimSequence(entry);
+
+        var processingError = new InvalidOperationException("index failure");
+        _indexServiceMock.Setup(indexService => indexService.ProcessAsync(It.IsAny<Entry>())).ThrowsAsync(processingError);
+
+        var nackSignal = new TaskCompletionSource();
+        _indexQueueMock.Setup(indexQueue => indexQueue.NackAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Callback(() => nackSignal.TrySetResult());
+
+        var worker = CreateWorker();
+        await worker.StartAsync(CancellationToken.None);
+        await nackSignal.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await worker.StopAsync(CancellationToken.None);
+
+        _indexQueueMock.Verify(indexQueue => indexQueue.NackAsync("e2", "index failure", It.IsAny<CancellationToken>()), Times.Once);
+        _indexQueueMock.Verify(indexQueue => indexQueue.AcknowledgeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenQueueIsEmpty_DoesNotCallIndexService()
+    {
+        int calls = 0;
+        var emptyQueueSignal = new TaskCompletionSource();
+        _indexQueueMock.Setup(indexQueue => indexQueue.ClaimNextAsync(It.IsAny<CancellationToken>()))
+            .Returns<CancellationToken>(async ct =>
+            {
+                if (Interlocked.Increment(ref calls) == 1)
+                {
+                    emptyQueueSignal.TrySetResult();
+                    return null;
+                }
+                await Task.Delay(Timeout.Infinite, ct).ConfigureAwait(false);
+                return null;
+            });
+
+        var worker = CreateWorker();
+        await worker.StartAsync(CancellationToken.None);
+        await emptyQueueSignal.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await worker.StopAsync(CancellationToken.None);
+
+        _indexQueueMock.Verify(indexQueue => indexQueue.ClaimNextAsync(It.IsAny<CancellationToken>()), Times.AtLeastOnce);
+        _indexServiceMock.Verify(indexService => indexService.ProcessAsync(It.IsAny<Entry>()), Times.Never);
+        _indexQueueMock.Verify(indexQueue => indexQueue.AcknowledgeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_OnCancellation_ExitsWithoutThrowing()
+    {
+        _indexQueueMock.Setup(q => q.ClaimNextAsync(It.IsAny<CancellationToken>()))
+            .Returns<CancellationToken>(async ct =>
+            {
+                await Task.Delay(Timeout.Infinite, ct).ConfigureAwait(false);
+                return null;
+            });
+
+        var worker = CreateWorker();
+        await worker.StartAsync(CancellationToken.None);
+        var exception = await Record.ExceptionAsync(() => worker.StopAsync(CancellationToken.None));
+        Assert.Null(exception);
+    }
+}

--- a/src/Spark.Engine/Core/IndexQueueEntry.cs
+++ b/src/Spark.Engine/Core/IndexQueueEntry.cs
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026, Incendi <info@incendi.no>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+using System;
+
+namespace Spark.Engine.Core;
+
+public class IndexQueueEntry
+{
+    public string Id { get; set; }
+    public Entry Entry { get; set; }
+    public int Attempts { get; set; }
+    public string LastError { get; set; }
+    public DateTime EnqueuedAt { get; set; }
+}

--- a/src/Spark.Engine/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Spark.Engine/Extensions/IServiceCollectionExtensions.cs
@@ -148,7 +148,15 @@ public static class IServiceCollectionExtensions
         services.TryAddTransient<ISearchService, SearchService>();
         services.TryAddTransient<ISnapshotPaginationProvider, SnapshotPaginationProvider>();
         services.TryAddTransient<ISnapshotPaginationCalculator, SnapshotPaginationCalculator>();
-        services.TryAddTransient<IServiceListener, IndexServiceListener>();
+        if (settings.Experimental.IndexingMode == IndexingMode.Background)
+        {
+            services.TryAddTransient<IServiceListener, IndexQueueEnqueueListener>();
+            services.AddHostedService<IndexWorker>();
+        }
+        else
+        {
+            services.TryAddTransient<IServiceListener, IndexServiceListener>();
+        }
         services.TryAddTransient(provider => new IServiceListener[] { provider.GetRequiredService<IServiceListener>() });
         services.TryAddTransient<SearchService>();                     // search
         services.TryAddTransient<ITransactionService, TransactionService>();  // transaction

--- a/src/Spark.Engine/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Spark.Engine/Extensions/IServiceCollectionExtensions.cs
@@ -148,7 +148,7 @@ public static class IServiceCollectionExtensions
         services.TryAddTransient<ISearchService, SearchService>();
         services.TryAddTransient<ISnapshotPaginationProvider, SnapshotPaginationProvider>();
         services.TryAddTransient<ISnapshotPaginationCalculator, SnapshotPaginationCalculator>();
-        services.TryAddTransient<IServiceListener, SearchService>();   // searchListener
+        services.TryAddTransient<IServiceListener, IndexServiceListener>();
         services.TryAddTransient(provider => new IServiceListener[] { provider.GetRequiredService<IServiceListener>() });
         services.TryAddTransient<SearchService>();                     // search
         services.TryAddTransient<ITransactionService, TransactionService>();  // transaction

--- a/src/Spark.Engine/IndexingMode.cs
+++ b/src/Spark.Engine/IndexingMode.cs
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026, Incendi <info@incendi.no>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+namespace Spark.Engine;
+
+/// <summary>
+/// Controls how the search index is updated after a FHIR resource write.
+/// </summary>
+public enum IndexingMode
+{
+    /// <summary>
+    /// Index updates are processed synchronously in the HTTP request path via
+    /// <c>IndexServiceListener</c>. Default behavior.
+    /// </summary>
+    Synchronous,
+
+    /// <summary>
+    /// Index updates are enqueued to the durable <c>indexqueue</c> MongoDB collection
+    /// and processed by <c>IndexWorker</c> running as a background service.
+    /// Search results become eventually consistent.
+    /// </summary>
+    Background
+}

--- a/src/Spark.Engine/Service/FhirServiceExtensions/SearchService.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/SearchService.cs
@@ -15,22 +15,19 @@ using Hl7.Fhir.Rest;
 using Spark.Engine.Core;
 using Spark.Engine.Extensions;
 using Spark.Engine.Interfaces;
-using Task = System.Threading.Tasks.Task;
 
 namespace Spark.Engine.Service.FhirServiceExtensions;
 
-public class SearchService : ISearchService, IServiceListener
+public class SearchService : ISearchService
 {
     private readonly IFhirModel _fhirModel;
     private readonly ILocalhost _localhost;
-    private IIndexService _indexService;
     private IFhirIndex _fhirIndex;
 
-    public SearchService(ILocalhost localhost, IFhirModel fhirModel, IFhirIndex fhirIndex, IIndexService indexService)
+    public SearchService(ILocalhost localhost, IFhirModel fhirModel, IFhirIndex fhirIndex)
     {
         _fhirModel = fhirModel;
         _localhost = localhost;
-        _indexService = indexService;
         _fhirIndex = fhirIndex;
     }
 
@@ -152,10 +149,5 @@ public class SearchService : ISearchService, IServiceListener
             firstSort = searchCommand.Sort[0].Item1; //TODO: Support sortorder and multiple sort arguments.
         }
         return firstSort;
-    }
-
-    public async Task InformAsync(Uri location, Entry interaction)
-    {
-        await _indexService.ProcessAsync(interaction).ConfigureAwait(false);
     }
 }

--- a/src/Spark.Engine/Service/IndexQueueEnqueueListener.cs
+++ b/src/Spark.Engine/Service/IndexQueueEnqueueListener.cs
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026, Incendi <info@incendi.no>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+using Spark.Engine.Core;
+using Spark.Engine.Store.Interfaces;
+using System;
+using System.Threading.Tasks;
+
+namespace Spark.Engine.Service;
+
+/// <summary>
+/// An <see cref="IServiceListener"/> that enqueues FHIR resource write events onto the
+/// <see cref="IIndexQueue"/> for asynchronous processing by <c>IndexWorker</c>.
+/// Register this in place of the default <c>SearchService</c> listener to switch from
+/// synchronous to background indexing.
+/// </summary>
+public class IndexQueueEnqueueListener : IServiceListener
+{
+    private readonly IIndexQueue _indexQueue;
+
+    public IndexQueueEnqueueListener(IIndexQueue indexQueue)
+    {
+        _indexQueue = indexQueue;
+    }
+
+    public Task InformAsync(Uri location, Entry interaction)
+    {
+        return _indexQueue.EnqueueAsync(interaction);
+    }
+}

--- a/src/Spark.Engine/Service/IndexServiceListener.cs
+++ b/src/Spark.Engine/Service/IndexServiceListener.cs
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026, Incendi <info@incendi.no>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+using System;
+using System.Threading.Tasks;
+using Spark.Engine.Core;
+
+namespace Spark.Engine.Service;
+
+/// <summary>
+/// An <see cref="IServiceListener"/> that processes FHIR resource write events
+/// synchronously via <see cref="IIndexService"/>.
+/// </summary>
+public class IndexServiceListener : IServiceListener
+{
+    private readonly IIndexService _indexService;
+
+    public IndexServiceListener(IIndexService indexService)
+    {
+        _indexService = indexService;
+    }
+
+    public Task InformAsync(Uri location, Entry interaction)
+    {
+        return _indexService.ProcessAsync(interaction);
+    }
+}

--- a/src/Spark.Engine/Service/IndexWorker.cs
+++ b/src/Spark.Engine/Service/IndexWorker.cs
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026, Incendi <info@incendi.no>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Spark.Engine.Core;
+using Spark.Engine.Store;
+using Spark.Engine.Store.Interfaces;
+
+namespace Spark.Engine.Service;
+
+public class IndexWorker : BackgroundService
+{
+    private readonly IIndexQueue _indexQueue;
+    private readonly IIndexService _indexService;
+    private readonly ILogger<IndexWorker> _logger;
+    private readonly IndexQueueSettings _settings;
+    private readonly string _workerId;
+
+    public IndexWorker(
+        IIndexQueue indexQueue,
+        IIndexService indexService,
+        ILogger<IndexWorker> logger,
+        IndexQueueSettings settings)
+    {
+        _indexQueue = indexQueue;
+        _indexService = indexService;
+        _logger = logger;
+        _settings = settings;
+        _workerId = $"{Environment.MachineName}:{Environment.ProcessId}";
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("IndexWorker {WorkerId} starting.", _workerId);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            IndexQueueEntry entry = null;
+            try
+            {
+                entry = await _indexQueue.ClaimNextAsync(stoppingToken).ConfigureAwait(false);
+
+                if (entry is null)
+                {
+                    await Task.Delay(_settings.PollInterval, stoppingToken).ConfigureAwait(false);
+                    continue;
+                }
+
+                await _indexService.ProcessAsync(entry.Entry).ConfigureAwait(false);
+                await _indexQueue.AcknowledgeAsync(entry.Id, stoppingToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                if (entry is null)
+                    continue;
+
+                _logger.LogWarning(ex, "IndexWorker {WorkerId} failed to process entry {EntryId} (attempt {Attempts}).",
+                    _workerId, entry.Id, entry.Attempts);
+                try
+                {
+                    await _indexQueue.NackAsync(entry.Id, ex.Message, stoppingToken).ConfigureAwait(false);
+                }
+                catch (Exception nackEx)
+                {
+                    _logger.LogError(nackEx, "IndexWorker {WorkerId} failed to nack entry {EntryId}.",
+                        _workerId, entry.Id);
+                }
+            }
+        }
+
+        _logger.LogInformation("IndexWorker {WorkerId} stopping.", _workerId);
+    }
+}

--- a/src/Spark.Engine/SparkSettings.cs
+++ b/src/Spark.Engine/SparkSettings.cs
@@ -13,6 +13,11 @@ using Spark.Engine.Search;
 
 namespace Spark.Engine;
 
+public class ExperimentalSettings
+{
+    public IndexingMode IndexingMode { get; set; } = IndexingMode.Synchronous;
+}
+
 public class SparkSettings
 {
     public Uri Endpoint { get; set; }
@@ -22,6 +27,7 @@ public class SparkSettings
     public ExportSettings ExportSettings { get; set; }
     public IndexSettings IndexSettings { get; set; }
     public SearchSettings Search { get; set; }
+    public ExperimentalSettings Experimental { get; set; } = new();
 
     public string FhirRelease
     {

--- a/src/Spark.Engine/Store/IndexQueueSettings.cs
+++ b/src/Spark.Engine/Store/IndexQueueSettings.cs
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026, Incendi <info@incendi.no>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+using System;
+
+namespace Spark.Engine.Store;
+
+public class IndexQueueSettings
+{
+    /// <summary>
+    /// How long a claimed entry may remain in the processing state before being
+    /// considered stale and reclaimed by another worker.
+    /// </summary>
+    public TimeSpan LeaseTimeout { get; set; } = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// Maximum number of processing attempts before an entry is moved to failed.
+    /// </summary>
+    public int MaxAttempts { get; set; } = 5;
+
+    /// <summary>
+    /// How long the IndexWorker sleeps between polling cycles when the queue is empty.
+    /// </summary>
+    public TimeSpan PollInterval { get; set; } = TimeSpan.FromMilliseconds(20);
+}

--- a/src/Spark.Engine/Store/Interfaces/IIndexQueue.cs
+++ b/src/Spark.Engine/Store/Interfaces/IIndexQueue.cs
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026, Incendi <info@incendi.no>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+using System.Threading;
+using System.Threading.Tasks;
+using Spark.Engine.Core;
+
+namespace Spark.Engine.Store.Interfaces;
+
+public interface IIndexQueue
+{
+    Task EnqueueAsync(Entry entry, CancellationToken cancellationToken = default);
+    Task<IndexQueueEntry> ClaimNextAsync(CancellationToken cancellationToken = default);
+    Task AcknowledgeAsync(string id, CancellationToken cancellationToken = default);
+    Task NackAsync(string id, string error, CancellationToken cancellationToken = default);
+}

--- a/src/Spark.Engine/StoreSettings.cs
+++ b/src/Spark.Engine/StoreSettings.cs
@@ -4,9 +4,12 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+using Spark.Engine.Store;
+
 namespace Spark.Engine;
 
 public class StoreSettings
 {
     public string ConnectionString { get; set; }
+    public IndexQueueSettings IndexQueue { get; set; } = new();
 }

--- a/src/Spark.Mongo/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Spark.Mongo/Extensions/IServiceCollectionExtensions.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Spark.Engine;
 using Spark.Engine.Interfaces;
+using Spark.Engine.Store;
 using Spark.Engine.Store.Interfaces;
 using Spark.Mongo.Search.Common;
 using Spark.Mongo.Search.Indexer;
@@ -36,5 +37,7 @@ public static class IServiceCollectionExtensions
         services.TryAddTransient((provider) => DefinitionsFactory.Generate(ModelInfo.SearchParameters));
         services.TryAddTransient<MongoSearcher>();
         services.TryAddTransient<IFhirIndex, MongoFhirIndex>();
+        services.TryAddSingleton(settings.IndexQueue);
+        services.TryAddTransient<IIndexQueue>(provider => new MongoIndexQueue(settings.ConnectionString, provider.GetRequiredService<IndexQueueSettings>()));
     }
 }

--- a/src/Spark.Mongo/Store/BsonHelper.cs
+++ b/src/Spark.Mongo/Store/BsonHelper.cs
@@ -17,6 +17,8 @@ namespace Spark.Store.Mongo;
 
 public static class SparkBsonHelper
 {
+    // FIXME: Move all extension methods into appropriate classes, i.e. ResourceExtensions, KeyExtensions, etc.
+
     public static BsonDocument CreateDocument(Resource resource)
     {
         if (resource != null)

--- a/src/Spark.Mongo/Store/Constants.cs
+++ b/src/Spark.Mongo/Store/Constants.cs
@@ -12,6 +12,26 @@ public static class Collection
     public const string RESOURCE = "resources";
     public const string COUNTERS = "counters";
     public const string SNAPSHOT = "snapshots";
+    public const string INDEX_QUEUE = "indexqueue";
+}
+
+public static class IndexQueueField
+{
+    public const string STATUS = "status";
+    public const string WORKER_ID = "workerId";
+    public const string CLAIMED_AT = "claimedAt";
+    public const string LEASE_EXPIRES_AT = "leaseExpiresAt";
+    public const string ATTEMPTS = "attempts";
+    public const string LAST_ERROR = "lastError";
+    public const string ENQUEUED_AT = "enqueuedAt";
+    public const string ENTRY = "entry";
+}
+
+public static class IndexQueueStatus
+{
+    public const string PENDING = "pending";
+    public const string PROCESSING = "processing";
+    public const string FAILED = "failed";
 }
 
 public static class Field

--- a/src/Spark.Mongo/Store/MongoIndexQueue.cs
+++ b/src/Spark.Mongo/Store/MongoIndexQueue.cs
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2026, Incendi <info@incendi.no>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using Spark.Engine.Core;
+using Spark.Engine.Store.Interfaces;
+using Spark.Engine.Store;
+using Spark.Store.Mongo;
+
+namespace Spark.Mongo.Store;
+
+public class MongoIndexQueue : IIndexQueue
+{
+    private readonly IMongoCollection<BsonDocument> _collection;
+    private readonly IndexQueueSettings _settings;
+    private readonly string _workerId;
+
+    public MongoIndexQueue(string mongoUrl, IndexQueueSettings settings)
+    {
+        var database = MongoDatabaseFactory.GetMongoDatabase(mongoUrl);
+        _collection = database.GetCollection<BsonDocument>(Collection.INDEX_QUEUE);
+        _settings = settings;
+        _workerId = $"{Environment.MachineName}:{Environment.ProcessId}";
+        EnsureIndexes();
+    }
+
+    public async Task EnqueueAsync(Entry entry, CancellationToken cancellationToken = default)
+    {
+        // FIXME: This is papering over a problem how ToBsonDocument() is asserting keys - AssertKeyIsValid().
+        //        ToBsonDocument() is made specifically for the resources collection, but we use it here since it works
+        //        good enough for us. It is also tied in with how ToEntry() works in ClaimNextAsync(), ToEntry() was
+        //        also made specifically for the 'resources' collection.
+        var newEntry = Entry.Create(entry.Method,
+            Key.Create(entry.Key.TypeName, entry.Key.ResourceId, entry.Key.VersionId), entry.Resource);
+        var document = new BsonDocument
+        {
+            [Field.PRIMARYKEY] = ObjectId.GenerateNewId().ToString(),
+            [IndexQueueField.ENTRY] = newEntry.ToBsonDocument(),
+            [IndexQueueField.STATUS] = IndexQueueStatus.PENDING,
+            [IndexQueueField.WORKER_ID] = BsonNull.Value,
+            [IndexQueueField.CLAIMED_AT] = BsonNull.Value,
+            [IndexQueueField.LEASE_EXPIRES_AT] = BsonNull.Value,
+            [IndexQueueField.ATTEMPTS] = 0,
+            [IndexQueueField.LAST_ERROR] = BsonNull.Value,
+            [IndexQueueField.ENQUEUED_AT] = DateTime.UtcNow,
+        };
+
+        await _collection.InsertOneAsync(document, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public async Task<IndexQueueEntry> ClaimNextAsync(CancellationToken cancellationToken = default)
+    {
+        var now = DateTime.UtcNow;
+
+        // Claim the oldest pending entry, or reclaim a processing entry whose lease has expired.
+        var filter = Builders<BsonDocument>.Filter.Or(
+            Builders<BsonDocument>.Filter.And(
+                Builders<BsonDocument>.Filter.Eq(IndexQueueField.STATUS, IndexQueueStatus.PENDING),
+                Builders<BsonDocument>.Filter.Lt(IndexQueueField.ATTEMPTS, _settings.MaxAttempts)
+            ),
+            Builders<BsonDocument>.Filter.And(
+                Builders<BsonDocument>.Filter.Eq(IndexQueueField.STATUS, IndexQueueStatus.PROCESSING),
+                Builders<BsonDocument>.Filter.Lt(IndexQueueField.LEASE_EXPIRES_AT, now)
+            )
+        );
+
+        var update = Builders<BsonDocument>.Update
+            .Set(IndexQueueField.STATUS, IndexQueueStatus.PROCESSING)
+            .Set(IndexQueueField.WORKER_ID, _workerId)
+            .Set(IndexQueueField.CLAIMED_AT, now)
+            .Set(IndexQueueField.LEASE_EXPIRES_AT, now.Add(_settings.LeaseTimeout));
+
+        var options = new FindOneAndUpdateOptions<BsonDocument>
+        {
+            ReturnDocument = ReturnDocument.After,
+            Sort = Builders<BsonDocument>.Sort.Ascending(IndexQueueField.ENQUEUED_AT),
+        };
+
+        var document = await _collection
+            .FindOneAndUpdateAsync(filter, update, options, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (document is null)
+            return null;
+
+        return new IndexQueueEntry
+        {
+            Id = document[Field.PRIMARYKEY].AsString,
+            Entry = document[IndexQueueField.ENTRY].AsBsonDocument.ToEntry(),
+            Attempts = document[IndexQueueField.ATTEMPTS].AsInt32,
+            LastError = document[IndexQueueField.LAST_ERROR] == BsonNull.Value
+                ? null
+                : document[IndexQueueField.LAST_ERROR].AsString,
+            EnqueuedAt = document[IndexQueueField.ENQUEUED_AT].ToUniversalTime(),
+        };
+    }
+
+    public async Task AcknowledgeAsync(string id, CancellationToken cancellationToken = default)
+    {
+        var filter = Builders<BsonDocument>.Filter.Eq(Field.PRIMARYKEY, id);
+        await _collection.DeleteOneAsync(filter, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task NackAsync(string id, string error, CancellationToken cancellationToken = default)
+    {
+        var filter = Builders<BsonDocument>.Filter.Eq(Field.PRIMARYKEY, id);
+
+        // Atomically increment attempts and set status to failed or pending using an
+        // aggregation pipeline update (requires MongoDB 4.2+).
+        BsonDocument[] stages =
+        [
+            new BsonDocument("$set", new BsonDocument
+            {
+                [IndexQueueField.ATTEMPTS] = new BsonDocument("$add",
+                    new BsonArray { $"${IndexQueueField.ATTEMPTS}", 1 }),
+                [IndexQueueField.LAST_ERROR] = error,
+                [IndexQueueField.WORKER_ID] = BsonNull.Value,
+                [IndexQueueField.CLAIMED_AT] = BsonNull.Value,
+                [IndexQueueField.LEASE_EXPIRES_AT] = BsonNull.Value,
+                [IndexQueueField.STATUS] = new BsonDocument("$cond", new BsonDocument
+                {
+                    ["if"] = new BsonDocument("$gte", new BsonArray
+                    {
+                        new BsonDocument("$add", new BsonArray { $"${IndexQueueField.ATTEMPTS}", 1 }),
+                        _settings.MaxAttempts,
+                    }),
+                    ["then"] = IndexQueueStatus.FAILED,
+                    ["else"] = IndexQueueStatus.PENDING,
+                }),
+            }),
+        ];
+
+        PipelineDefinition<BsonDocument, BsonDocument> pipeline = stages;
+        var update = Builders<BsonDocument>.Update.Pipeline(pipeline);
+        await _collection.UpdateOneAsync(filter, update, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private void EnsureIndexes()
+    {
+        var indexes = new List<CreateIndexModel<BsonDocument>>
+        {
+            new CreateIndexModel<BsonDocument>(
+                Builders<BsonDocument>.IndexKeys
+                    .Ascending(IndexQueueField.STATUS)
+                    .Ascending(IndexQueueField.LEASE_EXPIRES_AT)),
+            new CreateIndexModel<BsonDocument>(
+                Builders<BsonDocument>.IndexKeys
+                    .Ascending(IndexQueueField.STATUS)
+                    .Ascending(IndexQueueField.ENQUEUED_AT)),
+        };
+
+        _collection.Indexes.CreateMany(indexes);
+    }
+}


### PR DESCRIPTION
This introduces background indexing mode for search index updates as described in https://github.com/FirelyTeam/spark/blob/r4/master/Documentation/ADR/0004-BackgroundIndexService.md.

- IndexingMode enum to control synchronous vs. background indexing after
  FHIR resource writes.
- Service registrations in IServiceCollectionExtensions to conditionally
  use IndexQueueEnqueueListener and IndexWorker for background mode,
  falling back to IndexServiceListener for synchronous.
- IndexingMode property added to SparkSettings.Experimental with default of
  Synchronous.
- Introduced IndexQueueSettings in StoreSettings and registered
  MongoIndexQueue in Mongo extensions for durable queuing in background
  mode.
- Enables eventual consistency in search results when using background
  indexing to offload work from HTTP requests.