### PR TITLE
Engine: Split FHIR facade services from MVC

### DIFF
--- a/Applications/Spark.Web.R4/Startup.cs
+++ b/Applications/Spark.Web.R4/Startup.cs
@@ -123,7 +123,6 @@ public class Startup
         // Sets up the MongoDB store
         services.AddMongoFhirStore(storeSettings);
 
-        // AddFhirR4 also calls AddFhir (which calls AddMvcCore)
         services.AddFhirWithMvc(sparkSettings);
 
         services.AddTransient<ServerMetadata>();

--- a/Applications/Spark.Web.R4/Startup.cs
+++ b/Applications/Spark.Web.R4/Startup.cs
@@ -124,7 +124,7 @@ public class Startup
         services.AddMongoFhirStore(storeSettings);
 
         // AddFhirR4 also calls AddFhir (which calls AddMvcCore)
-        services.AddFhir(sparkSettings);
+        services.AddFhirWithMvc(sparkSettings);
 
         services.AddTransient<ServerMetadata>();
 
@@ -177,7 +177,7 @@ public class Startup
         });
 
         // UseFhir also calls UseMvc
-        app.UseFhir(r =>
+        app.UseFhirWithMvc(r =>
         {
             r.MapRoute(name: "default", template: "{controller}/{action}/{id?}");
             // SPA fallback - serve index.html for unmatched routes (client-side routing)

--- a/Applications/Spark.Web.STU3/Startup.cs
+++ b/Applications/Spark.Web.STU3/Startup.cs
@@ -123,7 +123,6 @@ public class Startup
         // Sets up the MongoDB store
         services.AddMongoFhirStore(storeSettings);
 
-        // AddFhirR4 also calls AddFhir (which calls AddMvcCore)
         services.AddFhirWithMvc(sparkSettings);
 
         services.AddTransient<ServerMetadata>();

--- a/Applications/Spark.Web.STU3/Startup.cs
+++ b/Applications/Spark.Web.STU3/Startup.cs
@@ -124,7 +124,7 @@ public class Startup
         services.AddMongoFhirStore(storeSettings);
 
         // AddFhirR4 also calls AddFhir (which calls AddMvcCore)
-        services.AddFhir(sparkSettings);
+        services.AddFhirWithMvc(sparkSettings);
 
         services.AddTransient<ServerMetadata>();
 
@@ -177,7 +177,7 @@ public class Startup
         });
 
         // UseFhir also calls UseMvc
-        app.UseFhir(r =>
+        app.UseFhirWithMvc(r =>
         {
             r.MapRoute(name: "default", template: "{controller}/{action}/{id?}");
             // SPA fallback - serve index.html for unmatched routes (client-side routing)

--- a/Documentation/MigrateFromv2Tov3.md
+++ b/Documentation/MigrateFromv2Tov3.md
@@ -191,7 +191,6 @@ We now target `net8.0`, `net9.0`, and `net10.0`. `netstandard2.0` and `net472` t
 - `AddFhir(this IServiceCollection, SparkSettings, Action<MvcOptions>)` has been renamed to `AddFhirWithMvc(this IServiceCollection, SparkSettings, Action<MvcOptions>)`.
 - `UseFhir(this IApplicationBuilder, Action<IRouteBuilder>)` has been renamed to `UseFhirWithMvc(this IApplicationBuilder, Action<IRouteBuilder>)`.
 - `AddFhirFacadeCore(this IServiceCollection, Action<SparkOptions>)` (new, in `Spark.Engine.Extensions`) — registers the FHIR facade service layer without adding MVC controllers or formatter services. Use this when you need the FHIR service layer outside a full MVC pipeline (e.g. minimal APIs or non-MVC hosts).
-- `AddFhirR4(this IServiceCollection, SparkSettings, Action<MvcOptions>)` (new, in `Spark.Engine.R4.Extensions`) — replaces direct calls to `AddFhir()`. Registers `IFhirModel`, `CapabilityStatementService`, and all `IFhirServiceExtension` implementations including the capability statement service, then delegates to `AddFhir()`.
 - `AddFhirFormatters(this IServiceCollection, SparkSettings, Action<MvcOptions>` now returns `IMvcBuilder` instead of `IMvcCoreBuilder`.
 - `AddMongoFhirStore(this IServiceCollection, StoreSettings)` now always registers `IndexQueueSettings` (sourced from `StoreSettings.IndexQueue`) and `IIndexQueue → MongoIndexQueue`.
 

--- a/Documentation/MigrateFromv2Tov3.md
+++ b/Documentation/MigrateFromv2Tov3.md
@@ -27,6 +27,7 @@ We now target `net8.0`, `net9.0`, and `net10.0`. `netstandard2.0` and `net472` t
 - `IFhirModel.GetModelInspector()` (`ModelInspector`) — new member; returns the FHIR model inspector for class mapping lookups.
 - `IFhirModel.GetTypeForFhirType(string)` (`Type`) — new member; maps a FHIR type name to its C# type.
 - `IFhirModel.GetFhirTypeNameForType(Type)` (`string`) — new member; maps a C# type to its FHIR type name.
+- `SparkOptionsMvc` (`Spark.Engine.Extensions`) — inherits from `SparkOptions`; adds `Action<MvcOptions> MvcOptions` for MVC-specific configuration. Pass a `SparkOptionsMvc` delegate to `AddFhirFacadeWithMvc` instead of the former `SparkOptions` delegate.
 
 ### IFhirService, FhirServiceBase and FhirService changes
 - New generic methods:
@@ -73,6 +74,7 @@ We now target `net8.0`, `net9.0`, and `net10.0`. `netstandard2.0` and `net472` t
 - `CriteriaMongoExtensions.GetTargetedReferenceTypes(this Criterium, string)` has been changed to `GetTargetedReferenceTypes(this Criterium, IReadOnlyList<SearchParameter>, string)`
 - `FhirService(IFhirServiceExtension[], IFhirResponseFactory, ICompositeServiceListener)` has been changed to `FhirService(IFhirModel, IFhirServiceExtension[], IFhirResponseFactory, ICompositeServiceListener)`
 - `FhirServiceBase(IFhirServiceExtension[], IFhirResponseFactory, ICompositeServiceListener)` has been changed to `FhirServiceBase(IFhirModel, IFhirServiceExtension[], IFhirResponseFactory, ICompositeServiceListener)`
+- `SparkOptions.MvcOption` has been moved to `SparkOptionsMvc.MvcOptions` (renamed from `MvcOption` to `MvcOptions`). Update any code that set `SparkOptions.MvcOption` to instead use `SparkOptionsMvc.MvcOptions` via `AddFhirFacadeWithMvc`.
 
 ### Removed classes and interfaces
 - `ResourceVisitor` (`Spark.Engine.Core`)
@@ -185,8 +187,10 @@ We now target `net8.0`, `net9.0`, and `net10.0`. `netstandard2.0` and `net472` t
 - `SparkSettings.Version` has changed from `string` to `ServerVersion`. An implicit `operator string` on `ServerVersion` ensures backward-compatible use anywhere a `string` was expected.
 
 ### Changes to extension methods
-- `AddFhirFacade(this IServiceCollection, Action<SparkOptions>)` now returns `IMvcBuilder` instead of `IMvcCoreBuilder`.
-- `AddFhir(this IServiceCollection, SparkSettings, Action<MvcOptions>)` now returns `IMvcBuilder` instead of `IMvcCoreBuilder`. It also conditionally registers `IndexServiceListener` (default, `IndexingMode.Synchronous`) or `IndexQueueEnqueueListener` + `IndexWorker` (opt-in, `IndexingMode.Background`) based on `SparkSettings.Experimental.IndexingMode`. It no longer registers `IFhirModel` or `CapabilityStatementService`; use `AddFhirR4()` instead.
+- `AddFhirFacade(this IServiceCollection, Action<SparkOptions>)` has been renamed to `AddFhirFacadeWithMvc(this IServiceCollection, Action<SparkOptionsMvc>)`. The options delegate now receives a `SparkOptionsMvc` (which inherits from `SparkOptions`); move any `MvcOption` assignment to `MvcOptions` on the new type.
+- `AddFhir(this IServiceCollection, SparkSettings, Action<MvcOptions>)` has been renamed to `AddFhirWithMvc(this IServiceCollection, SparkSettings, Action<MvcOptions>)`.
+- `UseFhir(this IApplicationBuilder, Action<IRouteBuilder>)` has been renamed to `UseFhirWithMvc(this IApplicationBuilder, Action<IRouteBuilder>)`.
+- `AddFhirFacadeCore(this IServiceCollection, Action<SparkOptions>)` (new, in `Spark.Engine.Extensions`) — registers the FHIR facade service layer without adding MVC controllers or formatter services. Use this when you need the FHIR service layer outside a full MVC pipeline (e.g. minimal APIs or non-MVC hosts).
 - `AddFhirR4(this IServiceCollection, SparkSettings, Action<MvcOptions>)` (new, in `Spark.Engine.R4.Extensions`) — replaces direct calls to `AddFhir()`. Registers `IFhirModel`, `CapabilityStatementService`, and all `IFhirServiceExtension` implementations including the capability statement service, then delegates to `AddFhir()`.
 - `AddFhirFormatters(this IServiceCollection, SparkSettings, Action<MvcOptions>` now returns `IMvcBuilder` instead of `IMvcCoreBuilder`.
 - `AddMongoFhirStore(this IServiceCollection, StoreSettings)` now always registers `IndexQueueSettings` (sourced from `StoreSettings.IndexQueue`) and `IIndexQueue → MongoIndexQueue`.

--- a/Libraries/Spark.Engine.R4/Extensions/IServiceCollectionExtensions.cs
+++ b/Libraries/Spark.Engine.R4/Extensions/IServiceCollectionExtensions.cs
@@ -13,12 +13,13 @@ using Spark.Engine.Service.FhirServiceExtensions;
 using Hl7.Fhir.Specification;
 using Spark.Engine.Search;
 using Spark.Engine.Service;
+using System;
 
 namespace Spark.Engine.Extensions;
 
 public static class IServiceCollectionExtensions
 {
-    public static IMvcBuilder AddFhir(this IServiceCollection services, SparkSettings settings, System.Action<MvcOptions> setupAction = null)
+    public static IMvcBuilder AddFhirWithMvc(this IServiceCollection services, SparkSettings settings, Action<MvcOptions> setupAction = null)
     {
         services.TryAddSingleton<IFhirModel>(_ => new FhirModel(ModelInfo.SearchParameters));
         services.TryAddSingleton<IFhirService, FhirServiceR4>();
@@ -45,6 +46,6 @@ public static class IServiceCollectionExtensions
             provider.GetRequiredService<PatchService>(),
         });
 
-        return services.AddFhirInternal(settings, setupAction);
+        return services.AddFhirWithMvcInternal(settings, setupAction);
     }
 }

--- a/Libraries/Spark.Engine.STU3/Extensions/IServiceCollectionExtensions.cs
+++ b/Libraries/Spark.Engine.STU3/Extensions/IServiceCollectionExtensions.cs
@@ -18,7 +18,7 @@ namespace Spark.Engine.Extensions;
 
 public static class IServiceCollectionExtensions
 {
-    public static IMvcBuilder AddFhir(this IServiceCollection services, SparkSettings settings, System.Action<MvcOptions> setupAction = null)
+    public static IMvcBuilder AddFhirWithMvc(this IServiceCollection services, SparkSettings settings, System.Action<MvcOptions> setupAction = null)
     {
         services.TryAddSingleton<IFhirModel>(_ => new FhirModel(ModelInfo.SearchParameters));
         services.TryAddSingleton<IFhirService, FhirServiceStu3>();
@@ -45,6 +45,6 @@ public static class IServiceCollectionExtensions
             provider.GetRequiredService<PatchService>(),
         });
 
-        return services.AddFhirInternal(settings, setupAction);
+        return services.AddFhirWithMvcInternal(settings, setupAction);
     }
 }

