### PR TITLE
Engine: Order entries in same order as keys where stored in Snapshot [v2-r4]

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,6 @@
 .vs/
 .idea/
 .github/
+**/bin/
+**/obj/
+**/node_modules/

--- a/src/Spark.Engine.Test/Service/SnapshotPaginationServiceTests.cs
+++ b/src/Spark.Engine.Test/Service/SnapshotPaginationServiceTests.cs
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2026, Incendi <info@incendi.no>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+using Hl7.Fhir.Model;
+using Moq;
+using Spark.Core;
+using Spark.Engine.Core;
+using Spark.Engine.Interfaces;
+using Spark.Engine.Service;
+using Spark.Engine.Service.FhirServiceExtensions;
+using Spark.Engine.Store.Interfaces;
+using Spark.Service;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using Task = System.Threading.Tasks.Task;
+
+namespace Spark.Engine.Test.Service;
+
+public class SnapshotPaginationServiceTests
+{
+    private const string BaseUrl = "http://localhost/fhir";
+
+    [Fact]
+    public async Task GetPageAsync_EntriesComesBackInTheSameOrderKeysWereStoredInTheSnapshot()
+    {
+        Snapshot snapshot = Snapshot.Create(
+            Bundle.BundleType.Searchset,
+            selflink: new Uri($"{BaseUrl}/Patient"),
+            keys:
+            [
+                "Patient/1/_history/1",
+                "Patient/2/_history/1",
+                "Patient/3/_history/1",
+            ],
+            sortby: null,
+            count: 10,
+            includes: [],
+            reverseIncludes: [],
+            elements: []
+        );
+        Entry[] entries =
+        [
+            Entry.Create(
+                Bundle.HTTPVerb.GET,
+                Key.ParseOperationPath("Patient/3/_history/1"),
+                new Patient { Id = "3" }
+            ),
+            Entry.Create(
+                Bundle.HTTPVerb.GET,
+                Key.ParseOperationPath("Patient/2/_history/1"),
+                new Patient { Id = "2" }
+            ),
+            Entry.Create(
+                Bundle.HTTPVerb.GET,
+                Key.ParseOperationPath("Patient/1/_history/1"),
+                new Patient { Id = "1" }
+            ),
+        ];
+        ISnapshotPagination snapshotPagination = CreateService(snapshot, entries);
+
+        Bundle bundle = await snapshotPagination.GetPageAsync();
+
+        Assert.Equal(["1", "2", "3"], bundle.Entry.Select(entry => entry.Resource?.Id));
+    }
+
+    private static ISnapshotPagination CreateService(Snapshot snapshot, Entry[] entries)
+    {
+        var mockFhirIndex = new Mock<IFhirIndex>();
+        var mockFhirStore = new Mock<IFhirStore>();
+        var mockTransfer = new Mock<ITransfer>();
+        var mockLocalhost = new Mock<ILocalhost>();
+        var calculator = new SnapshotPaginationCalculator();
+
+        mockLocalhost
+            .Setup(l => l.Absolute(It.IsAny<Uri>()))
+            .Returns<Uri>(u => u.IsAbsoluteUri ? u : new Uri(new Uri(BaseUrl), u));
+
+        mockFhirStore
+            .Setup(store => store.GetAsync(It.IsAny<IEnumerable<IKey>>(), It.IsAny<IEnumerable<string>>()))
+            .ReturnsAsync((IEnumerable<IKey> identifiers, IEnumerable<string> _) => identifiers.Any() ? entries : []);
+
+        return new SnapshotPaginationService(
+            mockFhirIndex.Object,
+            mockFhirStore.Object,
+            mockTransfer.Object,
+            mockLocalhost.Object,
+            calculator,
+            snapshot);
+    }
+}

--- a/src/Spark.Engine/Service/FhirServiceExtensions/SnapshotPaginationService.cs
+++ b/src/Spark.Engine/Service/FhirServiceExtensions/SnapshotPaginationService.cs
@@ -61,14 +61,9 @@ internal class SnapshotPaginationService : ISnapshotPagination
             Id = Guid.NewGuid().ToString()
         };
 
-        List<IKey> keys = _snapshotPaginationCalculator.GetKeysForPage(_snapshot, start).ToList();
+        IKey[] keys = _snapshotPaginationCalculator.GetKeysForPage(_snapshot, start).ToArray();
         var entries = (await _fhirStore.GetAsync(keys, _snapshot.Elements).ConfigureAwait(false)).ToList();
-        if (_snapshot.SortBy != null)
-        {
-            entries = entries.Select(e => new {Entry = e, Index = keys.IndexOf(e.Key)})
-                .OrderBy(e => e.Index)
-                .Select(e => e.Entry).ToList();
-        }
+        entries = SortEntriesBySnapshotKeys(entries, keys);
         IList<Entry> included = await GetIncludesRecursiveForAsync(entries, _snapshot.Includes).ConfigureAwait(false);
         entries.Append(included);
 
@@ -84,6 +79,16 @@ internal class SnapshotPaginationService : ISnapshotPagination
         BuildLinks(bundle, start);
 
         return bundle;
+    }
+
+    public static List<Entry> SortEntriesBySnapshotKeys(IEnumerable<Entry> entries, IKey[] keys)
+    {
+        var keyOrder = keys
+            .Select((key, index) => new { Key = key.ToOperationPath(), Index = index })
+            .ToDictionary(item => item.Key, item => item.Index);
+        return entries
+            .OrderBy(entry => keyOrder.TryGetValue(entry.Key.ToOperationPath(), out var index) ? index : int.MaxValue)
+            .ToList();
     }
 
     private async Task<IList<Entry>> GetIncludesRecursiveForAsync(IList<Entry> entries, IEnumerable<string> includes)

--- a/src/Spark.Mongo/Spark.Mongo.csproj
+++ b/src/Spark.Mongo/Spark.Mongo.csproj
@@ -12,10 +12,10 @@
     <ItemGroup>
         <PackageReference Include="Hl7.Fhir.R4" Version="5.13.0" />
         <PackageReference Include="Medo.Uuid7" Version="3.2.0" />
-        <PackageReference Include="MongoDB.Driver" Version="3.5.0">
+        <PackageReference Include="MongoDB.Driver" Version="3.9.0">
             <NoWarn>NU1701</NoWarn>
         </PackageReference>
-        <PackageReference Include="MongoDB.Bson" Version="3.5.0">
+        <PackageReference Include="MongoDB.Bson" Version="3.9.0">
             <NoWarn>NU1701</NoWarn>
         </PackageReference>
     </ItemGroup>

--- a/src/Spark.Web/Spark.Web.csproj
+++ b/src/Spark.Web/Spark.Web.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="AspNet.Security.OAuth.GitHub" Version="10.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This fixes a problem where entries in search results where not retrieved in the same order as the sorted keys in the Snapshot.

The guard behind Snapshot.SortBy seems to be a mistake as SortBy was not used in the actual sort it guarded.

Backports: #1317