### PR TITLE
Store: Surface chained-search inner-query errors

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -26,6 +26,9 @@ jobs:
           dotnet test "./Tests/Spark.Engine.Tests/Spark.Engine.Tests.csproj"
           dotnet test "./Tests/Spark.Engine.STU3.Tests/Spark.Engine.STU3.Tests.csproj"
           dotnet test "./Tests/Spark.Engine.R4.Tests/Spark.Engine.R4.Tests.csproj"
-          dotnet test "./Tests/Spark.Store.MongoDB.Tests/Spark.Store.MongoDB.Tests.csproj"
+          dotnet test "./Tests/Spark.Store.MongoDB.Tests/Spark.Store.MongoDB.Tests.csproj" --filter "Category!=Integration"
           dotnet test "./Tests/Spark.Web.STU3.Tests/Spark.Web.STU3.Tests.csproj"
           dotnet test "./Tests/Spark.Web.R4.Tests/Spark.Web.R4.Tests.csproj"
+      - name: Integration tests (Docker, Linux only)
+        if: runner.os == 'Linux'
+        run: dotnet test "./Tests/Spark.Store.MongoDB.Tests/Spark.Store.MongoDB.Tests.csproj" --filter "Category=Integration"

--- a/Libraries/Spark.Store.MongoDB/Search/CriteriaMongoExtensions.cs
+++ b/Libraries/Spark.Store.MongoDB/Search/CriteriaMongoExtensions.cs
@@ -65,7 +65,7 @@ internal static class CriteriaMongoExtensions
             //return null;
         }
 
-        throw new ArgumentException(string.Format("Resource {0} has no parameter with the name {1}.", resourceType, param.ParamName));
+        throw new UnknownSearchParameterException(string.Format("Resource {0} has no parameter with the name {1}.", resourceType, param.ParamName));
     }
 
     private static FilterDefinition<BsonDocument> CreateFilter(SearchParameter parameter, Operator op, String modifier, Expression operand)

--- a/Libraries/Spark.Store.MongoDB/Search/MongoSearcher.cs
+++ b/Libraries/Spark.Store.MongoDB/Search/MongoSearcher.cs
@@ -263,7 +263,7 @@ public class MongoSearcher
                     closedCriteria.Add(c.Clone(), CloseCriterium(c, resourceType, level));
                     //CK: We don't pass the SearchResults on to the (recursive) CloseCriterium. We catch any exceptions only on the highest level.
                 }
-                catch (ArgumentException ex)
+                catch (UnknownSearchParameterException ex)
                 {
                     if (results == null) throw; //The exception *will* be caught on the highest level.
                     results.AddIssue(String.Format("Parameter [{0}] was ignored for the reason: {1}.", c.ToString(), ex.Message), OperationOutcome.IssueSeverity.Warning);
@@ -293,7 +293,7 @@ public class MongoSearcher
                     closedCriteria.Add(c.Clone(), await CloseCriteriumAsync(c, resourceType, level).ConfigureAwait(false));
                     //CK: We don't pass the SearchResults on to the (recursive) CloseCriterium. We catch any exceptions only on the highest level.
                 }
-                catch (ArgumentException ex)
+                catch (UnknownSearchParameterException ex)
                 {
                     if (results == null) throw; //The exception *will* be caught on the highest level.
                     results.AddIssue(String.Format("Parameter [{0}] was ignored for the reason: {1}.", c.ToString(), ex.Message), OperationOutcome.IssueSeverity.Warning);
@@ -339,7 +339,7 @@ public class MongoSearcher
         if (errors.Count == targeted.Count())
         {
             //It is possible that some of the targets don't support the current parameter. But if none do, there is a serious problem.
-            throw new ArgumentException(String.Format("None of the possible target resources support querying for parameter {0}", crit.ParamName));
+            throw new UnknownSearchParameterException(String.Format("None of the possible target resources support querying for parameter {0}", crit.ParamName));
         }
         crit.Operator = Operator.IN;
         crit.Operand = new ChoiceValue(allKeys.Select(k => new UntypedValue(k)));
@@ -375,7 +375,7 @@ public class MongoSearcher
         if (errors.Count == targeted.Count())
         {
             //It is possible that some of the targets don't support the current parameter. But if none do, there is a serious problem.
-            throw new ArgumentException(String.Format("None of the possible target resources support querying for parameter {0}", crit.ParamName));
+            throw new UnknownSearchParameterException(String.Format("None of the possible target resources support querying for parameter {0}", crit.ParamName));
         }
         crit.Operator = Operator.IN;
         crit.Operand = new ChoiceValue(allKeys.Select(k => new UntypedValue(k)));

--- a/Libraries/Spark.Store.MongoDB/Search/MongoSearcher.cs
+++ b/Libraries/Spark.Store.MongoDB/Search/MongoSearcher.cs
@@ -331,8 +331,9 @@ public class MongoSearcher
                 var keys = CollectKeys(target, new List<Criterium> { innerCriterium }, ++level);
                 allKeys.AddRange(keys.Select(k => k.ToString()));
             }
