### PR TITLE
Engine+Mongo: Optimize _summary=count and _count=0 execution path

### DIFF
--- a/src/Spark.Engine.Test/Service/SnapshotPaginationServiceTests.cs
+++ b/src/Spark.Engine.Test/Service/SnapshotPaginationServiceTests.cs
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026, Incendi <info@incendi.no>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+using Hl7.Fhir.Model;
+using Moq;
+using Spark.Engine.Core;
+using Spark.Engine.Interfaces;
+using Spark.Engine.Service;
+using Spark.Engine.Service.FhirServiceExtensions;
+using System;
+using Xunit;
+using Task = System.Threading.Tasks.Task;
+
+namespace Spark.Engine.Test.Service;
+
+public class SnapshotPaginationServiceTests
+{
+    private const string BaseUrl = "http://localhost/fhir";
+
+    private static ISnapshotPagination CreateService(Snapshot snapshot)
+    {
+        var mockFhirIndex = new Mock<IFhirIndex>();
+        var mockFhirStore = new Mock<Store.Interfaces.IFhirStore>();
+        var mockTransfer = new Mock<ITransfer>();
+        var mockLocalhost = new Mock<ILocalhost>();
+        var calculator = new SnapshotPaginationCalculator();
+
+        mockLocalhost
+            .Setup(l => l.Absolute(It.IsAny<Uri>()))
+            .Returns<Uri>(u => u.IsAbsoluteUri ? u : new Uri(new Uri(BaseUrl), u));
+
+        return new SnapshotPaginationService(
+            mockFhirIndex.Object,
+            mockFhirStore.Object,
+            mockTransfer.Object,
+            mockLocalhost.Object,
+            calculator,
+            snapshot);
+    }
+
+    [Fact]
+    public async Task GetPageAsync_WhenIsCountOnly_ReturnsBundleWithTotalSet()
+    {
+        const int expectedCount = 42;
+        var snapshot = Snapshot.CreateCountOnly(Bundle.BundleType.Searchset, new Uri($"{BaseUrl}/Patient"), count: 42);
+        var service = CreateService(snapshot);
+
+        var bundle = await service.GetPageAsync();
+
+        Assert.Equal(expectedCount, bundle.Total);
+    }
+
+    [Fact]
+    public async Task GetPageAsync_WhenIsCountOnly_ReturnsEmptyEntries()
+    {
+        var snapshot = Snapshot.CreateCountOnly(Bundle.BundleType.Searchset, new Uri($"{BaseUrl}/Patient"), count: 42);
+        var service = CreateService(snapshot);
+
+        var bundle = await service.GetPageAsync();
+
+        Assert.Empty(bundle.Entry);
+    }
+
+    [Fact]
+    public async Task GetPageAsync_WhenIsCountOnly_HasNoNavigationLinks()
+    {
+        var snapshot = Snapshot.CreateCountOnly(Bundle.BundleType.Searchset, new Uri($"{BaseUrl}/Patient"), count: 42);
+        var service = CreateService(snapshot);
+
+        var bundle = await service.GetPageAsync();
+
+        Assert.Null(bundle.FirstLink);
+        Assert.Null(bundle.LastLink);
+        Assert.Null(bundle.NextLink);
+        Assert.Null(bundle.PreviousLink);
+    }
+
+    [Fact]
+    public async Task GetPageAsync_WhenIsCountOnly_HasSelfLink()
+    {
+        var snapshot = Snapshot.CreateCountOnly(Bundle.BundleType.Searchset, new Uri($"{BaseUrl}/Patient"), count: 42);
+        var service = CreateService(snapshot);
+
+        var bundle = await service.GetPageAsync();
+
+        Assert.NotNull(bundle.SelfLink);
+    }
+
+    [Fact]
+    public async Task GetPageAsync_WhenIsCountOnly_BundleTypeIsSearchset()
+    {
+        var snapshot = Snapshot.CreateCountOnly(Bundle.BundleType.Searchset, new Uri($"{BaseUrl}/Patient"), count: 42);
+        var service = CreateService(snapshot);
+
+        var bundle = await service.GetPageAsync();
+
+        Assert.Equal(Bundle.BundleType.Searchset, bundle.Type);
+    }
+}

