### PR TITLE
Applications: Upgrade typescript from 5.7.3 to 6.0.3

### DIFF
--- a/Applications/Spark.Web.R4/app/package-lock.json
+++ b/Applications/Spark.Web.R4/app/package-lock.json
@@ -25,7 +25,7 @@
         "eslint-plugin-react-refresh": "^0.4.16",
         "globals": "^15.14.0",
         "tailwindcss": "^4.2.4",
-        "typescript": "~5.7.0",
+        "typescript": "^6.0.3",
         "typescript-eslint": "^8.59.3",
         "vite": "^8.0.0"
       }
@@ -5065,11 +5065,10 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/Applications/Spark.Web.R4/app/package.json
+++ b/Applications/Spark.Web.R4/app/package.json
@@ -27,7 +27,7 @@
     "eslint-plugin-react-refresh": "^0.4.16",
     "globals": "^15.14.0",
     "tailwindcss": "^4.2.4",
-    "typescript": "~5.7.0",
+    "typescript": "^6.0.3",
     "typescript-eslint": "^8.59.3",
     "vite": "^8.0.0"
   }

--- a/Applications/Spark.Web.R4/app/tsconfig.json
+++ b/Applications/Spark.Web.R4/app/tsconfig.json
@@ -23,9 +23,8 @@
     "noUncheckedSideEffectImports": true,
 
     /* Paths */
-    "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     }
   },
   "include": ["src"]

--- a/Applications/Spark.Web.STU3/app/package-lock.json
+++ b/Applications/Spark.Web.STU3/app/package-lock.json
@@ -25,7 +25,7 @@
         "eslint-plugin-react-refresh": "^0.4.16",
         "globals": "^15.14.0",
         "tailwindcss": "^4.2.4",
-        "typescript": "~5.7.0",
+        "typescript": "^6.0.3",
         "typescript-eslint": "^8.59.2",
         "vite": "^8.0.0"
       }
@@ -5065,11 +5065,10 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/Applications/Spark.Web.STU3/app/package.json
+++ b/Applications/Spark.Web.STU3/app/package.json
@@ -27,7 +27,7 @@
     "eslint-plugin-react-refresh": "^0.4.16",
     "globals": "^15.14.0",
     "tailwindcss": "^4.2.4",
-    "typescript": "~5.7.0",
+    "typescript": "^6.0.3",
     "typescript-eslint": "^8.59.2",
     "vite": "^8.0.0"
   }

--- a/Applications/Spark.Web.STU3/app/tsconfig.json
+++ b/Applications/Spark.Web.STU3/app/tsconfig.json
@@ -23,9 +23,8 @@
     "noUncheckedSideEffectImports": true,
 
     /* Paths */
-    "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     }
   },
   "include": ["src"]


### PR DESCRIPTION
Removes baseUrl this has been deprecated.