### PR TITLE
IntegrationTests: Pin plan_executor to a known stable digest [v2-r4]

### DIFF
--- a/tests/integration-tests/docker-compose.yml
+++ b/tests/integration-tests/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - "17017:27017"
   plan_executor:
     container_name: plan_executor
-    image: incendi/plan_executor:latest
+    image: incendi/plan_executor@sha256:48372ed56f54c0843f17fd625a8074a4ec651965fcbff601a695f4eaf91cc021
     depends_on:
       - spark
     volumes:


### PR DESCRIPTION
As we move forward and add tests to plan-executor for new features we do
not want other branches to fail by pulling plan_executor:latest.