--- a/src/Spark.Engine/Core/Snapshot.cs
+++ b/src/Spark.Engine/Core/Snapshot.cs
@@ -23,6 +23,7 @@ public class Snapshot
     public string FeedSelfLink { get; set; }
     public int Count { get; set; }
     public int? CountParam { get; set; }
+    public bool IsCountOnly { get; set; }
     public DateTimeOffset WhenCreated;
     public string SortBy { get; set; }
     public IReadOnlyList<string> Includes;
@@ -48,6 +49,22 @@ public class Snapshot
             SortBy = sortby
         };
         return snapshot;
+    }
+
+    internal static Snapshot CreateCountOnly(Bundle.BundleType type, Uri selflink, long count)
+    {
+        return new Snapshot
+        {
+            Type = type,
+            Id = CreateKey(),
+            WhenCreated = DateTimeOffset.UtcNow,
+            FeedSelfLink = selflink.ToString(),
+            Keys = [],
+            Count = (int)count,
+            IsCountOnly = true,
+            Includes = [],
+            ReverseIncludes = [],
+        };
     }
 
     private static int? NormalizeCount(int? count)

--- a/src/Spark.Engine/Interfaces/IFhirIndex.cs
+++ b/src/Spark.Engine/Interfaces/IFhirIndex.cs
@@ -16,6 +16,7 @@ public interface IFhirIndex
 {
     Task CleanAsync();
     Task<SearchResults> SearchAsync(string resource, SearchParams searchCommand);
+    Task<long> CountAsync(string resource, SearchParams searchCommand);
     Task<Key> FindSingleAsync(string resource, SearchParams searchCommand);
     Task<SearchResults> GetReverseIncludesAsync(IList<IKey> keys, IList<string> revIncludes);
 }

--- a/src/Spark.Engine/Service/FhirService.cs
+++ b/src/Spark.Engine/Service/FhirService.cs
@@ -376,8 +376,11 @@ public class FhirService : FhirServiceBase, IInteractionHandler
                 Type = snapshot.Type,
                 Total = snapshot.Count
             };
-            var resourceStorage = FindExtension<IResourceStorageService>();
-            bundle.Append(await resourceStorage.GetAsync(snapshot.Keys).ConfigureAwait(false));
+            if (!snapshot.IsCountOnly)
+            {
+                var resourceStorage = FindExtension<IResourceStorageService>();
+                bundle.Append(await resourceStorage.GetAsync(snapshot.Keys).ConfigureAwait(false));
+            }
             return _responseFactory.GetFhirResponse(bundle);
         }
         else

--- a/src/Spark.Engine/Service/FhirServiceExtensions/SearchService.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/SearchService.cs
@@ -37,6 +37,16 @@ public class SearchService : ISearchService, IServiceListener
     public async Task<Snapshot> GetSnapshotAsync(string type, SearchParams searchCommand)
     {
         Validate.TypeName(type);
+
+        UriBuilder builder = new(_localhost.Uri(type));
+        Uri selflink = builder.Uri;
+
+        if (searchCommand.Count == 0 || searchCommand.Summary == SummaryType.Count)
+        {
+            long count = await _fhirIndex.CountAsync(type, searchCommand).ConfigureAwait(false);
+            return Snapshot.CreateCountOnly(Bundle.BundleType.Searchset, selflink, count);
+        }
+
         SearchResults results = await _fhirIndex.SearchAsync(type, searchCommand).ConfigureAwait(false);
 
         if (results.HasErrors)
@@ -44,13 +54,10 @@ public class SearchService : ISearchService, IServiceListener
             throw new SparkException(HttpStatusCode.BadRequest, results.Outcome);
         }
 
