### PR TITLE
Engine: Optimize ResourceStorage.AddAsync() [stu3/master]

### DIFF
--- a/Documentation/MigrateFromv2Tov3.md
+++ b/Documentation/MigrateFromv2Tov3.md
@@ -36,6 +36,7 @@ We now target `net8.0`, `net9.0`, and `net10.0`. `netstandard2.0` and `net472` t
 - `IEnumerable<Hl7.Fhir.Model.SearchParameter> IFhirModel.FindSearchParameters(string)` has been changed to `List<Spark.Engine.Model.SearchParameter> IFhirModel.FindSearchParameters(string)`
 - `IEnumerable<Hl7.Fhir.Model.SearchParameter> IFhirModel.FindSearchParameters(Type, string)` has been changed to `List<Spark.Engine.Model.SearchParameter> IFhirModel.FindSearchParameters(Type, string)`
 - `IEnumerable<Hl7.Fhir.Model.SearchParameter> IFhirModel.FindSearchParameters(string, string)` has been changed to `List<Spark.Engine.Model.SearchParameter> IFhirModel.FindSearchParameters(string, string)`
+- `Task IFhirStore.AddAsync(Entry)` has been changed to `Task<Entry> IFhirStore.AddAsync(Entry)`
 
 ### Removed classes and interfaces
 - `ResourceVisitor` (`Spark.Engine.Core`)

--- a/src/Spark.Engine/Service/FhirServiceExtensions/ResourceStorageService.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/ResourceStorageService.cs
@@ -41,18 +41,9 @@ public class ResourceStorageService : IResourceStorageService
         {
             _transfer.Internalize(entry);
         }
-        await _fhirStore.AddAsync(entry).ConfigureAwait(false);
-        Entry result;
-        if (entry.IsDelete)
-        {
-            result = entry;
-        }
-        else
-        {
-            result = await _fhirStore.GetAsync(entry.Key).ConfigureAwait(false);
-        }
-        _transfer.Externalize(result);
 
+        var result = await _fhirStore.AddAsync(entry).ConfigureAwait(false);
+        _transfer.Externalize(result);
         return result;
     }
 

--- a/src/Spark.Engine/Store/Interfaces/IFhirStore.cs
+++ b/src/Spark.Engine/Store/Interfaces/IFhirStore.cs
@@ -13,7 +13,7 @@ namespace Spark.Engine.Store.Interfaces;
 
 public interface IFhirStore
 {
-    Task AddAsync(Entry entry);
+    Task<Entry> AddAsync(Entry entry);
     Task<Entry> GetAsync(IKey key);
     Task<IList<Entry>> GetAsync(IEnumerable<IKey> localIdentifiers, IEnumerable<string> elements = null);
 }

--- a/src/Spark.Mongo/Store/MongoFhirStore.cs
+++ b/src/Spark.Mongo/Store/MongoFhirStore.cs
@@ -28,11 +28,12 @@ public class MongoFhirStore : IFhirStore
         _collection = _database.GetCollection<BsonDocument>(Collection.RESOURCE);
     }
 
-    public async Task AddAsync(Entry entry)
+    public async Task<Entry> AddAsync(Entry entry)
     {
         BsonDocument document = SparkBsonHelper.ToBsonDocument(entry);
         await SupercedeAsync(entry.Key).ConfigureAwait(false);
         await _collection.InsertOneAsync(document).ConfigureAwait(false);
+        return document.ToEntry();
     }
 
     public async Task<Entry> GetAsync(IKey key)


### PR DESCRIPTION
There is no need to fetch the Resource from the database right after we have stored it. The Resource we are holding MongoFhirStore already has the data needed so instead change the signature of IFhirStore.AddAsync() such that it can return the Entry from the stored BsonDocument.

Closes #1139