### PR TITLE
Engine: Include missing required attributes for CapabilityStatement 

### DIFF
--- a/Libraries/Spark.Engine.STU3/Spark.Engine.STU3.csproj
+++ b/Libraries/Spark.Engine.STU3/Spark.Engine.STU3.csproj
@@ -10,6 +10,10 @@
         <RootNamespace>Spark.Engine</RootNamespace>
     </PropertyGroup>
 
+    <PropertyGroup>
+        <DefineConstants>$(DefineConstants);FHIR_STU3</DefineConstants>
+    </PropertyGroup>
+
     <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
     </ItemGroup>

--- a/Libraries/Spark.Engine.Shared/Service/FhirServiceExtensions/CapabilityStatementService.cs
+++ b/Libraries/Spark.Engine.Shared/Service/FhirServiceExtensions/CapabilityStatementService.cs
@@ -40,6 +40,10 @@ public class CapabilityStatementService : ICapabilityStatementService
             .WithVersion(_serverVersion)
             .WithPublisher("Incendi")
             .WithDate(DateTimeOffset.UtcNow)
+            .WithStatus(PublicationStatus.Active)
+#if FHIR_STU3
+            .WithAcceptUnknown(UnknownContentCode.Extensions)
+#endif
             .WithCopyright(
                 "This server is Open Source Software, licensed under the terms of the [BSD-3-Clause License](https://raw.githubusercontent.com/FirelyTeam/spark/refs/heads/r4/master/LICENSE)")
             .WithExperimental(true)

--- a/Tests/Spark.Engine.R4.Tests/Service/CapabilityStatementServiceTests.Version.cs
+++ b/Tests/Spark.Engine.R4.Tests/Service/CapabilityStatementServiceTests.Version.cs
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Incendi <info@incendi.no>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
 using Hl7.Fhir.Model;
 using System.Collections.Generic;
 using System.Linq;

--- a/Tests/Spark.Engine.STU3.Tests/Service/CapabilityStatementServiceTests.Version.cs
+++ b/Tests/Spark.Engine.STU3.Tests/Service/CapabilityStatementServiceTests.Version.cs
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Incendi <info@incendi.no>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
 using Hl7.Fhir.Model;
 using System.Collections.Generic;
 using System.Linq;

--- a/Tests/Spark.Engine.Tests.Shared/Service/CapabilityStatementServiceTests.cs
+++ b/Tests/Spark.Engine.Tests.Shared/Service/CapabilityStatementServiceTests.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Hl7.Fhir.Model;
+using Hl7.Fhir.Serialization;
 using Moq;
 using Spark.Engine.Core;
 using Spark.Engine.Service.FhirServiceExtensions;
@@ -189,5 +190,18 @@ public partial class CapabilityStatementServiceTests
         Assert.True(ContainsOperationDefinition("OperationDefinition/Composition-document", operations));
         Assert.Contains("Fetch Patient Record", operations.Values);
         Assert.Contains("Generate a Document", operations.Values);
+    }
+
+    [Fact]
+    public void GetSparkCapabilityStatement_CanBeSerializedAndDeserializedInStrictMode()
+    {
+        var service = CreateService(new Uri("http://localhost/fhir/"));
+        var capabilityStatement = service.GetSparkCapabilityStatement();
+
+        var serializer = new FhirJsonSerializer();
+        var serializedCapabilityStatement = serializer.SerializeToString(capabilityStatement);
+
+        var deserializer = new FhirJsonDeserializer(new DeserializerSettings().UsingMode(DeserializationMode.Strict));
+        _ = deserializer.Deserialize<CapabilityStatement>(serializedCapabilityStatement);
     }
 }


### PR DESCRIPTION
CapabilityStatement.status has a cardinality of 1..1 and is required for both STU3 and R4.

CapabilityStatement.acceptUnknown has a cardinality of 1..1 and is required only for STU3.