### PR TITLE
Engine: Centralize registration of ICapabilityStatementService

### DIFF
--- a/Libraries/Spark.Engine.R4/Extensions/IServiceCollectionExtensions.cs
+++ b/Libraries/Spark.Engine.R4/Extensions/IServiceCollectionExtensions.cs
@@ -27,9 +27,6 @@ public static class IServiceCollectionExtensions
             provider.GetRequiredService<IFhirModel>(),
             provider.GetRequiredService<ServerVersion>(),
             FHIRVersion.N4_0_1));
-
-        var builder = services.AddFhirInternal(settings, setupAction);
-
         services.TryAddSingleton(provider =>
             new ResourceResolver(
                 provider.GetRequiredService<IFhirModel>().SupportedResources,
@@ -37,17 +34,6 @@ public static class IServiceCollectionExtensions
             )
         );
 
-        services.AddTransient((provider) => new IFhirServiceExtension[]
-        {
-            provider.GetRequiredService<SearchService>(),
-            provider.GetRequiredService<ITransactionService>(),
-            provider.GetRequiredService<HistoryService>(),
-            provider.GetRequiredService<PagingService>(),
-            provider.GetRequiredService<ResourceStorageService>(),
-            provider.GetRequiredService<ICapabilityStatementService>(),
-            provider.GetRequiredService<PatchService>(),
-        });
-
-        return builder;
+        return services.AddFhirInternal(settings, setupAction);
     }
 }

--- a/Libraries/Spark.Engine/Extensions/IServiceCollectionExtensions.cs
+++ b/Libraries/Spark.Engine/Extensions/IServiceCollectionExtensions.cs
@@ -183,6 +183,7 @@ public static class IServiceCollectionExtensions
             provider.GetRequiredService<HistoryService>(),
             provider.GetRequiredService<PagingService>(),
             provider.GetRequiredService<ResourceStorageService>(),
+            provider.GetRequiredService<ICapabilityStatementService>(),
             provider.GetRequiredService<PatchService>(),
         });
 


### PR DESCRIPTION
Remove duplicate code + move registration of ICapabilityStatementService into shared library.