### PR TITLE
deps: Upgrade MongoDB.Driver 3.8.1 -> 3.9.0

### DIFF
--- a/Libraries/Spark.Store.MongoDB/Spark.Store.MongoDB.csproj
+++ b/Libraries/Spark.Store.MongoDB/Spark.Store.MongoDB.csproj
@@ -12,7 +12,7 @@
     <ItemGroup>
         <PackageReference Include="Hl7.Fhir.Base" Version="6.1.1" />
         <PackageReference Include="Medo.Uuid7" Version="3.2.0" />
-        <PackageReference Include="MongoDB.Driver" Version="3.8.1" />
+        <PackageReference Include="MongoDB.Driver" Version="3.9.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This version of MongoDB.Driver contains an update for  the transitive dependency SharpCompress resolving the NU1902 warning.