-            catch (Exception ex)
+            catch (UnknownSearchParameterException ex)
             {
+                // Tolerate a target that doesn't declare the parameter; any other failure must surface.
                 errors.Add(ex);
             }
         }
@@ -367,8 +368,9 @@ public class MongoSearcher
                 var keys = await CollectKeysAsync(target, new List<Criterium> { innerCriterium }, ++level).ConfigureAwait(false);
                 allKeys.AddRange(keys.Select(k => k.ToString()));
             }
-            catch (Exception ex)
+            catch (UnknownSearchParameterException ex)
             {
+                // Tolerate a target that doesn't declare the parameter; any other failure must surface.
                 errors.Add(ex);
             }
         }

--- a/Libraries/Spark.Store.MongoDB/Search/UnknownSearchParameterException.cs
+++ b/Libraries/Spark.Store.MongoDB/Search/UnknownSearchParameterException.cs
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2025, Incendi <info@incendi.no>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+using System;
+
+namespace Spark.Store.MongoDB.Search;
+
+/// <summary>
+/// Thrown when a resource does not declare the requested search parameter. Derives from
+/// <see cref="ArgumentException"/> for backward compatibility, but lets chained-search resolution
+/// tell a genuinely unknown parameter apart from other (real) query failures that must surface.
+/// </summary>
+internal sealed class UnknownSearchParameterException : ArgumentException
+{
+    public UnknownSearchParameterException(string message) : base(message) { }
+}