--- a/Libraries/Spark.Engine/Extensions/IApplicationBuilderExtensions.cs
+++ b/Libraries/Spark.Engine/Extensions/IApplicationBuilderExtensions.cs
@@ -15,7 +15,7 @@ namespace Spark.Engine.Extensions;
 
 public static class IApplicationBuilderExtensions
 {
-    public static void UseFhir(this IApplicationBuilder app, Action<IRouteBuilder> configureRoutes = null)
+    public static void UseFhirWithMvc(this IApplicationBuilder app, Action<IRouteBuilder> configureRoutes = null)
     {
         app.UseMiddleware<ErrorHandler>();
         app.UseMiddleware<FormatTypeHandler>();

--- a/Libraries/Spark.Engine/Extensions/IServiceCollectionExtensions.cs
+++ b/Libraries/Spark.Engine/Extensions/IServiceCollectionExtensions.cs
@@ -76,28 +76,41 @@ public static class IServiceCollectionExtensions
     private static DeserializerSettings GetDeserializerSettings(SparkSettings settings) =>
         settings.DeserializerSettings ?? DeserializerSettingsFactory.GetStrictDeserializerSettings();
 
-    public static IMvcBuilder AddFhirFacade(this IServiceCollection services, Action<SparkOptions> options)
+    public static IServiceCollection AddFhirFacadeCore(this IServiceCollection services, Action<SparkOptions> options)
     {
         services.Configure(options);
-
         var serviceProvider = services.BuildServiceProvider();
-        var opts = serviceProvider.GetRequiredService<IOptions<SparkOptions>>()?.Value;
-        var settings = opts.Settings;
+        var opts = serviceProvider.GetRequiredService<IOptions<SparkOptionsMvc>>()?.Value;
+        return services.AddFhirFacadeCoreInternal(opts);
+    }
+
+    public static IMvcBuilder AddFhirFacadeWithMvc(this IServiceCollection services, Action<SparkOptionsMvc> options)
+    {
+        services.Configure(options);
+        var serviceProvider = services.BuildServiceProvider();
+        var opts = serviceProvider.GetRequiredService<IOptions<SparkOptionsMvc>>()?.Value;
+        services.AddFhirFacadeCoreInternal(opts);
+        return services.AddFhirFormatters(opts.Settings, opts.MvcOptions);
+    }
+
+    private static IServiceCollection AddFhirFacadeCoreInternal(this IServiceCollection services, SparkOptions options)
+    {
+        var settings = options.Settings;
 
         services.AddSingleton(settings);
-        services.AddSingleton(opts.StoreSettings);
+        services.AddSingleton(options.StoreSettings);
 
-        foreach (KeyValuePair<Type,Type> fhirService in opts.FhirServices)
+        foreach (KeyValuePair<Type, Type> fhirService in options.FhirServices)
         {
             services.AddSingleton(fhirService.Key, fhirService.Value);
         }
 
-        foreach (var fhirStore in opts.FhirStores)
+        foreach (var fhirStore in options.FhirStores)
         {
             services.AddTransient(fhirStore.Key, fhirStore.Value);
         }
 
-        services.AddTransient<ILocalhost>(_ => new Localhost(opts.Settings?.Endpoint));
+        services.AddTransient<ILocalhost>(_ => new Localhost(options.Settings?.Endpoint));
 
         services.TryAddTransient<ITransfer, Transfer>();
         services.TryAddTransient<ConditionalHeaderFhirResponseInterceptor>();
@@ -105,17 +118,13 @@ public static class IServiceCollectionExtensions
         services.TryAddTransient<IFhirResponseInterceptorRunner, FhirResponseInterceptorRunner>();
         services.TryAddTransient<IFhirResponseFactory, FhirResponseFactory.FhirResponseFactory>();
         services.TryAddTransient<ICompositeServiceListener, ServiceListener>();
-        services.TryAddTransient<ResourceJsonInputFormatter>();
-        services.TryAddTransient<ResourceJsonOutputFormatter>();
-        services.TryAddTransient<ResourceXmlInputFormatter>();
-        services.TryAddTransient<ResourceXmlOutputFormatter>();
 
         if (services.IndexOf(new ServiceDescriptor(typeof(IResourceStorageService), typeof(ResourceStorageService), ServiceLifetime.Transient)) == -1)
         {
             services.TryAddTransient<IResourceStorageService, ResourceStorageService>();
         }
 
-        services.AddFhirExtensions(opts.FhirExtensions);
+        services.AddFhirExtensions(options.FhirExtensions);
 
         services.TryAddTransient(provider =>  provider.GetServices<IServiceListener>().ToArray());
 
@@ -124,10 +133,10 @@ public static class IServiceCollectionExtensions
         services.TryAddSingleton(provider => new BaseFhirJsonSerializer(provider.GetRequiredService<IFhirModel>().GetModelInspector()));
         services.TryAddSingleton(provider => new BaseFhirXmlSerializer(provider.GetRequiredService<IFhirModel>().GetModelInspector()));
 
-        return services.AddFhirFormatters(settings, opts.MvcOption);
+        return services;
     }
 
-    internal static IMvcBuilder AddFhirInternal(this IServiceCollection services, SparkSettings settings, Action<MvcOptions> setupAction = null)
+    internal static IMvcBuilder AddFhirWithMvcInternal(this IServiceCollection services, SparkSettings settings, Action<MvcOptions> setupAction = null)
     {
         ArgumentNullException.ThrowIfNull(settings);
 
@@ -171,10 +180,6 @@ public static class IServiceCollectionExtensions
         services.TryAddTransient<ResourceStorageService>();            // storage
         services.TryAddTransient<PatchService>();           // patch
         services.TryAddTransient<ICompositeServiceListener, ServiceListener>();
-        services.TryAddTransient<ResourceJsonInputFormatter>();
-        services.TryAddTransient<ResourceJsonOutputFormatter>();
-        services.TryAddTransient<ResourceXmlInputFormatter>();
-        services.TryAddTransient<ResourceXmlOutputFormatter>();
 
         services.TryAddSingleton(provider => new BaseFhirJsonDeserializer(provider.GetRequiredService<IFhirModel>().GetModelInspector(), GetDeserializerSettings(settings)));
         services.TryAddSingleton(provider => new BaseFhirXmlDeserializer(provider.GetRequiredService<IFhirModel>().GetModelInspector(), GetDeserializerSettings(settings)));
@@ -192,6 +197,16 @@ public static class IServiceCollectionExtensions
         services.AddCustomSearchParameters(settings.CustomSearchParameters);
 
         return builder;
+    }
+
+    private static void AddFhirMvcFormatterServices(this IServiceCollection services)
+    {
+        services.TryAddTransient(provider => new ResourceJsonInputFormatter(
+            provider.GetRequiredService<BaseFhirJsonDeserializer>(),
+            ArrayPool<char>.Shared));
+        services.TryAddTransient<ResourceJsonOutputFormatter>();
+        services.TryAddTransient<ResourceXmlInputFormatter>();
+        services.TryAddTransient<ResourceXmlOutputFormatter>();
     }
 
     private static IMvcBuilder AddFhirFormatters(this IServiceCollection services, SparkSettings settings, Action<MvcOptions> setupAction = null)

--- a/Libraries/Spark.Engine/Extensions/SparkOptions.cs
+++ b/Libraries/Spark.Engine/Extensions/SparkOptions.cs
@@ -18,6 +18,9 @@ public class SparkOptions
     public FhirServiceDictionary FhirServices { get; } = new();
 
     public FhirStoreDictionary FhirStores { get; } = new();
+}
 
-    public Action<MvcOptions> MvcOption { get; set; }
+public class SparkOptionsMvc : SparkOptions
+{
+    public Action<MvcOptions> MvcOptions { get; set; }
 }

--- a/Tests/Spark.Engine.R4.Tests/Extensions/FhirFacadeServiceCollectionExtensionsTests.cs
+++ b/Tests/Spark.Engine.R4.Tests/Extensions/FhirFacadeServiceCollectionExtensionsTests.cs
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026, Incendi <info@incendi.no>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+using Hl7.Fhir.Serialization;
+using Microsoft.AspNetCore.Mvc.ApplicationParts;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Spark.Engine.Core;
+using Spark.Engine.Extensions;
+using Spark.Engine.FhirResponseFactory;
+using Spark.Engine.Interfaces;
+using System;
+using Xunit;
+
+namespace Spark.Engine.Tests.Extensions;
+
+public class FhirFacadeServiceCollectionExtensionsTests
+{
+    [Fact]
+    public void AddFhirFacadeCore_RegistersFacadeServices_WithoutControllerServices()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IFhirModel, FhirModel>();
+
+        services.AddFhirFacadeCore(options =>
+        {
+            options.Settings.Endpoint = new Uri("http://localhost/fhir");
+        });
+
+        Assert.DoesNotContain(services, descriptor => descriptor.ServiceType == typeof(ApplicationPartManager));
+        Assert.DoesNotContain(services, descriptor => descriptor.ServiceType == typeof(IActionInvokerFactory));
+
+        using var provider = services.BuildServiceProvider();
+
+        Assert.NotNull(provider.GetRequiredService<SparkSettings>());
+        Assert.NotNull(provider.GetRequiredService<StoreSettings>());
+        Assert.NotNull(provider.GetRequiredService<ILocalhost>());
+        Assert.NotNull(provider.GetRequiredService<IFhirResponseFactory>());
+        Assert.NotNull(provider.GetRequiredService<BaseFhirJsonDeserializer>());
+        Assert.NotNull(provider.GetRequiredService<BaseFhirXmlDeserializer>());
+        Assert.NotNull(provider.GetRequiredService<BaseFhirJsonSerializer>());
+        Assert.NotNull(provider.GetRequiredService<BaseFhirXmlSerializer>());
+    }
+}

