### PR TITLE
Engine: Correct Binary content negotiation for charset-qualified media [v2-stu3]

### DIFF
--- a/src/Spark.Engine.Test/Extensions/HttpRequestFhirExtensionsTests.cs
+++ b/src/Spark.Engine.Test/Extensions/HttpRequestFhirExtensionsTests.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
 using Spark.Engine.Utility;
 using System.Linq;
+using Spark.Engine.Core;
 using Xunit;
 
 namespace Spark.Engine.Test.Extensions;
@@ -136,4 +137,30 @@ public class HttpRequestFhirExtensionsTests
 
         Assert.NotNull(parameters.FirstOrDefault(p => p.Equals(Tuple.Create("arg", "A,B"))));
     }
+
+    [Theory]
+    [InlineData("application/fhir+json;charset=utf-8")]
+    [InlineData("application/fhir+xml; charset=utf-8")]
+    public void IsContentTypeHeaderFhirMediaType_WithParameters_ShouldReturnTrue(string contentType)
+    {
+        bool isFhirMediaType = HttpRequestExtensions.IsContentTypeHeaderFhirMediaType(contentType);
+
+        Assert.True(isFhirMediaType);
+    }
+
+    [Fact]
+    public void IsRawBinaryPostOrPutRequest_WithFhirJsonAndCharset_ShouldReturnFalse()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Method = HttpMethod.Post.Method;
+        context.Request.Scheme = "http";
+        context.Request.Host = new HostString("example.org");
+        context.Request.Path = "/fhir/Binary";
+        context.Request.ContentType = "application/fhir+json;charset=utf-8";
+
+        bool isRawBinaryRequest = context.Request.IsRawBinaryPostOrPutRequest();
+
+        Assert.False(isRawBinaryRequest);
+    }
+
 }

--- a/src/Spark.Engine/Extensions/HttpHeadersExtensions.cs
+++ b/src/Spark.Engine/Extensions/HttpHeadersExtensions.cs
@@ -49,6 +49,10 @@ public static class HttpRequestExtensions
     public static bool IsContentTypeHeaderFhirMediaType(string contentType)
     {
         if (string.IsNullOrEmpty(contentType)) return false;
+
+        if (MediaTypeHeaderValue.TryParse(contentType, out MediaTypeHeaderValue mediaTypeHeaderValue))
+            contentType = mediaTypeHeaderValue.MediaType;
+
         return ContentType.XML_CONTENT_HEADERS.Contains(contentType)
                || ContentType.JSON_CONTENT_HEADERS.Contains(contentType);
     }

--- a/src/Spark.Engine/Extensions/HttpRequestFhirExtensions.cs
+++ b/src/Spark.Engine/Extensions/HttpRequestFhirExtensions.cs
@@ -340,7 +340,7 @@ public static class HttpRequestFhirExtensions
     {
         if (!string.IsNullOrEmpty(contentType) && resource is Binary && resource.Id == null && id != null)
         {
-            if (!ContentType.XML_CONTENT_HEADERS.Contains(contentType) && !ContentType.JSON_CONTENT_HEADERS.Contains(contentType))
+            if (!HttpRequestExtensions.IsContentTypeHeaderFhirMediaType(contentType))
                 resource.Id = id;
         }
     }


### PR DESCRIPTION
'application/fhir+json;charset=utf-8' should be treated as FHIR JSON,
not raw Binary content.