-        UriBuilder builder = new UriBuilder(_localhost.Uri(type))
-        {
-            Query = results.UsedParameters
-        };
-        Uri link = builder.Uri;
+        builder.Query = results.UsedParameters;
+        selflink = builder.Uri;
 
-        return CreateSnapshot(type, link, results, searchCommand);
+        return CreateSnapshot(type, selflink, results, searchCommand);
     }
 
     public async Task<Snapshot> GetSnapshotForEverythingAsync(IKey key)

--- a/src/Spark.Engine/Service/FhirServiceExtensions/SnapshotPaginationService.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/SnapshotPaginationService.cs
@@ -60,6 +60,12 @@ internal class SnapshotPaginationService : ISnapshotPagination
             Id = Guid.NewGuid().ToString()
         };
 
+        if (_snapshot.IsCountOnly)
+        {
+            bundle.SelfLink = _localhost.Absolute(new Uri(_snapshot.FeedSelfLink, UriKind.RelativeOrAbsolute));
+            return bundle;
+        }
+
         List<IKey> keys = _snapshotPaginationCalculator.GetKeysForPage(_snapshot, start).ToList();
         var entries = (await _fhirStore.GetAsync(keys, _snapshot.Elements).ConfigureAwait(false)).ToList();
         if (_snapshot.SortBy != null)

--- a/src/Spark.Mongo/Search/Infrastructure/MongoFhirIndex.cs
+++ b/src/Spark.Mongo/Search/Infrastructure/MongoFhirIndex.cs
@@ -52,6 +52,11 @@ public class MongoFhirIndex : IFhirIndex
         return await _searcher.SearchAsync(resource, searchCommand, _searchSettings).ConfigureAwait(false);
     }
 
+    public async Task<long> CountAsync(string resource, SearchParams searchCommand)
+    {
+        return await _searcher.CountAsync(resource, searchCommand, _searchSettings).ConfigureAwait(false);
+    }
+
     public async Task<Key> FindSingleAsync(string resource, SearchParams searchCommand)
     {
         // todo: this needs optimization

--- a/src/Spark.Mongo/Search/Searcher/MongoSearcher.cs
+++ b/src/Spark.Mongo/Search/Searcher/MongoSearcher.cs
@@ -584,6 +584,28 @@ public class MongoSearcher
         return results;
     }
 
+    public async Task<long> CountAsync(string resourceType, SearchParams searchCommand, SearchSettings searchSettings = null)
+    {
+        searchSettings ??= new SearchSettings();
+
+        SearchResults results = [];
+
+        var criteria = parseCriteria(resourceType, searchCommand, results);
+
+        if (results.HasErrors)
+        {
+            return 0;
+        }
+
+        results.UsedCriteria = criteria.Select(c => c.Clone()).ToList();
+        criteria = EnrichCriteriaWithSearchParameters(resourceType, results);
+        var normalizedCriteria = NormalizeNonChainedReferenceCriteria(criteria, resourceType, searchSettings);
+        var closedCriteria = await CloseChainedCriteriaAsync(resourceType, normalizedCriteria, results, 0).ConfigureAwait(false);
+        var filter = CreateMongoQuery(resourceType, results, 0, closedCriteria);
+
+        return await _collection.CountDocumentsAsync(filter).ConfigureAwait(false);
+    }
+
     private IList<(string, SortOrder)> NormalizeSortItems(string resourceType, SearchParams searchCommand)
     {
         var sortItems = searchCommand.Sort.Select(s => NormalizeSortItem(resourceType, s)).ToList();


### PR DESCRIPTION
This creates a dedicated path in our code to retrieve only the count matching the search query. On the MongoDB side of this we use MongoDB's countDocuments().

Before this change we would retrieve the FHIR resources then discarding them later in the request pipeline, specifically in the OutputFormatter.

Closes #948 