### PR TITLE
Meta: Use pascal case for constant qualified members

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -183,9 +183,9 @@ dotnet_naming_rule.private_method_should_be_pascal_case.severity = suggestion
 dotnet_naming_rule.private_method_should_be_pascal_case.symbols = private_method
 dotnet_naming_rule.private_method_should_be_pascal_case.style = pascal_case
 
-dotnet_naming_rule.constants_should_be_allupper.severity = suggestion
-dotnet_naming_rule.constants_should_be_allupper.symbols = constants
-dotnet_naming_rule.constants_should_be_allupper.style = allupper
+dotnet_naming_rule.constants_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.constants_should_be_pascal_case.symbols = constants
+dotnet_naming_rule.constants_should_be_pascal_case.style = pascal_case
 
 dotnet_naming_rule.static_readonly_should_be_pascal_case.severity = suggestion
 dotnet_naming_rule.static_readonly_should_be_pascal_case.symbols = static_readonly
@@ -258,8 +258,3 @@ dotnet_naming_style._camelcase.required_prefix = _
 dotnet_naming_style._camelcase.required_suffix =
 dotnet_naming_style._camelcase.word_separator =
 dotnet_naming_style._camelcase.capitalization = camel_case
-
-dotnet_naming_style.allupper.required_prefix =
-dotnet_naming_style.allupper.required_suffix =
-dotnet_naming_style.allupper.word_separator =
-dotnet_naming_style.allupper.capitalization = all_upper

--- a/Libraries/Spark.Engine/Core/Const.cs
+++ b/Libraries/Spark.Engine/Core/Const.cs
@@ -6,25 +6,66 @@
  */
 
 
+using System;
+
 namespace Spark.Engine.Core;
 
 public static class FhirRestOp
 {
-    public const string SNAPSHOT = "_snapshot";
+    public const string Snapshot = "_snapshot";
+
+// ReSharper disable InconsistentNaming
+#pragma warning disable IDE1006
+    [Obsolete("Use Snapshot instead. This member will be removed in the next major version.")]
+    public const string SNAPSHOT = Snapshot;
+#pragma warning restore IDE1006
+// ReSharper restore InconsistentNaming
 }
 
 public static class FhirHeader
 {
-    public const string CATEGORY = "Category";
+    public const string Category = "Category";
+
+// ReSharper disable InconsistentNaming
+#pragma warning disable IDE1006
+    [Obsolete("Use Category instead. This member will be removed in the next major version.")]
+    public const string CATEGORY = Category;
+#pragma warning restore IDE1006
+// ReSharper restore InconsistentNaming
 }
 
 public static class FhirParameter
 {
-    public const string SNAPSHOT_ID = "id";
-    public const string SNAPSHOT_INDEX = "start";
-    public const string OFFSET = "_offset";
-    public const string SUMMARY = "_summary";
-    public const string COUNT = "_count";
-    public const string SINCE = "_since";
-    public const string SORT = "_sort";
+    public const string SnapshotId = "id";
+    public const string SnapshotIndex = "start";
+    public const string Offset = "_offset";
+    public const string Summary = "_summary";
+    public const string Count = "_count";
+    public const string Since = "_since";
+    public const string Sort = "_sort";
+
+// ReSharper disable InconsistentNaming
+#pragma warning disable IDE1006
+    [Obsolete("Use SnapshotId instead. This member will be removed in the next major version.")]
+    public const string SNAPSHOT_ID = SnapshotId;
+
+    [Obsolete("Use SnapshotIndex instead. This member will be removed in the next major version.")]
+    public const string SNAPSHOT_INDEX = SnapshotIndex;
+
+    [Obsolete("Use Offset instead. This member will be removed in the next major version.")]
+    public const string OFFSET = Offset;
+
+    [Obsolete("Use Summary instead. This member will be removed in the next major version.")]
+    public const string SUMMARY = Summary;
+
+    [Obsolete("Use Count instead. This member will be removed in the next major version.")]
+    public const string COUNT = Count;
+
+    [Obsolete("Use Since instead. This member will be removed in the next major version.")]
+    public const string SINCE = Since;
+
+    [Obsolete("Use Sort instead. This member will be removed in the next major version.")]
+    public const string SORT = Sort;
+#pragma warning restore IDE1006
+// ReSharper restore InconsistentNaming
 }

