### PR TITLE
Engine: Detailed OperationOutcome on request body parse failures

### DIFF
--- a/Libraries/Spark.Engine/Core/Error.cs
+++ b/Libraries/Spark.Engine/Core/Error.cs
@@ -5,6 +5,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+using Hl7.Fhir.Model;
+using System;
 using System.Net;
 
 namespace Spark.Engine.Core;
@@ -19,6 +21,12 @@ public static class Error
     public static SparkException BadRequest(string message, params object[] values)
     {
         return new SparkException(HttpStatusCode.BadRequest, message, values);
+    }
+
+    public static SparkException BadRequest(OperationOutcome outcome, string message = null)
+    {
+        ArgumentNullException.ThrowIfNull(outcome);
+        return new SparkException(HttpStatusCode.BadRequest, outcome, message);
     }
 
     public static SparkException NotFound(string message, params object[] values)

--- a/Libraries/Spark.Engine/Formatters/AsyncResourceJsonInputFormatter.cs
+++ b/Libraries/Spark.Engine/Formatters/AsyncResourceJsonInputFormatter.cs
@@ -55,6 +55,10 @@ namespace Spark.Engine.Formatters
 
                 return await InputFormatterResult.SuccessAsync(resource);
             }
+            catch (DeserializationFailedException exception)
+            {
+                throw Error.BadRequest(exception.ToOperationOutcome(), "Body parsing failed");
+            }
             catch (FormatException exception)
             {
                 throw Error.BadRequest($"Body parsing failed: {exception.Message}");

--- a/Libraries/Spark.Engine/Formatters/AsyncResourceXmlInputFormatter.cs
+++ b/Libraries/Spark.Engine/Formatters/AsyncResourceXmlInputFormatter.cs
@@ -55,6 +55,10 @@ public class AsyncResourceXmlInputFormatter : TextInputFormatter
 
             return await InputFormatterResult.SuccessAsync(resource);
         }
+        catch (DeserializationFailedException exception)
+        {
+            throw Error.BadRequest(exception.ToOperationOutcome(), "Body parsing failed");
+        }
         catch (FormatException exception)
         {
             throw Error.BadRequest($"Body parsing failed: {exception.Message}");

--- a/Libraries/Spark.Engine/Formatters/ResourceJsonInputFormatter.cs
+++ b/Libraries/Spark.Engine/Formatters/ResourceJsonInputFormatter.cs
@@ -74,6 +74,10 @@ public class ResourceJsonInputFormatter : TextInputFormatter
 
             return await InputFormatterResult.SuccessAsync(resource);
         }
+        catch (DeserializationFailedException exception)
+        {
+            throw Error.BadRequest(exception.ToOperationOutcome(), "Body parsing failed");
+        }
         catch (FormatException exception)
         {
             throw Error.BadRequest($"Body parsing failed: {exception.Message}");

--- a/Libraries/Spark.Engine/Formatters/ResourceXmlInputFormatter.cs
+++ b/Libraries/Spark.Engine/Formatters/ResourceXmlInputFormatter.cs
@@ -71,6 +71,10 @@ public class ResourceXmlInputFormatter : TextInputFormatter
             context.HttpContext.AddResourceType(resource.GetType());
             return InputFormatterResult.Success(resource);
         }
+        catch (DeserializationFailedException exception)
+        {
+            throw Error.BadRequest(exception.ToOperationOutcome(), "Body parsing failed");
+        }
         catch (FormatException exception)
         {
             throw Error.BadRequest($"Body parsing failed: {exception.Message}");

--- a/Tests/Spark.Engine.Tests.Shared/Formatters/AsyncResourceJsonInputFormatterTests.cs
+++ b/Tests/Spark.Engine.Tests.Shared/Formatters/AsyncResourceJsonInputFormatterTests.cs
@@ -11,6 +11,7 @@ using Spark.Engine.Core;
 using Spark.Engine.Formatters;
 using Spark.Engine.Tests.Utility;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Text;
 using System.Threading.Tasks;
@@ -99,6 +100,22 @@ public class AsyncResourceJsonInputFormatterTests : FormatterTestBase
 
         SparkException exception = await Assert.ThrowsAsync<SparkException>(() => formatter.ReadAsync(formatterContext));
         Assert.Equal(HttpStatusCode.BadRequest, exception.StatusCode);
+    }
+
+    [Fact]
+    public async Task ReadAsync_ThrowsSparkException_WithOperationOutcome_OnInvalidElement()
+    {
+        var formatter = GetInputFormatter();
+
+        var contentBytes = "{ \"resourceType\": \"Patient\", \"gender\": \"bogus\" }"u8.ToArray();
+        var httpContext = GetHttpContext(contentBytes, DefaultContentType);
+
+        var formatterContext = CreateInputFormatterContext(typeof(FhirModel.Resource), httpContext);
+
+        SparkException exception = await Assert.ThrowsAsync<SparkException>(() => formatter.ReadAsync(formatterContext));
+        Assert.Equal(HttpStatusCode.BadRequest, exception.StatusCode);
+        Assert.NotNull(exception.Outcome);
+        Assert.Contains(exception.Outcome.Issue, issue => issue.Expression.Contains("Patient.gender"));
     }
 
     [Fact]

