### PR TITLE
Engine+Mongo: Version-guarded conditional searchindex write

### DIFF
--- a/scripts/CreateIndexes.js
+++ b/scripts/CreateIndexes.js
@@ -1,6 +1,7 @@
 print("indexes for just about any operation, including create / update");
 printjson(db.searchindex.createIndex({ "internal_resource" : 1, "identifier.code" : 1, "identifier.system" : 1}, { "name" : "ix_resource_identifier", "background" : true}));
 printjson(db.searchindex.createIndex({"internal_id":1, "internal_selflink":1},{"name":"ix_internal_id_selflink", "background":true}));
+printjson(db.searchindex.createIndex({"internal_id":1},{"name":"ix_internal_id_unique", "unique":true, "sparse":true, "background":true}));
 printjson(db.resources.createIndex({"@REFERENCE" : 1, "@state" : 1}, { "name" : "ix_REFERENCE_state", "background" : "true" }));
 
 print("indexes for when you query by Patient.name or Patient.family a lot");

--- a/src/Spark.Engine/Search/Model/IndexFieldNames.cs
+++ b/src/Spark.Engine/Search/Model/IndexFieldNames.cs
@@ -21,7 +21,8 @@ public static class IndexFieldNames
         TAGSCHEME = "scheme",
         TAGTERM = "term",
         TAGLABEL = "label",
-        LASTUPDATED = "lastupdated";
+        LASTUPDATED = "lastupdated",
+        VERSION = "internal_version";
 
     public static string[] All = { ID, JUSTID, SELFLINK, CONTAINER, RESOURCE, LEVEL, TAG, LASTUPDATED };
 }

--- a/src/Spark.Engine/Service/FhirServiceExtensions/IndexService.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/IndexService.cs
@@ -188,5 +188,7 @@ public class IndexService : IIndexService
         entry.Values.Add(new IndexValue(IndexFieldNames.ID, new StringValue(resource.TypeName + "/" + key.ResourceId)));
         entry.Values.Add(new IndexValue(IndexFieldNames.JUSTID, new StringValue(resource.Id)));
         entry.Values.Add(new IndexValue(IndexFieldNames.SELFLINK, new StringValue(key.ToUriString()))); //CK TODO: This is actually Mongo-specific. Move it to Spark.Mongo, but then you will have to communicate the key to the MongoIndexMapper.
+        if (long.TryParse(key.VersionId, out long version))
+            entry.Values.Add(new IndexValue(IndexFieldNames.VERSION, new NumberValue(version)));
     }
 }

--- a/src/Spark.Mongo/Search/Common/Config.cs
+++ b/src/Spark.Mongo/Search/Common/Config.cs
@@ -18,6 +18,7 @@ internal static class InternalField
     internal const string LEVEL = "internal_level";
     internal const string RESOURCE = "internal_resource";
     internal const string SELF_LINK = "internal_selflink";
+    internal const string VERSION = "internal_version";
 
     internal static readonly string[] ALL = [ID, JUST_ID, SELF_LINK, RESOURCE, LEVEL, LAST_UPDATED];
 }

--- a/src/Spark.Mongo/Search/Infrastructure/MongoIndexStore.cs
+++ b/src/Spark.Mongo/Search/Infrastructure/MongoIndexStore.cs
@@ -40,11 +40,37 @@ public class MongoIndexStore : IIndexStore
         }
     }
 
-    public async Task SaveAsync(BsonDocument document)
+    private async Task SaveAsync(BsonDocument document)
     {
         string keyvalue = document.GetValue(InternalField.ID).ToString();
-        var query = Builders<BsonDocument>.Filter.Eq(InternalField.ID, keyvalue);
-        await Collection.ReplaceOneAsync(query, document, new ReplaceOptions { IsUpsert = true }).ConfigureAwait(false);
+
+        if (document.TryGetValue(InternalField.VERSION, out BsonValue versionBson))
+        {
+            long newVersion = versionBson.ToInt64();
+
+            var conditionalFilter = Builders<BsonDocument>.Filter.And(
+                Builders<BsonDocument>.Filter.Eq(InternalField.ID, keyvalue),
+                Builders<BsonDocument>.Filter.Or(
+                    Builders<BsonDocument>.Filter.Exists(InternalField.VERSION, false),
+                    Builders<BsonDocument>.Filter.Lt(InternalField.VERSION, newVersion)
+                )
+            );
+            try
+            {
+                await Collection.FindOneAndReplaceAsync(conditionalFilter, document,
+                    new FindOneAndReplaceOptions<BsonDocument> { IsUpsert = true }).ConfigureAwait(false);
+            }
+            catch (MongoWriteException ex) when (ex.WriteError.Code == 11000)
+            {
+                // Duplicate key: a newer version is already indexed — stale write, skip.
+            }
+        }
+        else
+        {
+            // No version info (backward compat).
+            var query = Builders<BsonDocument>.Filter.Eq(InternalField.ID, keyvalue);
+            await Collection.ReplaceOneAsync(query, document, new ReplaceOptions { IsUpsert = true }).ConfigureAwait(false);
+        }
     }
 
     public async Task DeleteAsync(Entry entry)

--- a/src/Spark.Mongo/Store/MongoStoreAdministration.cs
+++ b/src/Spark.Mongo/Store/MongoStoreAdministration.cs
@@ -11,6 +11,7 @@ using MongoDB.Bson;
 using MongoDB.Driver;
 using Spark.Engine.Interfaces;
 using Spark.Store.Mongo;
+using Spark.Mongo.Search.Common;
 
 namespace Spark.Mongo.Store;
 
@@ -57,6 +58,12 @@ public class MongoStoreAdministration : IFhirStoreAdministration
             new CreateIndexModel<BsonDocument>(Builders<BsonDocument>.IndexKeys.Descending(Field.WHEN).Ascending(Field.TYPENAME)),
         };
         await _collection.Indexes.CreateManyAsync(indices).ConfigureAwait(false);
+
+        var searchIndexCollection = _database.GetCollection<BsonDocument>(MongoCollections.SEARCH_INDEX_COLLECTION);
+        var searchIndexUniqueIndex = new CreateIndexModel<BsonDocument>(
+            Builders<BsonDocument>.IndexKeys.Ascending(InternalField.ID),
+            new CreateIndexOptions { Unique = true, Sparse = true });
+        await searchIndexCollection.Indexes.CreateOneAsync(searchIndexUniqueIndex).ConfigureAwait(false);
     }
 
     private async Task TryDropCollectionAsync(string name)


### PR DESCRIPTION
If the filter matches nothing (current indexed version is already newer), the operation is a no-op. This is a single atomic `FindOneAndReplace` at the MongoDB level.

- Store an `internal_version` field (integer) in the searchindex BSON document and include this when doing conditional search index writes.
- Change `MongoIndexStore.SaveAsync` to use a conditional replace using 'FindOneAndReplace' with 'IsUpsert' set to 'true'.