### PR TITLE
Engine: Add support for _revinclude

### DIFF
--- a/src/Spark.Engine.Test/Search/ReverseIncludeTests.cs
+++ b/src/Spark.Engine.Test/Search/ReverseIncludeTests.cs
@@ -17,7 +17,7 @@ public class ReverseIncludeTests
     [TestMethod]
     public void TestParseValid()
     {
-        ReverseInclude sut = ReverseInclude.Parse("Patient.actor");
+        ReverseInclude sut = ReverseInclude.Parse("Patient:actor");
 
         Assert.AreEqual("Patient", sut.ResourceType);
         Assert.AreEqual("actor", sut.SearchPath);
@@ -25,7 +25,7 @@ public class ReverseIncludeTests
     [TestMethod]
     public void TestParseValidLongerPath()
     {
-        ReverseInclude sut = ReverseInclude.Parse("Provenance.target.patient");
+        ReverseInclude sut = ReverseInclude.Parse("Provenance:target.patient");
 
         Assert.AreEqual("Provenance", sut.ResourceType);
         Assert.AreEqual("target.patient", sut.SearchPath);

--- a/src/Spark.Engine/Search/Model/ReverseInclude.cs
+++ b/src/Spark.Engine/Search/Model/ReverseInclude.cs
@@ -12,7 +12,7 @@ namespace Spark.Engine.Search.Model;
 
 public class ReverseInclude
 {
-    private static Regex _pattern = new Regex(@"(?<resourcetype>[^\.]+)\.(?<searchpath>.*)");
+    private static Regex _pattern = new Regex(@"(?<resourcetype>[^\.]+):(?<searchpath>.*)");
 
     public string ResourceType { get; set; }
     public string SearchPath { get; set; }

--- a/src/Spark.Engine/Service/FhirServiceExtensions/SnapshotPaginationProvider.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/SnapshotPaginationProvider.cs
@@ -13,13 +13,15 @@ namespace Spark.Engine.Service.FhirServiceExtensions;
 
 public class SnapshotPaginationProvider : ISnapshotPaginationProvider
 {
+    private readonly IFhirIndex _fhirIndex;
     private IFhirStore _fhirStore;
     private readonly ITransfer _transfer;
     private readonly ILocalhost _localhost;
     private readonly ISnapshotPaginationCalculator _snapshotPaginationCalculator;
      
-    public SnapshotPaginationProvider(IFhirStore fhirStore, ITransfer transfer, ILocalhost localhost, ISnapshotPaginationCalculator snapshotPaginationCalculator)
+    public SnapshotPaginationProvider(IFhirIndex fhirIndex, IFhirStore fhirStore, ITransfer transfer, ILocalhost localhost, ISnapshotPaginationCalculator snapshotPaginationCalculator)
     {
+        _fhirIndex = fhirIndex;
         _fhirStore = fhirStore;
         _transfer = transfer;
         _localhost = localhost;
@@ -28,6 +30,6 @@ public class SnapshotPaginationProvider : ISnapshotPaginationProvider
 
     public ISnapshotPagination StartPagination(Snapshot snapshot)
     {
-        return new SnapshotPaginationService(_fhirStore, _transfer, _localhost, _snapshotPaginationCalculator, snapshot);
+        return new SnapshotPaginationService(_fhirIndex, _fhirStore, _transfer, _localhost, _snapshotPaginationCalculator, snapshot);
     }
 }

--- a/src/Spark.Engine/Service/FhirServiceExtensions/SnapshotPaginationService.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/SnapshotPaginationService.cs
@@ -19,14 +19,16 @@ namespace Spark.Engine.Service.FhirServiceExtensions;
 
 internal class SnapshotPaginationService : ISnapshotPagination
 {
+    private readonly IFhirIndex _fhirIndex;
     private IFhirStore _fhirStore;
     private readonly ITransfer _transfer;
     private readonly ILocalhost _localhost;
     private readonly ISnapshotPaginationCalculator _snapshotPaginationCalculator;
     private readonly Snapshot _snapshot;
 
-    public SnapshotPaginationService(IFhirStore fhirStore, ITransfer transfer, ILocalhost localhost, ISnapshotPaginationCalculator snapshotPaginationCalculator, Snapshot snapshot)
+    public SnapshotPaginationService(IFhirIndex fhirIndex, IFhirStore fhirStore, ITransfer transfer, ILocalhost localhost, ISnapshotPaginationCalculator snapshotPaginationCalculator, Snapshot snapshot)
     {
+        _fhirIndex = fhirIndex;
         _fhirStore = fhirStore;
         _transfer = transfer;
         _localhost = localhost;
@@ -69,6 +71,9 @@ internal class SnapshotPaginationService : ISnapshotPagination
         IList<Entry> included = await GetIncludesRecursiveForAsync(entries, _snapshot.Includes).ConfigureAwait(false);
         entries.Append(included);
 
+        IList<Entry> revIncluded = await GetRevIncludeAsync(entries, _snapshot.ReverseIncludes);
+        entries.Append(revIncluded);
+
         _transfer.Externalize(entries);
         bundle.Append(entries);
         BuildLinks(bundle, start);
@@ -93,7 +98,7 @@ internal class SnapshotPaginationService : ISnapshotPagination
 
     private async Task<IList<Entry>> GetIncludesForAsync(IList<Entry> entries, IEnumerable<string> includes)
     {
-        if (includes == null) return new List<Entry>();
+        if (includes == null || !includes.Any()) return new List<Entry>();
 
         IEnumerable<string> paths = includes.SelectMany(i => IncludeToPath(i));
         IList<IKey> identifiers = entries.GetResources().GetReferences(paths).Distinct().Select(k => (IKey)Key.ParseOperationPath(k)).ToList();
@@ -101,6 +106,19 @@ internal class SnapshotPaginationService : ISnapshotPagination
         IList<Entry> result = (await _fhirStore.GetAsync(identifiers).ConfigureAwait(false)).ToList();
 
         return result;
+    }
+
+    private async Task<IList<Entry>> GetRevIncludeAsync(IList<Entry> entries, IEnumerable<string> revIncludes)
+    {
+        if (revIncludes == null || !revIncludes.Any()) return new List<Entry>();
+
+        var searchResults = await _fhirIndex.GetReverseIncludesAsync(entries.Select(e => e.Key).ToList(), revIncludes.ToList());
+        if (!searchResults.Any())
+        {
+            return new List<Entry>();
+        }
+
+        return await _fhirStore.GetAsync(searchResults.Select(k => Key.ParseOperationPath(k))).ConfigureAwait(false);
     }
 
     private void BuildLinks(Bundle bundle, int? offset = null)

--- a/src/Spark.Mongo/Search/Searcher/MongoSearcher.cs
+++ b/src/Spark.Mongo/Search/Searcher/MongoSearcher.cs
@@ -651,27 +651,34 @@ public class MongoSearcher
 
         if (keys != null && revIncludes != null)
         {
-            var riQueries = new List<FilterDefinition<BsonDocument>>();
-
             foreach (var revInclude in revIncludes)
             {
                 var ri = SM.ReverseInclude.Parse(revInclude);
                 if (!ri.SearchPath.Contains(".")) //for now, leave out support for chained revIncludes. There aren't that many anyway.
                 {
-                    riQueries.Add(
-                        Builders<BsonDocument>.Filter.And(
-                            Builders<BsonDocument>.Filter.Eq(InternalField.RESOURCE, ri.ResourceType)
-                            , Builders<BsonDocument>.Filter.In(ri.SearchPath, internal_ids)));
+                    var searchParamter = _fhirModel.FindSearchParameter(ri.ResourceType, ri.SearchPath);
+                    if (searchParamter == null || searchParamter.Type != SearchParamType.Reference)
+                    {
+                        continue;
+                    }
+
+                    var queries = new List<FilterDefinition<BsonDocument>>
+                    {
+                        Builders<BsonDocument>.Filter.Eq(InternalField.RESOURCE, ri.ResourceType),
+                        Builders<BsonDocument>.Filter.In(ri.SearchPath, internal_ids)
+                    };
+
+                    // Avoid using Or queries as indexes do not hit
+                    var revIncludeQuery = Builders<BsonDocument>.Filter.And(queries);
+                    List<BsonValue> selfLinks = await CollectSelfLinksAsync(revIncludeQuery, null);
+                    foreach (BsonValue selfLink in selfLinks)
+                    {
+                        results.Add(selfLink.ToString());
+                    }
                 }
             }
-
-            if (riQueries.Count > 0)
-            {
-                var revIncludeQuery = Builders<BsonDocument>.Filter.Or(riQueries);
-                var resultKeys = await CollectKeysAsync(revIncludeQuery).ConfigureAwait(false);
-                results = await KeysToSearchResultsAsync(resultKeys).ConfigureAwait(false);
-            }
         }
+
         return results;
     }
 


### PR DESCRIPTION
Only supports simple _revinclude, does not support iteration.

This is a backport of #658.