### PR TITLE
CI: Revert to ./docker/linux path + Capitalize commit prefixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,10 +21,10 @@ updates:
     schedule:
       interval: weekly
     commit-message:
-      prefix: "docker:"
+      prefix: "Docker:"
   - package-ecosystem: github-actions
     directory: "/.github/"
     schedule:
       interval: weekly
     commit-message:
-      prefix: "ci:"
+      prefix: "CI:"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,7 @@ updates:
     commit-message:
       prefix: "deps:"
   - package-ecosystem: docker
-    directory: "/.docker/"
+    directory: "/.docker/linux"
     schedule:
       interval: weekly
     commit-message:


### PR DESCRIPTION
A Dockerfile must be present in the path for dependabot to function correctly.