--- a/Tests/Spark.Store.MongoDB.Tests/Search/ChainedSearchErrorHandlingTests.cs
+++ b/Tests/Spark.Store.MongoDB.Tests/Search/ChainedSearchErrorHandlingTests.cs
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2025, Incendi <info@incendi.no>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+using System;
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Rest;
+using Hl7.Fhir.Specification;
+using MongoDB.Driver;
+using Spark.Engine.Core;
+using Spark.Engine.Search;
+using Spark.Engine.Service.FhirServiceExtensions;
+using Spark.Store.MongoDB.Search;
+using Spark.Store.MongoDB.Search.Common;
+using Spark.Store.MongoDB.Search.Indexer;
+using Testcontainers.MongoDb;
+using Xunit;
+using Task = System.Threading.Tasks.Task;
+
+namespace Spark.Store.MongoDB.Tests.Search;
+
+/// <summary>
+/// When a chained search resolves its inner sub-query, a failure of that sub-query must not be
+/// swallowed: doing so mis-reports it as an unsupported parameter and silently drops the chain
+/// constraint, so the search returns every resource instead of the filtered set. Here the inner
+/// query fails because the date prefix (ge) is not stripped for it and the value fails to parse.
+///
+/// Requires Docker (Testcontainers); tagged Integration so the cross-platform unit run skips it
+/// (only the Linux CI leg has Docker), while it still runs locally via a normal `dotnet test`.
+/// </summary>
+[Trait("Category", "Integration")]
+public class ChainedSearchErrorHandlingTests
+{
+    private const string BaseUri = "http://localhost/";
+
+    [Theory]
+    [InlineData("subject:Patient.birthdate", "ge1974-12-25")] // prefix not stripped -> the date fails to parse
+    [InlineData("subject:Patient.name:above", "Smith")]        // unsupported modifier on the inner parameter
+    public async Task Chained_search_does_not_silently_drop_constraint_when_inner_query_fails(string chainedParameter, string value)
+    {
+        MongoDbContainer container = null;
+        try
+        {
+            // Building/starting the container probes the Docker endpoint; on a host without Docker
+            // (e.g. the macOS/Windows CI runners) that throws, so skip rather than fail.
+            try
+            {
+                container = new MongoDbBuilder("mongo:8.2.7").Build();
+                await container.StartAsync(TestContext.Current.CancellationToken);
+            }
+            catch (Exception ex)
+            {
+                Assert.Skip($"Docker/Testcontainers not available: {ex.Message}");
+            }
+
+            var connectionString = BuildConnectionString(container.GetConnectionString(), "sparktest");
+
+            // Wire up the real index/search object graph.
+            IFhirModel fhirModel = new FhirModel();
+            ILocalhost localhost = new Localhost(new Uri(BaseUri));
+            var referenceNormalization = new ReferenceNormalizationService(localhost);
+            var indexStore = new MongoIndexStore(connectionString, new MongoIndexMapper());
+            var elementIndexer = new ElementIndexer(fhirModel);
+            var resolver = new ResourceResolver(fhirModel.SupportedResources, new PocoStructureDefinitionSummaryProvider());
+            var indexService = new IndexService(fhirModel, indexStore, elementIndexer, resolver);
+            var searcher = new MongoSearcher(indexStore, localhost, fhirModel, referenceNormalization);
+
+            // Two patients born after the cut-off and two before, each with one Observation.
+            var birthdates = new[] { "2000-01-01", "2001-01-01", "1950-01-01", "1951-01-01" };
+            for (var i = 0; i < birthdates.Length; i++)
+            {
+                var patient = new Patient { Id = $"p{i}", BirthDate = birthdates[i] };
+                await indexService.IndexResourceAsync(patient, new Key(BaseUri, "Patient", $"p{i}", "1"));
+
+                var observation = new Observation
+                {
+                    Id = $"o{i}",
+                    Status = ObservationStatus.Final,
+                    Code = new CodeableConcept("http://loinc.org", "1234-5"),
+                    Subject = new ResourceReference($"Patient/p{i}"),
+                };
+                await indexService.IndexResourceAsync(observation, new Key(BaseUri, "Observation", $"o{i}", "1"));
+            }
+
+            var search = new SearchParams().Add(chainedParameter, value);
+
+            SearchResults results = null;
+            Exception thrown = null;
+            try
+            {
+                results = await searcher.SearchAsync("Observation", search);
+            }
+            catch (Exception ex)
+            {
+                thrown = ex;
+            }
+
+            // The chain constraint must take effect (fewer matches than the total) or the failure must
+            // surface as an exception. Silently returning every Observation - or returning nothing
+            // without an error - means the inner-query failure was swallowed.
+            Assert.True(thrown != null || (results != null && results.MatchCount < birthdates.Length),
+                $"Chained constraint had no effect: matches={results?.MatchCount.ToString() ?? "null"}, " +
+                $"thrown={thrown?.GetType().Name ?? "none"}.");
+        }
+        finally
+        {
+            if (container != null)
+                await container.DisposeAsync();
+        }
+    }
+
+    private static string BuildConnectionString(string raw, string databaseName)
+    {
+        var builder = new MongoUrlBuilder(raw) { DatabaseName = databaseName };
+        if (!string.IsNullOrEmpty(builder.Username) && string.IsNullOrEmpty(builder.AuthenticationSource))
+        {
+            builder.AuthenticationSource = "admin";
+        }
+        return builder.ToMongoUrl().ToString();
+    }
+}

--- a/Tests/Spark.Store.MongoDB.Tests/Spark.Store.MongoDB.Tests.csproj
+++ b/Tests/Spark.Store.MongoDB.Tests/Spark.Store.MongoDB.Tests.csproj
@@ -14,6 +14,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="Testcontainers.MongoDb" Version="4.12.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR fixes chained-search behavior in the MongoDB store so that failures while resolving an inner (chained) sub-query no longer get swallowed and mis-reported as “unsupported parameter,” which previously caused the chain constraint to be dropped and the search to return unfiltered results (root cause of the “returns everything” symptom described in https://github.com/FirelyTeam/spark/issues/552).