### PR TITLE
Engine+Mongo: Include outcome entry in Bundle when unknown query param [v2-stu3]

### DIFF
--- a/src/Spark.Engine/Core/SearchResults.cs
+++ b/src/Spark.Engine/Core/SearchResults.cs
@@ -37,10 +37,14 @@ public class SearchResults : List<string>
         };
     }
 
-    public void AddIssue(string errorMessage, OperationOutcome.IssueSeverity severity = OperationOutcome.IssueSeverity.Error)
+    public void AddIssue(
+        string errorMessage,
+        OperationOutcome.IssueSeverity severity = OperationOutcome.IssueSeverity.Error,
+        OperationOutcome.IssueType code = OperationOutcome.IssueType.Processing)
     {
-        var newIssue = new OperationOutcome.IssueComponent() { Diagnostics = errorMessage, Severity = severity };
-        _outcome.Issue.Add(newIssue);
+        _outcome.Issue.Add(
+            new OperationOutcome.IssueComponent { Diagnostics = errorMessage, Severity = severity, Code = code }
+        );
     }
 
     public bool HasErrors

--- a/src/Spark.Engine/Core/Snapshot.cs
+++ b/src/Spark.Engine/Core/Snapshot.cs
@@ -28,24 +28,33 @@ public class Snapshot
     public IReadOnlyList<string> Includes;
     public IReadOnlyList<string> ReverseIncludes;
     public IReadOnlyList<string> Elements;
+    internal OperationOutcome Outcome { get; private set; }
 
-    public static Snapshot Create(Bundle.BundleType type, Uri selflink, IReadOnlyList<string> keys, string sortby, int? count, IReadOnlyList<string> includes, IReadOnlyList<string> reverseIncludes, IReadOnlyList<string> elements)
+    public static Snapshot Create(
+        Bundle.BundleType type,
+        Uri selflink,
+        IReadOnlyList<string> keys,
+        string sortby,
+        int? count,
+        IReadOnlyList<string> includes,
+        IReadOnlyList<string> reverseIncludes,
+        IReadOnlyList<string> elements,
+        OperationOutcome outcome = null)
     {
-        Snapshot snapshot = new Snapshot
+        Snapshot snapshot = new()
         {
             Type = type,
             Id = CreateKey(),
             WhenCreated = DateTimeOffset.UtcNow,
             FeedSelfLink = selflink.ToString(),
-
             Includes = includes,
             ReverseIncludes = reverseIncludes,
             Elements = elements,
             Keys = keys,
             Count = keys.Count(),
             CountParam = NormalizeCount(count),
-
-            SortBy = sortby
+            SortBy = sortby,
+            Outcome = outcome,
         };
         return snapshot;
     }

--- a/src/Spark.Engine/Extensions/BundleExtensions.cs
+++ b/src/Spark.Engine/Extensions/BundleExtensions.cs
@@ -6,6 +6,7 @@
  */
 
 using Hl7.Fhir.Model;
+using System;
 using System.Collections.Generic;
 using Spark.Engine.Core;
 
@@ -89,5 +90,15 @@ public static class BundleExtensions
         }
 
         return entries;
+    }
+
+    public static void AppendOutcome(this Bundle bundle, OperationOutcome outcome)
+    {
+        bundle.Entry.Add(new Bundle.EntryComponent
+        {
+            FullUrl = $"urn:uuid:{Guid.NewGuid()}",
+            Resource = outcome,
+            Search = new Bundle.SearchComponent { Mode = Bundle.SearchEntryMode.Outcome }
+        });
     }
 }

--- a/src/Spark.Engine/Service/FhirService.cs
+++ b/src/Spark.Engine/Service/FhirService.cs
@@ -362,6 +362,10 @@ public class FhirService : FhirServiceBase, IInteractionHandler
             };
             var resourceStorage = FindExtension<IResourceStorageService>();
             bundle.Append(await resourceStorage.GetAsync(snapshot.Keys).ConfigureAwait(false));
+
+            if (snapshot.Outcome != null)
+                bundle.AppendOutcome(snapshot.Outcome);
+
             return _responseFactory.GetFhirResponse(bundle);
         }
         else

--- a/src/Spark.Engine/Service/FhirServiceExtensions/SearchService.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/SearchService.cs
@@ -51,7 +51,7 @@ public class SearchService : ISearchService, IServiceListener
         };
         Uri link = builder.Uri;
 
-        return CreateSnapshot(type, link, results, searchCommand);
+        return CreateSnapshot(type, link, results, searchCommand, results.Outcome);
     }
 
     public async Task<Snapshot> GetSnapshotForEverythingAsync(IKey key)
@@ -92,7 +92,12 @@ public class SearchService : ISearchService, IServiceListener
         return results.HasErrors ? throw new SparkException(HttpStatusCode.BadRequest, results.Outcome) : results;
     }
 
-    private Snapshot CreateSnapshot(string type, Uri selflink, IEnumerable<string> keys, SearchParams searchCommand)
+    private Snapshot CreateSnapshot(
+        string type,
+        Uri selflink,
+        IEnumerable<string> keys,
+        SearchParams searchCommand,
+        OperationOutcome outcome = null)
     {
         string sort = GetFirstSort(searchCommand);
 
@@ -141,8 +146,17 @@ public class SearchService : ISearchService, IServiceListener
             }
         }
 
-        return Snapshot.Create(Bundle.BundleType.Searchset, selflink, keys.ToList(), sort, count, searchCommand.Include.Select(inc => inc.Item1).ToList(),
-            searchCommand.RevInclude.Select(inc => inc.Item1).ToList(), searchCommand.Elements);
+        return Snapshot.Create(
+            Bundle.BundleType.Searchset,
+            selflink,
+            keys.ToList(),
+            sort,
+            count,
+            searchCommand.Include.Select(inc => inc.Item1).ToList(),
+            searchCommand.RevInclude.Select(inc => inc.Item1).ToList(),
+            searchCommand.Elements,
+            outcome
+        );
     }
 
     private static string GetFirstSort(SearchParams searchCommand)

--- a/src/Spark.Engine/Service/FhirServiceExtensions/SnapshotPaginationService.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/SnapshotPaginationService.cs
@@ -72,10 +72,15 @@ internal class SnapshotPaginationService : ISnapshotPagination
 
         _transfer.Externalize(entries);
         bundle.Append(entries);
+
+        if (start is null or 0 && _snapshot.Outcome != null)
+            bundle.AppendOutcome(_snapshot.Outcome);
+
         BuildLinks(bundle, start);
 
         return bundle;
     }
+
     private async Task<IList<Entry>> GetIncludesRecursiveForAsync(IList<Entry> entries, IEnumerable<string> includes)
     {
         IList<Entry> included = new List<Entry>();

--- a/src/Spark.Mongo/Search/Searcher/MongoSearcher.cs
+++ b/src/Spark.Mongo/Search/Searcher/MongoSearcher.cs
@@ -718,7 +718,11 @@ public class MongoSearcher
             else
             {
                 notUsed.Add(crit);
-                results.AddIssue(String.Format("Parameter with name {0} is not supported for resource type {1}.", crit.ParamName, resourceType), OperationOutcome.IssueSeverity.Warning);
+                results.AddIssue(
+                    $"Parameter with name {crit.ParamName} is not supported for resource type {resourceType}.",
+                    OperationOutcome.IssueSeverity.Warning,
+                    OperationOutcome.IssueType.NotSupported
+                );
             }
         }
 


### PR DESCRIPTION
When we encounter an unknown query param in a search, include an outcome entry in the Bundle to indicate that we encountered a query parameter we could not interpret.