### PR TITLE
Everywhere: Target .NET 10.0 [v2-stu3]

### DIFF
--- a/.docker/linux/Spark.Dockerfile
+++ b/.docker/linux/Spark.Dockerfile
@@ -1,8 +1,11 @@
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-bookworm-slim AS base
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine AS base
+
+RUN apk add --no-cache icu-libs
+ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
 WORKDIR /app
 ENV ASPNETCORE_URLS=http://+:80
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0-bookworm-slim AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine AS build
 WORKDIR /src
 COPY ["./Directory.Build.props", "../Directory.Build.props"]
 COPY ["./src/Spark.Web/Spark.Web.csproj", "Spark.Web/Spark.Web.csproj"]

--- a/.github/workflows/nuget_deploy.yml
+++ b/.github/workflows/nuget_deploy.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
       - name: Build
         run: |
           dotnet pack "./src/Spark.Engine/Spark.Engine.csproj" -c Release

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
       - name: Build with dotnet
         run: dotnet build src/Spark.Web/Spark.Web.csproj -c Release
       - name: Unit tests

--- a/src/Spark.Engine.Test/Spark.Engine.Test.csproj
+++ b/src/Spark.Engine.Test/Spark.Engine.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Spark.Mongo.Tests/Spark.Mongo.Tests.csproj
+++ b/src/Spark.Mongo.Tests/Spark.Mongo.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Spark.Web.Tests/Spark.Web.Tests.csproj
+++ b/src/Spark.Web.Tests/Spark.Web.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/Spark.Web/Spark.Web.csproj
+++ b/src/Spark.Web/Spark.Web.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AspNetCoreModuleName>AspNetCoreModuleV2</AspNetCoreModuleName>
     <UserSecretsId>a4d3c2a3-5edd-47d1-8407-62489d5568c5</UserSecretsId>
   </PropertyGroup>


### PR DESCRIPTION
This affects the Docker images, tests and the Spark.Web project. The ibraries targets netstandard2.0 and are therefore already .NET 10 compatible.