--- a/Tests/Spark.Engine.STU3.Tests/Extensions/FhirFacadeServiceCollectionExtensionsTests.cs
+++ b/Tests/Spark.Engine.STU3.Tests/Extensions/FhirFacadeServiceCollectionExtensionsTests.cs
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026, Incendi <info@incendi.no>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+using Hl7.Fhir.Serialization;
+using Microsoft.AspNetCore.Mvc.ApplicationParts;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Spark.Engine.Core;
+using Spark.Engine.Extensions;
+using Spark.Engine.FhirResponseFactory;
+using Spark.Engine.Interfaces;
+using System;
+using Xunit;
+
+namespace Spark.Engine.Tests.Extensions;
+
+public class FhirFacadeServiceCollectionExtensionsTests
+{
+    [Fact]
+    public void AddFhirFacadeCore_RegistersFacadeServices_WithoutControllerServices()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IFhirModel, FhirModel>();
+
+        services.AddFhirFacadeCore(options =>
+        {
+            options.Settings.Endpoint = new Uri("http://localhost/fhir");
+        });
+
+        Assert.DoesNotContain(services, descriptor => descriptor.ServiceType == typeof(ApplicationPartManager));
+        Assert.DoesNotContain(services, descriptor => descriptor.ServiceType == typeof(IActionInvokerFactory));
+
+        using var provider = services.BuildServiceProvider();
+
+        Assert.NotNull(provider.GetRequiredService<SparkSettings>());
+        Assert.NotNull(provider.GetRequiredService<StoreSettings>());
+        Assert.NotNull(provider.GetRequiredService<ILocalhost>());
+        Assert.NotNull(provider.GetRequiredService<IFhirResponseFactory>());
+        Assert.NotNull(provider.GetRequiredService<BaseFhirJsonDeserializer>());
+        Assert.NotNull(provider.GetRequiredService<BaseFhirXmlDeserializer>());
+        Assert.NotNull(provider.GetRequiredService<BaseFhirJsonSerializer>());
+        Assert.NotNull(provider.GetRequiredService<BaseFhirXmlSerializer>());
+    }
+}

