### PR TITLE
Engine: Order entries in same order as keys where stored in Snapshot

### DIFF
--- a/Libraries/Spark.Engine/Service/FhirServiceExtensions/SnapshotPaginationService.cs
+++ b/Libraries/Spark.Engine/Service/FhirServiceExtensions/SnapshotPaginationService.cs
@@ -68,14 +68,9 @@ internal class SnapshotPaginationService : ISnapshotPagination
             return bundle;
         }
 
-        var keys = _snapshotPaginationCalculator.GetKeysForPage(_snapshot, offset).ToList();
+        var keys = _snapshotPaginationCalculator.GetKeysForPage(_snapshot, offset).ToArray();
         var entries = (await _fhirStore.GetAsync(keys, _snapshot.Elements).ConfigureAwait(false)).ToList();
-        if (_snapshot.SortBy != null)
-        {
-            entries = entries.Select(e => new {Entry = e, Index = keys.IndexOf(e.Key)})
-                .OrderBy(e => e.Index)
-                .Select(e => e.Entry).ToList();
-        }
+        entries = SortEntriesBySnapshotKeys(entries, keys);
         var included = await GetIncludesRecursiveForAsync(entries, _snapshot.Includes).ConfigureAwait(false);
         entries.Append(included);
 
@@ -91,6 +86,16 @@ internal class SnapshotPaginationService : ISnapshotPagination
         BuildLinks(bundle, offset);
 
         return bundle;
+    }
+
+    public static List<Entry> SortEntriesBySnapshotKeys(IEnumerable<Entry> entries, IKey[] keys)
+    {
+        var keyOrder = keys
+            .Select((key, index) => new { Key = key.ToOperationPath(), Index = index })
+            .ToDictionary(item => item.Key, item => item.Index);
+        return entries
+            .OrderBy(entry => keyOrder.GetValueOrDefault(entry.Key.ToOperationPath(), int.MaxValue))
+            .ToList();
     }
 
     private async Task<List<Entry>> GetIncludesRecursiveForAsync(List<Entry> entries, IEnumerable<string> includes)

--- a/Tests/Spark.Engine.Tests.Shared/Service/SnapshotPaginationServiceTests.cs
+++ b/Tests/Spark.Engine.Tests.Shared/Service/SnapshotPaginationServiceTests.cs
@@ -7,10 +7,13 @@
 using Hl7.Fhir.Model;
 using Moq;
 using Spark.Engine.Core;
+using Spark.Engine.Extensions;
 using Spark.Engine.Interfaces;
 using Spark.Engine.Service;
 using Spark.Engine.Service.FhirServiceExtensions;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 using Task = System.Threading.Tasks.Task;
 
@@ -20,7 +23,7 @@ public class SnapshotPaginationServiceTests
 {
     private const string BaseUrl = "http://localhost/fhir";
 
-    private static ISnapshotPagination CreateService(Snapshot snapshot)
+    private static ISnapshotPagination CreateService(Snapshot snapshot, Entry[] entries = null)
     {
         var mockFhirIndex = new Mock<IFhirIndex>();
         var mockFhirStore = new Mock<Store.Interfaces.IFhirStore>();
@@ -31,6 +34,10 @@ public class SnapshotPaginationServiceTests
         mockLocalhost
             .Setup(l => l.Absolute(It.IsAny<Uri>()))
             .Returns<Uri>(u => u.IsAbsoluteUri ? u : new Uri(new Uri(BaseUrl), u));
+
+        mockFhirStore
+            .Setup(store => store.GetAsync(It.IsAny<IEnumerable<IKey>>(), It.IsAny<IEnumerable<string>>()))
+            .ReturnsAsync(entries ?? []);
 
         return new SnapshotPaginationService(
             mockFhirIndex.Object,
@@ -99,5 +106,48 @@ public class SnapshotPaginationServiceTests
         var bundle = await service.GetPageAsync();
 
         Assert.Equal(Bundle.BundleType.Searchset, bundle.Type);
+    }
+
+    [Fact]
+    public async Task GetPageAsync_EntriesComesBackInTheSameOrderKeysWereStoredInTheSnapshot()
+    {
+        Snapshot snapshot = Snapshot.Create(
+            Bundle.BundleType.Searchset,
+            selfLink: new Uri($"{BaseUrl}/Patient"),
+            keys:
+            [
+                "Patient/1/_history/1",
+                "Patient/2/_history/1",
+                "Patient/3/_history/1",
+            ],
+            sortBy: null,
+            count: 10,
+            includes: [],
+            reverseIncludes: [],
+            elements: []
+        );
+        Entry[] entries =
+        [
+            Entry.Create(
+                Bundle.HTTPVerb.GET,
+                Key.ParseOperationPath("Patient/3/_history/1"),
+                new Patient { Id = "3" }
+            ),
+            Entry.Create(
+                Bundle.HTTPVerb.GET,
+                Key.ParseOperationPath("Patient/2/_history/1"),
+                new Patient { Id = "2" }
+            ),
+            Entry.Create(
+                Bundle.HTTPVerb.GET,
+                Key.ParseOperationPath("Patient/1/_history/1"),
+                new Patient { Id = "1" }
+            ),
+        ];
+        ISnapshotPagination snapshotPagination = CreateService(snapshot, entries);
+
+        Bundle bundle = await snapshotPagination.GetPageAsync();
+
+        Assert.Equal(["1", "2", "3"], bundle.Entry.Select(entry => entry.Resource?.Id));
     }
 }


### PR DESCRIPTION
This fixes a problem where entries in search results where not retrieved in the same order as the sorted keys in the Snapshot.                    
                                                                         
The guard behind Snapshot.SortBy seems to be a mistake as SortBy was not used in the actual sort it guarded.