### PR TITLE
MongoDB: Use callbacks instead of reflection for the FixedQueries

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -236,6 +236,10 @@ csharp_style_prefer_primary_constructors = false
 resharper_convert_to_primary_constructor_highlighting = none
 dotnet_diagnostic.IDE0290.severity = none
 
+# Use collection expressions
+dotnet_style_prefer_collection_expression = true
+dotnet_diagnostic.IDE0300.severity = none
+
 # Naming styles
 
 dotnet_naming_style.pascal_case.required_prefix =

--- a/.editorconfig
+++ b/.editorconfig
@@ -182,8 +182,9 @@ dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion
 dotnet_naming_rule.types_should_be_pascal_case.symbols = types
 dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
 
-dotnet_naming_rule.private_method_should_be_camelcase.symbols = private_method
-dotnet_naming_rule.private_method_should_be_camelcase.style = camelcase
+dotnet_naming_rule.private_method_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.private_method_should_be_pascal_case.symbols = private_method
+dotnet_naming_rule.private_method_should_be_pascal_case.style = pascal_case
 
 dotnet_naming_rule.constants_should_be_allupper.severity = suggestion
 dotnet_naming_rule.constants_should_be_allupper.symbols = constants

--- a/.editorconfig
+++ b/.editorconfig
@@ -190,9 +190,9 @@ dotnet_naming_rule.constants_should_be_allupper.severity = suggestion
 dotnet_naming_rule.constants_should_be_allupper.symbols = constants
 dotnet_naming_rule.constants_should_be_allupper.style = allupper
 
-dotnet_naming_rule.static_readonly_should_be_allupper.severity = suggestion
-dotnet_naming_rule.static_readonly_should_be_allupper.symbols = static_readonly
-dotnet_naming_rule.static_readonly_should_be_allupper.style = allupper
+dotnet_naming_rule.static_readonly_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.static_readonly_should_be_pascal_case.symbols = static_readonly
+dotnet_naming_rule.static_readonly_should_be_pascal_case.style = pascal_case
 
 dotnet_naming_rule.private_field_should_be__camelcase.severity = suggestion
 dotnet_naming_rule.private_field_should_be__camelcase.symbols = private_field

--- a/.editorconfig
+++ b/.editorconfig
@@ -232,7 +232,9 @@ resharper_csharp_namespace_body = file_scoped
 dotnet_diagnostic.IDE0160.severity = none
 
 # Primary constructor diagnostic
-dotnet_diagnostic.IDE0300.severity = none
+csharp_style_prefer_primary_constructors = false
+resharper_convert_to_primary_constructor_highlighting = none
+dotnet_diagnostic.IDE0290.severity = none
 
 # Naming styles
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -71,9 +71,6 @@ dotnet_style_readonly_field = true:suggestion
 # Parameter preferences
 dotnet_code_quality_unused_parameters = all:suggestion
 
-# Suppression preferences
-dotnet_remove_unnecessary_suppression_exclusions = none
-
 #### C# Coding Conventions ####
 
 # var preferences

--- a/Libraries/Spark.Store.MongoDB/Search/CriteriaMongoExtensions.cs
+++ b/Libraries/Spark.Store.MongoDB/Search/CriteriaMongoExtensions.cs
@@ -12,7 +12,6 @@ using System.Collections.Generic;
 using System.Linq;
 using MongoDB.Bson;
 using System.Text.RegularExpressions;
-using System.Reflection;
 using Spark.Store.MongoDB.Search.Common;
 using Spark.Engine.Extensions;
 using Hl7.Fhir.Utility;
@@ -24,11 +23,23 @@ namespace Spark.Store.MongoDB.Search;
 
 internal static class CriteriaMongoExtensions
 {
-    private static readonly List<MethodInfo> _fixedQueries = CacheQueryMethods();
+    // FIXME: The so-called FixedQueries can probably be removed when we remove:
+    //        SearchSettings.CheckReferences and SearchSettings.CheckReferencesFor.
+    private static readonly Dictionary<string, Func<Criterium, FilterDefinition<BsonDocument>>> FixedQueries =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            { InternalField.JUST_ID, InternalJustIdExactStringQuery },
+            { InternalField.ID, InternalIdExactStringQuery }
+        };
 
-    private static List<MethodInfo> CacheQueryMethods()
+    private static FilterDefinition<BsonDocument> InternalJustIdExactStringQuery(Criterium crit)
     {
-        return typeof(CriteriaMongoExtensions).GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static).Where(m => m.Name.EndsWith("FixedQuery")).ToList();
+        return StringQuery(InternalField.JUST_ID, crit.Operator, "exact", (ValueExpression)crit.Operand);
+    }
+
+    private static FilterDefinition<BsonDocument> InternalIdExactStringQuery(Criterium crit)
+    {
+        return StringQuery(InternalField.ID, crit.Operator, "exact", (ValueExpression)crit.Operand);
     }
 
     internal static FilterDefinition<BsonDocument> ResourceFilter(string resourceType, int level)
