### PR TITLE
Engine: Apply comparator prefix on chained inner search parameter

### DIFF
--- a/Libraries/Spark.Engine/Search/Types/Criterium.cs
+++ b/Libraries/Spark.Engine/Search/Types/Criterium.cs
@@ -165,7 +165,9 @@ public class Criterium : Expression, ICloneable
         if (path.Length > 1)
         {
             type = Operator.CHAIN;
-            operand = fromPathTuples(path.Slice(1), value, resourceType, searchParameters);
+            // Resolve the rest of the chain against the reference's target type (subject:Patient),
+            // not the outer type - otherwise a comparator prefix (e.g. ge) is left unstripped.
+            operand = fromPathTuples(path.Slice(1), value, modifier ?? resourceType, searchParameters);
         }
 
         // :missing modifier is actually not a real modifier and is turned into

--- a/Tests/Spark.Engine.Tests.Shared/Search/CriteriumTests.cs
+++ b/Tests/Spark.Engine.Tests.Shared/Search/CriteriumTests.cs
@@ -125,6 +125,25 @@ public class CriteriumTests
     }
 
     [TestMethod]
+    public void ParseChainStripsComparatorPrefixOnInnerParameter()
+    {
+        // subject:Patient.birthdate=ge1974-12-25 : the comparator prefix belongs to the inner
+        // parameter (Patient.birthdate), so the chain must be resolved against Patient - not the
+        // outer Observation - for the prefix to be recognised and stripped from the value.
+        var searchParameters = new FhirModel().SearchParameters;
+        var crit = Criterium.Parse(searchParameters, "Observation", "subject:Patient.birthdate", "ge1974-12-25");
+
+        Assert.AreEqual(Operator.CHAIN, crit.Operator);
+        Assert.AreEqual("Patient", crit.Modifier);
+
+        var inner = crit.Operand as Criterium;
+        Assert.IsNotNull(inner);
+        Assert.AreEqual("birthdate", inner.ParamName);
+        Assert.AreEqual(Operator.GTE, inner.Operator);
+        Assert.AreEqual("1974-12-25", inner.Operand.ToString());
+    }
+
+    [TestMethod]
     public void SerializeChain()
     {
         var crit = new Criterium


### PR DESCRIPTION
Fixes chained search parsing so comparator prefixes (e.g. ge, lt) on the inner parameter of a typed chain (e.g. subject:Patient.birthdate=ge1974-12-25) are recognised and applied.

The inner parameter was resolved against the outer resource type, so CanHaveOperatorPrefix() missed it and the prefix stayed glued to the value and failed to parse. Pass the reference's type modifier (subject:Patient)
down the chain so the prefix is recognised against the right resource and turned into the proper operator (>=).

Only covers typed chains; an untyped chain's target is known first at search time.

Related to, and part of the fix on #552.