### PR TITLE
Engine: Add and use constants for general parameters

### DIFF
--- a/Libraries/Spark.Engine/Core/Const.cs
+++ b/Libraries/Spark.Engine/Core/Const.cs
@@ -69,3 +69,18 @@ public static class FhirParameter
 #pragma warning restore IDE1006
 // ReSharper restore InconsistentNaming
 }
+
+internal static class GeneralParameters
+{
+    public const string Elements = "_elements";
+    public const string Format = "_format";
+    public const string Pretty = "_pretty";
+    public const string Summary = "_summary";
+
+    internal static readonly string[] DoNotForwardAsSearchParameters =
+    [
+        Elements,
+        Format,
+        Pretty,
+    ];
+}

--- a/Libraries/Spark.Engine/Extensions/HttpHeadersExtensions.cs
+++ b/Libraries/Spark.Engine/Extensions/HttpHeadersExtensions.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http.Headers;
 using Microsoft.AspNetCore.Http;
+using Spark.Engine.Core;
 
 namespace Spark.Engine.Extensions;
 
@@ -57,7 +58,7 @@ public static class HttpRequestExtensions
 
     public static SearchParams GetSearchParams(this HttpRequest request)
     {
-        var parameters = request.TupledParameters().Where(tp => tp.Item1 != "_format");
+        var parameters = request.TupledParameters().Where(tp => !GeneralParameters.DoNotForwardAsSearchParameters.Contains(tp.Item1));
         var searchCommand = SearchParams.FromUriParamList(parameters);
         return searchCommand;
     }

--- a/Libraries/Spark.Engine/Handlers/FormatTypeHandler.cs
+++ b/Libraries/Spark.Engine/Handlers/FormatTypeHandler.cs
@@ -24,7 +24,7 @@ public class FormatTypeHandler
 
     public async Task InvokeAsync(HttpContext context)
     {
-        string format = context.Request.GetParameter("_format");
+        string format = context.Request.GetParameter(GeneralParameters.Format);
         if (!string.IsNullOrEmpty(format))
         {
             ResourceFormat accepted = ContentType.GetResourceFormatFromFormatParam(format);

--- a/Tests/Spark.Engine.Tests/Extensions/HttpRequestFhirExtensionsTests.cs
+++ b/Tests/Spark.Engine.Tests/Extensions/HttpRequestFhirExtensionsTests.cs
@@ -4,9 +4,10 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+using Hl7.Fhir.Model;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
-using Hl7.Fhir.Model;
+using Spark.Engine.Core;
 using Spark.Engine.Extensions;
 using Xunit;
 
@@ -82,5 +83,43 @@ public class HttpRequestFhirExtensionsTests
         context.Request.TransferResourceIdIfRawBinary(binary, "example");
 
         Assert.Equal("example", binary.Id);
+    }
+    [Theory]
+    [InlineData(GeneralParameters.Format, "json")]
+    [InlineData(GeneralParameters.Pretty, "true")]
+    [InlineData(GeneralParameters.Elements, "id,name")]
+    public void GetSearchParams_WithGeneralParameter_ShouldFilterGeneralParameterFromSearchParameters(
+        string parameterName,
+        string parameterValue)
+    {
+        DefaultHttpContext context = new()
+        {
+            Request = { QueryString = new QueryString($"?{parameterName}={parameterValue}") }
+        };
+
+        var searchParams = context.Request.GetSearchParams();
+
+        Assert.DoesNotContain(searchParams.Parameters, p => p.Item1 == parameterName);
+    }
+
+    [Theory]
+    [InlineData(GeneralParameters.Format, "json")]
+    [InlineData(GeneralParameters.Pretty, "true")]
+    [InlineData(GeneralParameters.Elements, "id,name")]
+    public void GetSearchParams_WithGeneralParameterAndSearchParameter_ShouldFilterGeneralParameterAndKeepSearchParameter(
+        string parameterName,
+        string parameterValue)
+    {
+        DefaultHttpContext context = new()
+        {
+            Request = { QueryString = new QueryString($"?{parameterName}={parameterValue}&name=Smith") }
+        };
+
+        var searchParams = context.Request.GetSearchParams();
+
+        Assert.DoesNotContain(searchParams.Parameters, p => p.Item1 == parameterName);
+        var parameter = Assert.Single(searchParams.Parameters);
+        Assert.Equal("name", parameter.Item1);
+        Assert.Equal("Smith", parameter.Item2);
     }
 }


### PR DESCRIPTION
Add tests that verify general parameters are excluded from the search parameter set.

We do not exclude `_summary` since there is special handling for `_summary=count` elsewhere in the code and therefore also `_summary` is not included in the search parameter set.