@@ -49,11 +60,8 @@ internal static class CriteriaMongoExtensions
     internal static FilterDefinition<BsonDocument> ToFilter(this Criterium param, string resourceType)
     {
         //Maybe it's a generic parameter.
-        MethodInfo methodForParameter = _fixedQueries.Find(m => m.Name.Equals(param.ParamName + "FixedQuery"));
-        if (methodForParameter != null)
-        {
-            return (FilterDefinition<BsonDocument>)methodForParameter.Invoke(null, new object[] { param });
-        }
+        if (FixedQueries.TryGetValue(param.ParamName, out Func<Criterium, FilterDefinition<BsonDocument>> query))
+            return query(param);
 
         //Otherwise it should be a parameter as defined in the metadata
         var critSp = FindSearchParamDefinition(param, resourceType);
@@ -122,7 +130,6 @@ internal static class CriteriaMongoExtensions
                 case SearchParamType.Uri:
                     return UriQuery(parameterName, op, modifier, valueOperand);
                 default:
-                    //return Builders<BsonDocument>.Filter.Null;
                     throw new NotSupportedException(string.Format("SearchParamType {0} on parameter {1} not supported.", parameter.Type, parameter.Name));
             }
         }
@@ -509,16 +516,6 @@ internal static class CriteriaMongoExtensions
             return Builders<BsonDocument>.Filter.And(queries);
         }
         throw new ArgumentException(string.Format("Invalid operator {0} on composite parameter {1}", optor.ToString(), parameterDef.Name));
-    }
-
-    internal static FilterDefinition<BsonDocument> internal_justidFixedQuery(Criterium crit)
-    {
-        return StringQuery(InternalField.JUST_ID, crit.Operator, "exact", (ValueExpression)crit.Operand);
-    }
-
-    internal static FilterDefinition<BsonDocument> internal_idFixedQuery(Criterium crit)
-    {
-        return StringQuery(InternalField.ID, crit.Operator, "exact", (ValueExpression)crit.Operand);
     }
 
     private static FilterDefinition<BsonDocument> FalseQuery()

--- a/Libraries/Spark.Store.MongoDB/Search/MongoSearcher.cs
+++ b/Libraries/Spark.Store.MongoDB/Search/MongoSearcher.cs
@@ -200,7 +200,7 @@ public class MongoSearcher
     private static FilterDefinition<BsonDocument> CreateMongoQuery(string resourceType, SearchResults results, int level, Dictionary<Criterium, Criterium> closedCriteria)
     {
         FilterDefinition<BsonDocument> resultQuery = CriteriaMongoExtensions.ResourceFilter(resourceType, level);
-        if (closedCriteria.Count() > 0)
+        if (closedCriteria.Count > 0)
         {
             var criteriaQueries = new List<FilterDefinition<BsonDocument>>();
             foreach (var crit in closedCriteria)

--- a/Tests/Spark.Store.MongoDB.Tests/Search/ChainedSearchErrorHandlingTests.cs
+++ b/Tests/Spark.Store.MongoDB.Tests/Search/ChainedSearchErrorHandlingTests.cs
@@ -99,6 +99,41 @@ public class ChainedSearchErrorHandlingTests
         }
     }
 
+    /// <summary>
+    /// Reference checking rewrites a non-chained reference search into an internal chained lookup.
+    /// The inner lookup uses internal_justid for bare ids and internal_id for typed/full references.
+    /// </summary>
+    [Theory]
+    [InlineData("subject", "p1")]
+    [InlineData("subject:Patient", "p1")]
+    [InlineData("subject", "Patient/p1")]
+    public async Task Reference_search_with_reference_check_uses_internal_reference_lookup(string parameterName, string parameterValue)
+    {
+        var container = await StartMongoOrSkipAsync();
+        try
+        {
+            var searcher = await SeedSearcherAsync(container);
+            var searchSettings = new SearchSettings
+            {
+                CheckReferences = true,
+                CheckReferencesFor = ["Observation.subject"]
+            };
+
+            var results = await searcher.SearchAsync("Observation",
+                new SearchParams().Add(parameterName, parameterValue),
+                searchSettings);
+
+            Assert.False(results.HasErrors);
+            Assert.Equal(1, results.MatchCount);
+            Assert.Single(results);
+            Assert.Equal("http://localhost/Observation/o1/_history/1", results[0]);
+        }
+        finally
+        {
+            await container.DisposeAsync();
+        }
+    }
+
     private static async System.Threading.Tasks.Task<MongoDbContainer> StartMongoOrSkipAsync()
     {
         // Building/starting the container probes the Docker endpoint; on a host without Docker


### PR DESCRIPTION
Add a FIXME reminding ourself that these probably can be removed when we remove `SearchSettings.CheckReferences` and `SearchSettings.CheckReferencesFor`.