### PR TITLE
Applications: Correct react/react-dom mismatch causing blank page

### DIFF
--- a/Applications/Spark.Web.R4/app/package-lock.json
+++ b/Applications/Spark.Web.R4/app/package-lock.json
@@ -11,7 +11,7 @@
         "@microsoft/signalr": "^10.0.0",
         "react": "^19.2.5",
         "react-aria-components": "^1.5.0",
-        "react-dom": "^19.0.0",
+        "react-dom": "^19.2.5",
         "react-router-dom": "^7.14.2"
       },
       "devDependencies": {
@@ -4505,10 +4505,9 @@
       "license": "MIT"
     },
     "node_modules/react": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
-      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
-      "license": "MIT",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4609,15 +4608,14 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
-      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
-      "license": "MIT",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
+      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.4"
+        "react": "^19.2.6"
       }
     },
     "node_modules/react-router": {

--- a/Applications/Spark.Web.R4/app/package.json
+++ b/Applications/Spark.Web.R4/app/package.json
@@ -13,7 +13,7 @@
     "@microsoft/signalr": "^10.0.0",
     "react": "^19.2.5",
     "react-aria-components": "^1.5.0",
-    "react-dom": "^19.0.0",
+    "react-dom": "^19.2.5",
     "react-router-dom": "^7.14.2"
   },
   "devDependencies": {

--- a/Applications/Spark.Web.STU3/app/package-lock.json
+++ b/Applications/Spark.Web.STU3/app/package-lock.json
@@ -11,7 +11,7 @@
         "@microsoft/signalr": "^10.0.0",
         "react": "^19.2.5",
         "react-aria-components": "^1.5.0",
-        "react-dom": "^19.0.0",
+        "react-dom": "^19.2.5",
         "react-router-dom": "^7.14.2"
       },
       "devDependencies": {
@@ -4505,10 +4505,9 @@
       "license": "MIT"
     },
     "node_modules/react": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
-      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
-      "license": "MIT",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4609,15 +4608,14 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
-      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
-      "license": "MIT",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
+      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.4"
+        "react": "^19.2.6"
       }
     },
     "node_modules/react-router": {

--- a/Applications/Spark.Web.STU3/app/package.json
+++ b/Applications/Spark.Web.STU3/app/package.json
@@ -13,7 +13,7 @@
     "@microsoft/signalr": "^10.0.0",
     "react": "^19.2.5",
     "react-aria-components": "^1.5.0",
-    "react-dom": "^19.0.0",
+    "react-dom": "^19.2.5",
     "react-router-dom": "^7.14.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Both apps had react@19.2.5 but react-dom@19.0.0 (locked to 19.2.4). React 19 requires react and react-dom to be at the exact same version. The mismatch broke shared internals and produced a blank page.

Bump react-dom from ^19.0.0 to ^19.2.5 in both package.json files so npm resolves both to the same version (now 19.2.6).