### PR TITLE
Engine: Return 400 instead of 500 on unreadable request bodies

### DIFF
--- a/Libraries/Spark.Engine/Formatters/AsyncResourceJsonInputFormatter.cs
+++ b/Libraries/Spark.Engine/Formatters/AsyncResourceJsonInputFormatter.cs
@@ -12,6 +12,7 @@ using Spark.Engine.Extensions;
 using System;
 using System.IO;
 using System.Text;
+using System.Text.Json;
 using System.Threading.Tasks;
 
 namespace Spark.Engine.Formatters
@@ -55,6 +56,10 @@ namespace Spark.Engine.Formatters
                 return await InputFormatterResult.SuccessAsync(resource);
             }
             catch (FormatException exception)
+            {
+                throw Error.BadRequest($"Body parsing failed: {exception.Message}");
+            }
+            catch (JsonException exception)
             {
                 throw Error.BadRequest($"Body parsing failed: {exception.Message}");
             }

--- a/Libraries/Spark.Engine/Formatters/AsyncResourceXmlInputFormatter.cs
+++ b/Libraries/Spark.Engine/Formatters/AsyncResourceXmlInputFormatter.cs
@@ -13,6 +13,7 @@ using System;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
+using System.Xml;
 
 namespace Spark.Engine.Formatters;
 
@@ -55,6 +56,10 @@ public class AsyncResourceXmlInputFormatter : TextInputFormatter
             return await InputFormatterResult.SuccessAsync(resource);
         }
         catch (FormatException exception)
+        {
+            throw Error.BadRequest($"Body parsing failed: {exception.Message}");
+        }
+        catch (XmlException exception)
         {
             throw Error.BadRequest($"Body parsing failed: {exception.Message}");
         }

--- a/Libraries/Spark.Engine/Formatters/ResourceXmlInputFormatter.cs
+++ b/Libraries/Spark.Engine/Formatters/ResourceXmlInputFormatter.cs
@@ -75,5 +75,9 @@ public class ResourceXmlInputFormatter : TextInputFormatter
         {
             throw Error.BadRequest($"Body parsing failed: {exception.Message}");
         }
+        catch (XmlException exception)
+        {
+            throw Error.BadRequest($"Body parsing failed: {exception.Message}");
+        }
     }
 }

--- a/Tests/Spark.Engine.Tests.Shared/Formatters/AsyncResourceJsonInputFormatterTests.cs
+++ b/Tests/Spark.Engine.Tests.Shared/Formatters/AsyncResourceJsonInputFormatterTests.cs
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026, Incendi <info@incendi.no>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+using FhirModel = Hl7.Fhir.Model;
+using Hl7.Fhir.Serialization;
+using Spark.Engine.Core;
+using Spark.Engine.Formatters;
+using Spark.Engine.Tests.Utility;
+using System.IO;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Spark.Engine.Tests.Formatters;
+
+public class AsyncResourceJsonInputFormatterTests : FormatterTestBase
+{
+    private const string DEFAULT_CONTENT_TYPE = "application/json";
+
+    [Fact]
+    public async Task ReadAsync_ValidResource_ReturnsResource()
+    {
+        var formatter = GetInputFormatter();
+
+        var fhirVersionMoniker = FhirVersionUtility.GetFhirVersionMoniker();
+        var content = GetResourceFromFileAsString(Path.Combine("TestData", fhirVersionMoniker.ToString(), "patient-example.json"));
+        var contentBytes = Encoding.UTF8.GetBytes(content);
+        var httpContext = GetHttpContext(contentBytes, DEFAULT_CONTENT_TYPE);
+
+        var formatterContext = CreateInputFormatterContext(typeof(FhirModel.Resource), httpContext);
+
+        var result = await formatter.ReadAsync(formatterContext);
+
+        Assert.False(result.HasError);
+
+        var patient = Assert.IsType<FhirModel.Patient>(result.Model);
+        Assert.Equal("example", patient.Id);
+    }
+
+    [Fact]
+    public async Task ReadAsync_ThrowsSparkException_BadRequest_OnMalformedBody()
+    {
+        var formatter = GetInputFormatter();
+
+        var contentBytes = Encoding.UTF8.GetBytes("this is not json");
+        var httpContext = GetHttpContext(contentBytes, DEFAULT_CONTENT_TYPE);
+
+        var formatterContext = CreateInputFormatterContext(typeof(FhirModel.Resource), httpContext);
+
+        SparkException exception = await Assert.ThrowsAsync<SparkException>(() => formatter.ReadAsync(formatterContext));
+        Assert.Equal(HttpStatusCode.BadRequest, exception.StatusCode);
+    }
+
+    private static AsyncResourceJsonInputFormatter GetInputFormatter(DeserializerSettings parserSettings = null)
+    {
+        if (parserSettings == null) parserSettings = new DeserializerSettings().UsingMode(DeserializationMode.Strict);
+        return new AsyncResourceJsonInputFormatter(
+            new FhirJsonDeserializer(parserSettings));
+    }
+}

