### PR TITLE
deps: Upgrade MongoDB.Driver 3.5.2 -> 3.8.1

### DIFF
--- a/Libraries/Spark.Mongo/Spark.Mongo.csproj
+++ b/Libraries/Spark.Mongo/Spark.Mongo.csproj
@@ -12,7 +12,7 @@
     <ItemGroup>
         <PackageReference Include="Hl7.Fhir.Base" Version="6.1.1" />
         <PackageReference Include="Medo.Uuid7" Version="3.2.0" />
-        <PackageReference Include="MongoDB.Driver" Version="3.5.2" />
+        <PackageReference Include="MongoDB.Driver" Version="3.8.1" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
See https://github.com/mongodb/mongo-csharp-driver/releases/tag/v3.8.1 for further information on the NU1902 audit warning for the transitive dependency SharpCompress 0.30.1.