--- a/Libraries/Spark.Engine/Core/HistoryParameters.cs
+++ b/Libraries/Spark.Engine/Core/HistoryParameters.cs
@@ -16,9 +16,9 @@ public class HistoryParameters
 {
     public HistoryParameters(HttpRequest request)
     {
-        Count = FhirParameterParser.ParseIntParameter(request.GetParameter(FhirParameter.COUNT));
-        Since = FhirParameterParser.ParseDateParameter(request.GetParameter(FhirParameter.SINCE));
-        SortBy = request.GetParameter(FhirParameter.SORT);
+        Count = FhirParameterParser.ParseIntParameter(request.GetParameter(FhirParameter.Count));
+        Since = FhirParameterParser.ParseDateParameter(request.GetParameter(FhirParameter.Since));
+        SortBy = request.GetParameter(FhirParameter.Sort);
     }
 
     public int? Count { get; set; }

--- a/Libraries/Spark.Engine/Core/HttpHeaderName.cs
+++ b/Libraries/Spark.Engine/Core/HttpHeaderName.cs
@@ -4,17 +4,47 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+using System;
+
 namespace Spark.Engine.Core;
 
 internal static class HttpHeaderName
 {
-    public const string ACCEPT = "Accept";
-    public const string CONTENT_DISPOSITION = "Content-Disposition";
-    public const string CONTENT_LOCATION = "Content-Location";
-    public const string CONTENT_TYPE = "Content-Type";
-    public const string ETAG = "ETag";
-    public const string LOCATION = "Location";
-    public const string LAST_MODIFIED = "Last-Modified";
+    public const string Accept = "Accept";
+    public const string ContentDisposition = "Content-Disposition";
+    public const string ContentLocation = "Content-Location";
+    public const string ContentType = "Content-Type";
+    public const string ETag = "ETag";
+    public const string Location = "Location";
+    public const string LastModified = "Last-Modified";
 
-    public const string X_CONTENT_TYPE = "X-Content-Type";
+    public const string XContentType = "X-Content-Type";
+
+// ReSharper disable InconsistentNaming
+#pragma warning disable IDE1006
+    [Obsolete("Use Accept instead. This member will be removed in the next major version.")]
+    public const string ACCEPT = Accept;
+
+    [Obsolete("Use ContentDisposition instead. This member will be removed in the next major version.")]
+    public const string CONTENT_DISPOSITION = ContentDisposition;
+
+    [Obsolete("Use ContentLocation instead. This member will be removed in the next major version.")]
+    public const string CONTENT_LOCATION = ContentLocation;
+
+    [Obsolete("Use ContentType instead. This member will be removed in the next major version.")]
+    public const string CONTENT_TYPE = ContentType;
+
+    [Obsolete("Use ETag instead. This member will be removed in the next major version.")]
+    public const string ETAG = ETag;
+
+    [Obsolete("Use Location instead. This member will be removed in the next major version.")]
+    public const string LOCATION = Location;
+
+    [Obsolete("Use LastModified instead. This member will be removed in the next major version.")]
+    public const string LAST_MODIFIED = LastModified;
+
+    [Obsolete("Use XContentType instead. This member will be removed in the next major version.")]
+    public const string X_CONTENT_TYPE = XContentType;
+#pragma warning restore IDE1006
+// ReSharper restore InconsistentNaming
 }

--- a/Libraries/Spark.Engine/Extensions/HttpRequestFhirExtensions.cs
+++ b/Libraries/Spark.Engine/Extensions/HttpRequestFhirExtensions.cs
@@ -28,12 +28,12 @@ public static class HttpRequestFhirExtensions
 {
     public static int GetPagingOffsetParameter(this HttpRequest request)
     {
-        var offset = FhirParameterParser.ParseIntParameter(request.GetParameter(FhirParameter.OFFSET));
+        var offset = FhirParameterParser.ParseIntParameter(request.GetParameter(FhirParameter.Offset));
         if (!offset.HasValue)
         {
             // This part is kept as backwards compatibility for the "start" parameter which was used as an offset
             // in earlier versions of Spark.
-            offset = FhirParameterParser.ParseIntParameter(request.GetParameter(FhirParameter.SNAPSHOT_INDEX));
+            offset = FhirParameterParser.ParseIntParameter(request.GetParameter(FhirParameter.SnapshotIndex));
         }
 
         return offset.HasValue ? offset.Value : 0;
@@ -160,17 +160,17 @@ public static class HttpRequestFhirExtensions
     {
         if (fhirResponse.Key != null)
         {
-            response.Headers.Append(HttpHeaderName.ETAG, ETag.Create(fhirResponse.Key.VersionId)?.ToString());
+            response.Headers.Append(HttpHeaderName.ETag, ETag.Create(fhirResponse.Key.VersionId)?.ToString());
 
             Uri location = fhirResponse.Key.ToUri();
-            response.Headers.Append(HttpHeaderName.LOCATION, location.OriginalString);
+            response.Headers.Append(HttpHeaderName.Location, location.OriginalString);
 
             if (response.ContentLength > 0)
             {
-                response.Headers.Append(HttpHeaderName.CONTENT_LOCATION, location.OriginalString);
+                response.Headers.Append(HttpHeaderName.ContentLocation, location.OriginalString);
                 if (fhirResponse.Resource?.Meta?.LastUpdated != null)
                 {
-                    response.Headers.Append(HttpHeaderName.LAST_MODIFIED,
+                    response.Headers.Append(HttpHeaderName.LastModified,
                         fhirResponse.Resource.Meta.LastUpdated.Value.ToString("R"));
                 }
             }

--- a/Libraries/Spark.Engine/Formatters/BinaryOutputFormatter.cs
+++ b/Libraries/Spark.Engine/Formatters/BinaryOutputFormatter.cs
@@ -40,7 +40,7 @@ public class BinaryOutputFormatter : OutputFormatter
             }
             if (binary == null) return;
 
-            context.HttpContext.Response.Headers.Append(HttpHeaderName.CONTENT_DISPOSITION, "attachment");
+            context.HttpContext.Response.Headers.Append(HttpHeaderName.ContentDisposition, "attachment");
             context.HttpContext.Response.ContentType = binary.ContentType;
 
             if (binary.Data is { Length: > 0 })

--- a/Libraries/Spark.Engine/Handlers/FormatTypeHandler.cs
+++ b/Libraries/Spark.Engine/Handlers/FormatTypeHandler.cs
@@ -30,11 +30,11 @@ public class FormatTypeHandler
             ResourceFormat accepted = ContentType.GetResourceFormatFromFormatParam(format);
             if (accepted != ResourceFormat.Unknown)
             {
-                if (context.Request.Headers.ContainsKey(HttpHeaderName.ACCEPT)) context.Request.Headers.Remove(HttpHeaderName.ACCEPT);
+                if (context.Request.Headers.ContainsKey(HttpHeaderName.Accept)) context.Request.Headers.Remove(HttpHeaderName.Accept);
                 if (accepted == ResourceFormat.Json)
-                    context.Request.Headers.Append(HttpHeaderName.ACCEPT, new StringValues(ContentType.JSON_CONTENT_HEADER));
+                    context.Request.Headers.Append(HttpHeaderName.Accept, new StringValues(ContentType.JSON_CONTENT_HEADER));
                 else
-                    context.Request.Headers.Append(HttpHeaderName.ACCEPT, new StringValues(ContentType.XML_CONTENT_HEADER));
+                    context.Request.Headers.Append(HttpHeaderName.Accept, new StringValues(ContentType.XML_CONTENT_HEADER));
             }
         }
 
@@ -43,7 +43,7 @@ public class FormatTypeHandler
             if (!HttpRequestExtensions.IsContentTypeHeaderFhirMediaType(context.Request.ContentType))
             {
                 string contentType = context.Request.ContentType;
-                context.Request.Headers.Append(HttpHeaderName.X_CONTENT_TYPE, contentType);
+                context.Request.Headers.Append(HttpHeaderName.XContentType, contentType);
                 context.Request.ContentType = FhirMediaType.OctetStreamMimeType;
             }
         }

--- a/Libraries/Spark.Engine/Service/FhirServiceExtensions/SnapshotPaginationService.cs
+++ b/Libraries/Spark.Engine/Service/FhirServiceExtensions/SnapshotPaginationService.cs
@@ -172,10 +172,10 @@ internal class SnapshotPaginationService : ISnapshotPagination
             new Uri(_snapshot.FeedSelfLink)
             :
             // Stateful pagination
-            _localhost.Absolute(new Uri(FhirRestOp.SNAPSHOT, UriKind.Relative))
-                .AddParam(FhirParameter.SNAPSHOT_ID, _snapshot.Id);
+            _localhost.Absolute(new Uri(FhirRestOp.Snapshot, UriKind.Relative))
+                .AddParam(FhirParameter.SnapshotId, _snapshot.Id);
 
-        return baseUrl.AddParam(FhirParameter.OFFSET, offset.ToString());
+        return baseUrl.AddParam(FhirParameter.Offset, offset.ToString());
     }
 
     private IEnumerable<string> IncludeToPath(string include)


### PR DESCRIPTION
Obsolete all upper case consts and wrap them in #pragma disable/restore so they do not issue warnings during compile, and so that dotnet format do not affect them.