--- a/Tests/Spark.Web.Tests.Shared/MultiFormatterSupportTest.cs
+++ b/Tests/Spark.Web.Tests.Shared/MultiFormatterSupportTest.cs
@@ -38,7 +38,7 @@ public class MultiFormatterSupportTest : IClassFixture<WebApplicationFactory<Pro
                     DeserializerSettings = new DeserializerSettings().UsingMode(DeserializationMode.Strict),
                     UseAsynchronousIO = true
                 };
-                services.AddFhir(settings);
+                services.AddFhirWithMvc(settings);
                 services.AddMvc(options =>
                 {
                     options.EnableEndpointRouting = false;
@@ -48,7 +48,7 @@ public class MultiFormatterSupportTest : IClassFixture<WebApplicationFactory<Pro
 
             builder.Configure(app =>
             {
-                app.UseFhir();
+                app.UseFhirWithMvc();
             });
         });
     }


### PR DESCRIPTION
Introduce AddFhirFacadeCore for registering the FHIR facade service layer
without calling AddControllers or registering MVC formatter services.

Renames:
- AddFhirFacade -> AddFhirFacadeWithMvc.
- AddFhir -> AddFhirWithMvc
- UseFhir -> UseFhirWithMvc

Add SparkOptionsMvc inheriting from SparkOptions and move property
Action<MvcOptions> MvcOptions to this class.

Drop the TryAddTransient registrations for ResourceJson/XmlInput/OutputFormatter
from both the facade and AddFhirInternal — nothing resolved them from DI, and
the formatters are still constructed manually and inserted into
MvcOptions.InputFormatters/OutputFormatters by AddFhirFormatters when wiring
up the MVC pipeline.

Add a contract test covering the MVC-free facade registration.