--- a/Tests/Spark.Engine.Tests.Shared/Formatters/AsyncResourceXmlInputFormatterTests.cs
+++ b/Tests/Spark.Engine.Tests.Shared/Formatters/AsyncResourceXmlInputFormatterTests.cs
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026, Incendi <info@incendi.no>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+using FhirModel = Hl7.Fhir.Model;
+using Hl7.Fhir.Serialization;
+using Spark.Engine.Core;
+using Spark.Engine.Formatters;
+using Spark.Engine.Tests.Utility;
+using System.IO;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Spark.Engine.Tests.Formatters;
+
+public class AsyncResourceXmlInputFormatterTests : FormatterTestBase
+{
+    private const string DEFAULT_CONTENT_TYPE = "application/xml";
+
+    [Fact]
+    public async Task ReadAsync_ValidResource_ReturnsResource()
+    {
+        var formatter = GetInputFormatter();
+
+        var fhirVersionMoniker = FhirVersionUtility.GetFhirVersionMoniker();
+        var content = GetResourceFromFileAsString(Path.Combine("TestData", fhirVersionMoniker.ToString(), "patient-example.xml"));
+        var contentBytes = Encoding.UTF8.GetBytes(content);
+        var httpContext = GetHttpContext(contentBytes, DEFAULT_CONTENT_TYPE);
+
+        var formatterContext = CreateInputFormatterContext(typeof(FhirModel.Resource), httpContext);
+
+        var result = await formatter.ReadAsync(formatterContext);
+
+        Assert.False(result.HasError);
+
+        var patient = Assert.IsType<FhirModel.Patient>(result.Model);
+        Assert.Equal("example", patient.Id);
+    }
+
+    [Fact]
+    public async Task ReadAsync_ThrowsSparkException_BadRequest_OnMalformedBody()
+    {
+        var formatter = GetInputFormatter();
+
+        var contentBytes = Encoding.UTF8.GetBytes("this is not xml");
+        var httpContext = GetHttpContext(contentBytes, DEFAULT_CONTENT_TYPE);
+
+        var formatterContext = CreateInputFormatterContext(typeof(FhirModel.Resource), httpContext);
+
+        SparkException exception = await Assert.ThrowsAsync<SparkException>(() => formatter.ReadAsync(formatterContext));
+        Assert.Equal(HttpStatusCode.BadRequest, exception.StatusCode);
+    }
+
+    private static AsyncResourceXmlInputFormatter GetInputFormatter(DeserializerSettings parserSettings = null)
+    {
+        if (parserSettings == null) parserSettings = new DeserializerSettings().UsingMode(DeserializationMode.Strict);
+        return new AsyncResourceXmlInputFormatter(
+            new FhirXmlDeserializer(parserSettings));
+    }
+}

--- a/Tests/Spark.Engine.Tests.Shared/Formatters/ResourceJsonInputFormatterTests.cs
+++ b/Tests/Spark.Engine.Tests.Shared/Formatters/ResourceJsonInputFormatterTests.cs
@@ -117,6 +117,20 @@ public class ResourceJsonInputFormatterTests : FormatterTestBase
         Assert.Equal(HttpStatusCode.BadRequest, exception.StatusCode);
     }
 
+    [Fact]
+    public async Task ReadAsync_ThrowsSparkException_BadRequest_OnMalformedBody()
+    {
+        var formatter = GetInputFormatter();
+
+        var contentBytes = Encoding.UTF8.GetBytes("this is not xml");
+        var httpContext = GetHttpContext(contentBytes, DEFAULT_CONTENT_TYPE);
+
+        var formatterContext = CreateInputFormatterContext(typeof(FhirModel.Resource), httpContext);
+
+        SparkException exception = await Assert.ThrowsAsync<SparkException>(() => formatter.ReadAsync(formatterContext));
+        Assert.Equal(HttpStatusCode.BadRequest, exception.StatusCode);
+    }
+
     protected static ResourceJsonInputFormatter GetInputFormatter(DeserializerSettings parserSettings = null)
     {
         if (parserSettings == null) parserSettings = new DeserializerSettings().UsingMode(DeserializationMode.Strict);

--- a/Tests/Spark.Engine.Tests.Shared/Formatters/ResourceXmlInputFormatterTests.cs
+++ b/Tests/Spark.Engine.Tests.Shared/Formatters/ResourceXmlInputFormatterTests.cs
@@ -7,9 +7,11 @@
 using FhirModel = Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
 using Microsoft.AspNetCore.Http;
+using Spark.Engine.Core;
 using Spark.Engine.Formatters;
 using Spark.Engine.Tests.Utility;
 using System.IO;
+using System.Net;
 using System.Text;
 using System.Threading.Tasks;
 using Xunit;
@@ -96,6 +98,20 @@ public class ResourceXmlInputFormatterTests : FormatterTestBase
         patient = Assert.IsType<FhirModel.Patient>(result.Model);
         Assert.Equal("example", patient.Id);
         Assert.Equal(true, patient.Active);
+    }
+
+    [Fact]
+    public async Task ReadAsync_ThrowsSparkException_BadRequest_OnMalformedBody()
+    {
+        var formatter = GetInputFormatter();
+
+        var contentBytes = Encoding.UTF8.GetBytes("this is not xml");
+        var httpContext = GetHttpContext(contentBytes, DEFAULT_CONTENT_TYPE);
+
+        var formatterContext = CreateInputFormatterContext(typeof(FhirModel.Resource), httpContext);
+
+        SparkException exception = await Assert.ThrowsAsync<SparkException>(() => formatter.ReadAsync(formatterContext));
+        Assert.Equal(HttpStatusCode.BadRequest, exception.StatusCode);
     }
 
     protected static ResourceXmlInputFormatter GetInputFormatter(DeserializerSettings parserSettings = null)


### PR DESCRIPTION
Unreadable bodies escaped the input formatters'  catch(FormatException) and surfaced as 500 Internal Server Error: XmlException on both XML input formatters, and JsonException on the async JSON input formatter (the sync JSON formatter already caught it).

Catch them and return 400 Bad Request, per the FHIR HTTP spec (https://hl7.org/fhir/R4/http.html#create).