--- a/Tests/Spark.Engine.Tests.Shared/Formatters/AsyncResourceXmlInputFormatterTests.cs
+++ b/Tests/Spark.Engine.Tests.Shared/Formatters/AsyncResourceXmlInputFormatterTests.cs
@@ -10,6 +10,7 @@ using Spark.Engine.Core;
 using Spark.Engine.Formatters;
 using Spark.Engine.Tests.Utility;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Text;
 using System.Threading.Tasks;
@@ -98,6 +99,22 @@ public class AsyncResourceXmlInputFormatterTests : FormatterTestBase
 
         SparkException exception = await Assert.ThrowsAsync<SparkException>(() => formatter.ReadAsync(formatterContext));
         Assert.Equal(HttpStatusCode.BadRequest, exception.StatusCode);
+    }
+
+    [Fact]
+    public async Task ReadAsync_ThrowsSparkException_WithOperationOutcome_OnInvalidElement()
+    {
+        var formatter = GetInputFormatter();
+
+        var contentBytes = "<Patient xmlns=\"http://hl7.org/fhir\"><active value=\"true\"/><gender value=\"bogus\"/></Patient>"u8.ToArray();
+        var httpContext = GetHttpContext(contentBytes, DefaultContentType);
+
+        var formatterContext = CreateInputFormatterContext(typeof(FhirModel.Resource), httpContext);
+
+        SparkException exception = await Assert.ThrowsAsync<SparkException>(() => formatter.ReadAsync(formatterContext));
+        Assert.Equal(HttpStatusCode.BadRequest, exception.StatusCode);
+        Assert.NotNull(exception.Outcome);
+        Assert.Contains(exception.Outcome.Issue, issue => issue.Expression.Contains("Patient.gender"));
     }
 
     [Fact]

--- a/Tests/Spark.Engine.Tests.Shared/Formatters/ResourceJsonInputFormatterTests.cs
+++ b/Tests/Spark.Engine.Tests.Shared/Formatters/ResourceJsonInputFormatterTests.cs
@@ -12,6 +12,7 @@ using Spark.Engine.Formatters;
 using Spark.Engine.Tests.Utility;
 using System.Buffers;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Text;
 using System.Threading.Tasks;
@@ -141,6 +142,22 @@ public class ResourceJsonInputFormatterTests : FormatterTestBase
 
         SparkException exception = await Assert.ThrowsAsync<SparkException>(() => formatter.ReadAsync(formatterContext));
         Assert.Equal(HttpStatusCode.BadRequest, exception.StatusCode);
+    }
+
+    [Fact]
+    public async Task ReadAsync_ThrowsSparkException_WithOperationOutcome_OnInvalidElement()
+    {
+        var formatter = GetInputFormatter();
+
+        var contentBytes = "{ \"resourceType\": \"Patient\", \"gender\": \"bogus\" }"u8.ToArray();
+        var httpContext = GetHttpContext(contentBytes, DefaultContentType);
+
+        var formatterContext = CreateInputFormatterContext(typeof(FhirModel.Resource), httpContext);
+
+        SparkException exception = await Assert.ThrowsAsync<SparkException>(() => formatter.ReadAsync(formatterContext));
+        Assert.Equal(HttpStatusCode.BadRequest, exception.StatusCode);
+        Assert.NotNull(exception.Outcome);
+        Assert.Contains(exception.Outcome.Issue, issue => issue.Expression.Contains("Patient.gender"));
     }
 
     [Fact]

--- a/Tests/Spark.Engine.Tests.Shared/Formatters/ResourceXmlInputFormatterTests.cs
+++ b/Tests/Spark.Engine.Tests.Shared/Formatters/ResourceXmlInputFormatterTests.cs
@@ -11,6 +11,7 @@ using Spark.Engine.Core;
 using Spark.Engine.Formatters;
 using Spark.Engine.Tests.Utility;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Text;
 using System.Threading.Tasks;
@@ -140,6 +141,22 @@ public class ResourceXmlInputFormatterTests : FormatterTestBase
 
         SparkException exception = await Assert.ThrowsAsync<SparkException>(() => formatter.ReadAsync(formatterContext));
         Assert.Equal(HttpStatusCode.BadRequest, exception.StatusCode);
+    }
+
+    [Fact]
+    public async Task ReadAsync_ThrowsSparkException_WithOperationOutcome_OnInvalidElement()
+    {
+        var formatter = GetInputFormatter();
+
+        var contentBytes = "<Patient xmlns=\"http://hl7.org/fhir\"><active value=\"true\"/><gender value=\"bogus\"/></Patient>"u8.ToArray();
+        var httpContext = GetHttpContext(contentBytes, DefaultContentType);
+
+        var formatterContext = CreateInputFormatterContext(typeof(FhirModel.Resource), httpContext);
+
+        SparkException exception = await Assert.ThrowsAsync<SparkException>(() => formatter.ReadAsync(formatterContext));
+        Assert.Equal(HttpStatusCode.BadRequest, exception.StatusCode);
+        Assert.NotNull(exception.Outcome);
+        Assert.Contains(exception.Outcome.Issue, issue => issue.Expression.Contains("Patient.gender"));
     }
 
     [Fact]


### PR DESCRIPTION
Catch `DeserializationFailedException` in the input formatters and attach its `ToOperationOutcome()` to the thrown `SparkException`, so a 400 response carries one issue per invalid element with FHIRPath expressions (e.g. 
`Patient.gender`) instead of a flattened message string — for create, update and transaction alike. 

`DeserializationFailedException` derives from `FormatException`, so it was previously swallowed by the existing catch and reduced to its message.


