### PR TITLE
Engine: Correct Binary content negotiation for charset-qualified media

### DIFF
--- a/Libraries/Spark.Engine/Extensions/HttpHeadersExtensions.cs
+++ b/Libraries/Spark.Engine/Extensions/HttpHeadersExtensions.cs
@@ -9,6 +9,7 @@ using Hl7.Fhir.Rest;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http.Headers;
 using Microsoft.AspNetCore.Http;
 
 namespace Spark.Engine.Extensions;
@@ -23,9 +24,12 @@ public static class HttpRequestExtensions
     public static bool IsContentTypeHeaderFhirMediaType(string contentType)
     {
         if (string.IsNullOrEmpty(contentType)) return false;
-        var mediaType = contentType.Split(';')[0];
-        return ContentType.XML_CONTENT_HEADERS.Contains(mediaType, StringComparer.OrdinalIgnoreCase)
-               || ContentType.JSON_CONTENT_HEADERS.Contains(mediaType, StringComparer.OrdinalIgnoreCase);
+
+        if (MediaTypeHeaderValue.TryParse(contentType, out MediaTypeHeaderValue mediaTypeHeaderValue))
+            contentType = mediaTypeHeaderValue.MediaType;
+
+        return ContentType.XML_CONTENT_HEADERS.Contains(contentType)
+               || ContentType.JSON_CONTENT_HEADERS.Contains(contentType);
     }
 
     public static string GetParameter(this HttpRequest request, string key)

--- a/Libraries/Spark.Engine/Extensions/HttpRequestFhirExtensions.cs
+++ b/Libraries/Spark.Engine/Extensions/HttpRequestFhirExtensions.cs
@@ -192,7 +192,7 @@ public static class HttpRequestFhirExtensions
     {
         if (!string.IsNullOrEmpty(contentType) && resource is Binary && resource.Id == null && id != null)
         {
-            if (!ContentType.XML_CONTENT_HEADERS.Contains(contentType) && !ContentType.JSON_CONTENT_HEADERS.Contains(contentType))
+            if (!HttpRequestExtensions.IsContentTypeHeaderFhirMediaType(contentType))
                 resource.Id = id;
         }
     }

--- a/Tests/Spark.Engine.Tests/Extensions/HttpRequestFhirExtensionsTests.cs
+++ b/Tests/Spark.Engine.Tests/Extensions/HttpRequestFhirExtensionsTests.cs
@@ -6,6 +6,7 @@
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
+using Hl7.Fhir.Model;
 using Spark.Engine.Extensions;
 using Xunit;
 
@@ -47,5 +48,39 @@ public class HttpRequestFhirExtensionsTests
         string actualVersionId = context.Request.IfMatchVersionId();
 
         Assert.Null(actualVersionId);
+    }
+
+    [Theory]
+    [InlineData("application/fhir+json;charset=utf-8")]
+    [InlineData("application/fhir+xml; charset=utf-8")]
+    public void IsContentTypeHeaderFhirMediaType_WithParameters_ShouldReturnTrue(string contentType)
+    {
+        bool isFhirMediaType = HttpRequestExtensions.IsContentTypeHeaderFhirMediaType(contentType);
+
+        Assert.True(isFhirMediaType);
+    }
+
+    [Fact]
+    public void TransferResourceIdIfRawBinary_WithFhirJsonAndCharset_ShouldKeepResourceIdNull()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.ContentType = "application/fhir+json;charset=utf-8";
+        var binary = new Binary();
+
+        context.Request.TransferResourceIdIfRawBinary(binary, "example");
+
+        Assert.Null(binary.Id);
+    }
+
+    [Fact]
+    public void TransferResourceIdIfRawBinary_WithRawBinaryContentType_ShouldTransferResourceId()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.ContentType = "application/pdf";
+        var binary = new Binary();
+
+        context.Request.TransferResourceIdIfRawBinary(binary, "example");
+
+        Assert.Equal("example", binary.Id);
     }
 }


### PR DESCRIPTION
'application/fhir+json;charset=utf-8' should be treated as FHIR JSON, not raw Binary content.