### PR TITLE
Engine: Apply comparator prefix on untyped chained search

### DIFF
--- a/Libraries/Spark.Engine/Search/Types/Criterium.cs
+++ b/Libraries/Spark.Engine/Search/Types/Criterium.cs
@@ -139,6 +139,32 @@ public class Criterium : Expression, ICloneable
         return result + "=" + BuildValue();
     }
 
+    // For an untyped chain (subject.birthdate), find the referenced target type. Prefers one where the
+    // inner parameter accepts a comparator prefix (so it is recognised), else any that declares it;
+    // null if unresolved.
+    private static string ResolveReferenceTargetType(
+        IReadOnlyList<SearchParameter> searchParameters,
+        string resourceType,
+        string referenceParam,
+        string innerParam)
+    {
+        if (searchParameters == null) return null;
+
+        SearchParameter reference = searchParameters.FirstOrDefault(
+            p => (p.Resource == resourceType || p.Resource == "Resource") && p.Name == referenceParam);
+        if (reference?.Target == null) return null;
+
+        // The reference's allowed target types as resource-type strings (e.g. "Patient").
+        List<string> targets = reference.Target.Select(t => Hl7.Fhir.Utility.EnumUtility.GetLiteral(t)).ToList();
+
+        // Prefer a target where the inner parameter accepts a comparator prefix (so it is recognised).
+        var ordered = targets.FirstOrDefault(t => searchParameters.CanHaveOperatorPrefix(t, innerParam));
+        if (ordered != null) return ordered;
+
+        // Otherwise any target that declares the inner parameter at all.
+        return targets.FirstOrDefault(t => searchParameters.Any(p => p.Resource == t && p.Name == innerParam));
+    }
+
     private static Tuple<string, string> pathToKeyModifTuple(string pathPart)
     {
         string[] pair = pathPart.Split(SearchParams.SEARCH_MODIFIERSEPARATOR);
@@ -165,9 +191,12 @@ public class Criterium : Expression, ICloneable
         if (path.Length > 1)
         {
             type = Operator.CHAIN;
-            // Resolve the rest of the chain against the reference's target type (subject:Patient),
-            // not the outer type - otherwise a comparator prefix (e.g. ge) is left unstripped.
-            operand = fromPathTuples(path.Slice(1), value, modifier ?? resourceType, searchParameters);
+            // Resolve the chain against the reference's target type so a comparator prefix on the inner
+            // parameter is recognised: use the explicit modifier (subject:Patient), else look it up.
+            string innerResourceType = modifier
+                ?? ResolveReferenceTargetType(searchParameters, resourceType, name, path[1].Item1)
+                ?? resourceType;
+            operand = fromPathTuples(path.Slice(1), value, innerResourceType, searchParameters);
         }
 
         // :missing modifier is actually not a real modifier and is turned into

--- a/Tests/Spark.Engine.Tests.Shared/Search/CriteriumTests.cs
+++ b/Tests/Spark.Engine.Tests.Shared/Search/CriteriumTests.cs
@@ -1,4 +1,4 @@
-﻿/* 
+/* 
  * Copyright (c) 2015-2018, Firely <info@fire.ly>
  * Copyright (c) 2019-2025, Incendi <info@incendi.no>
  * 
@@ -130,7 +130,7 @@ public class CriteriumTests
     {
         // subject:Patient.birthdate=ge1974-12-25 : the comparator prefix belongs to the inner
         // parameter (Patient.birthdate), so the chain must be resolved against Patient - not the
-        // outer Observation - for the prefix to be recognised and stripped from the value.
+        // outer Observation - for the prefix to be recognised, applied, and stripped from the value.
         var searchParameters = new FhirModel().SearchParameters;
         var crit = Criterium.Parse(searchParameters, "Observation", "subject:Patient.birthdate", "ge1974-12-25");
 
@@ -166,6 +166,21 @@ public class CriteriumTests
         Assert.IsNotNull(inner);
         Assert.AreEqual(expectedOperator, inner.Operator);
         Assert.AreEqual(expectedOperand, inner.Operand.ToString());
+    }
+
+    [TestMethod]
+    public void ParseUntypedChainAppliesComparatorPrefixOnInnerParameter()
+    {
+        // subject.birthdate=ge1974-12-25 : no explicit :Patient type, so the target must be resolved
+        // from the reference's declared targets for the prefix to be recognised and applied.
+        var searchParameters = new FhirModel().SearchParameters;
+        var crit = Criterium.Parse(searchParameters, "Observation", "subject.birthdate", "ge1974-12-25");
+
+        var inner = crit.Operand as Criterium;
+        Assert.IsNotNull(inner);
+        Assert.AreEqual("birthdate", inner.ParamName);
+        Assert.AreEqual(Operator.GTE, inner.Operator);
+        Assert.AreEqual("1974-12-25", inner.Operand.ToString());
     }
 
     [TestMethod]

--- a/Tests/Spark.Engine.Tests.Shared/Search/CriteriumTests.cs
+++ b/Tests/Spark.Engine.Tests.Shared/Search/CriteriumTests.cs
@@ -124,6 +124,7 @@ public class CriteriumTests
         Assert.IsTrue(crit.Operand is UntypedValue);
     }
 
+    // FHIR R4 spec on prefixes: https://hl7.org/fhir/R4/search.html#prefix
     [TestMethod]
     public void ParseChainStripsComparatorPrefixOnInnerParameter()
     {
@@ -149,11 +150,15 @@ public class CriteriumTests
     [DataRow("gt2000-01-01", Operator.GT, "2000-01-01")]
     [DataRow("lt2000-01-01", Operator.LT, "2000-01-01")]
     [DataRow("eq2000-01-01", Operator.EQ, "2000-01-01")]
+    [DataRow("ne2000-01-01", Operator.NOT_EQUAL, "2000-01-01")]
+    [DataRow("sa2000-01-01", Operator.STARTS_AFTER, "2000-01-01")]
+    [DataRow("eb2000-01-01", Operator.ENDS_BEFORE, "2000-01-01")]
+    [DataRow("ap2000-01-01", Operator.APPROX, "2000-01-01")]
     [DataRow("2000-01-01", Operator.EQ, "2000-01-01")] // no prefix: operator stays EQ, value untouched
     public void ParseChainAppliesComparatorPrefixToInnerParameter(string value, Operator expectedOperator, string expectedOperand)
     {
         // The comparator prefix belongs to the inner parameter (Patient.birthdate), so it must be
-        // recognised and stripped there - regardless of which prefix is used.
+        // recognised and applied there - regardless of which prefix is used.
         var searchParameters = new FhirModel().SearchParameters;
         var crit = Criterium.Parse(searchParameters, "Observation", "subject:Patient.birthdate", value);
 

--- a/Tests/Spark.Store.MongoDB.Tests/Search/ChainedSearchErrorHandlingTests.cs
+++ b/Tests/Spark.Store.MongoDB.Tests/Search/ChainedSearchErrorHandlingTests.cs
@@ -56,6 +56,29 @@ public class ChainedSearchErrorHandlingTests
     }
 
     /// <summary>
+    /// The same comparator prefix on an untyped chain (subject.birthdate, no explicit :Patient type) is
+    /// resolved against the reference's target and applied, again leaving exactly two of four Observations.
+    /// </summary>
+    [Fact]
+    public async Task Chained_search_applies_comparator_prefix_on_untyped_inner_parameter()
+    {
+        var container = await StartMongoOrSkipAsync();
+        try
+        {
+            var searcher = await SeedSearcherAsync(container);
+
+            var results = await searcher.SearchAsync("Observation",
+                new SearchParams().Add("subject.birthdate", "ge1974-12-25"));
+
+            Assert.Equal(2, results.MatchCount);
+        }
+        finally
+        {
+            await container.DisposeAsync();
+        }
+    }
+
+    /// <summary>
     /// An unsupported modifier on the inner parameter (Patient.name:above) makes the inner sub-query
     /// fail; that failure must surface as an exception, not be swallowed into an unfiltered result.
     /// </summary>


### PR DESCRIPTION
Resolve an untyped chain (subject.birthdate) against the reference's
target types so the inner comparator prefix is recognised and applied,
matching the typed form.