### PR TITLE
Engine: Add virtual GetGenericSearchParamDefinitions() + Override it in R5

### DIFF
--- a/Libraries/Spark.Engine.R5/Core/FhirModel.cs
+++ b/Libraries/Spark.Engine.R5/Core/FhirModel.cs
@@ -32,4 +32,49 @@ public class FhirModel : FhirModelBase
 
     public override string GetFhirTypeNameForType(Type type) => ModelInfo.GetFhirTypeNameForType(type);
 
+    protected override SearchParamDefinition[] GetGenericSearchParamDefinitions()
+    {
+        return [
+            new()
+            {
+                Resource = "Resource",
+                Name = "_id",
+                Type = SearchParamType.Token,
+                Expression = "Resource.id",
+                Path = ["Resource.id"]
+            },
+            new()
+            {
+                Resource = "Resource",
+                Name = "_lastUpdated",
+                Type = SearchParamType.Date,
+                Expression = "Resource.meta.lastUpdated",
+                Path = ["Resource.meta.lastUpdated"]
+            },
+            new()
+            {
+                Resource = "Resource",
+                Name = "_tag",
+                Type = SearchParamType.Token,
+                Expression = "Resource.meta.tag",
+                Path = ["Resource.meta.tag"]
+            },
+            new()
+            {
+                Resource = "Resource",
+                Name = "_profile",
+                Type = SearchParamType.Reference,
+                Expression = "Resource.meta.profile",
+                Path = ["Resource.meta.profile"]
+            },
+            new()
+            {
+                Resource = "Resource",
+                Name = "_security",
+                Type = SearchParamType.Token,
+                Expression = "Resource.meta.security",
+                Path = ["Resource.meta.security"]
+            }
+        ];
+    }
 }

--- a/Libraries/Spark.Engine/Core/FhirModelBase.cs
+++ b/Libraries/Spark.Engine/Core/FhirModelBase.cs
@@ -18,50 +18,6 @@ namespace Spark.Engine.Core;
 
 public abstract class FhirModelBase : IFhirModel
 {
-    private static readonly SearchParamDefinition[] GenericSearchParamDefinitions =
-    [
-        new()
-        {
-            Resource = "Resource",
-            Name = "_id",
-            Type = SearchParamType.Token,
-            Expression = "Resource.id",
-            Path = ["Resource.id"]
-        },
-        new()
-        {
-            Resource = "Resource",
-            Name = "_lastUpdated",
-            Type = SearchParamType.Date,
-            Expression = "Resource.meta.lastUpdated",
-            Path = ["Resource.meta.lastUpdated"]
-        },
-        new()
-        {
-            Resource = "Resource",
-            Name = "_tag",
-            Type = SearchParamType.Token,
-            Expression = "Resource.meta.tag",
-            Path = ["Resource.meta.tag"]
-        },
-        new()
-        {
-            Resource = "Resource",
-            Name = "_profile",
-            Type = SearchParamType.Uri,
-            Expression = "Resource.meta.profile",
-            Path = ["Resource.meta.profile"]
-        },
-        new()
-        {
-            Resource = "Resource",
-            Name = "_security",
-            Type = SearchParamType.Token,
-            Expression = "Resource.meta.security",
-            Path = ["Resource.meta.security"]
-        }
-    ];
-
     private readonly List<CompartmentInfo> _compartments = [];
     private List<SearchParameter> _searchParameters;
 
@@ -90,7 +46,7 @@ public abstract class FhirModelBase : IFhirModel
 
     private void ApplyCommonGenericSearchParameters(List<SearchParameter> searchParameters)
     {
-        var genericSearchParameters = GenericSearchParamDefinitions.Select(CreateSearchParameterFromSearchParamDefinition);
+        var genericSearchParameters = GetGenericSearchParamDefinitions().Select(CreateSearchParameterFromSearchParamDefinition);
         // NOTE: The incoming list of searchParameters may already contain these generic parameters,
         //       so use Except to ensure they are not added twice.
         searchParameters.AddRange(genericSearchParameters.Except(searchParameters));
@@ -197,6 +153,52 @@ public abstract class FhirModelBase : IFhirModel
     private bool IsDefinitionResourceType(VersionIndependentResourceTypesAll resourceType)
     {
         return DefinitionResourceTypes().Contains(resourceType);
+    }
+
+    protected virtual SearchParamDefinition[] GetGenericSearchParamDefinitions()
+    {
+        return [
+            new()
+            {
+                Resource = "Resource",
+                Name = "_id",
+                Type = SearchParamType.Token,
+                Expression = "Resource.id",
+                Path = ["Resource.id"]
+            },
+            new()
+            {
+                Resource = "Resource",
+                Name = "_lastUpdated",
+                Type = SearchParamType.Date,
+                Expression = "Resource.meta.lastUpdated",
+                Path = ["Resource.meta.lastUpdated"]
+            },
+            new()
+            {
+                Resource = "Resource",
+                Name = "_tag",
+                Type = SearchParamType.Token,
+                Expression = "Resource.meta.tag",
+                Path = ["Resource.meta.tag"]
+            },
+            new()
+            {
+                Resource = "Resource",
+                Name = "_profile",
+                Type = SearchParamType.Uri,
+                Expression = "Resource.meta.profile",
+                Path = ["Resource.meta.profile"]
+            },
+            new()
+            {
+                Resource = "Resource",
+                Name = "_security",
+                Type = SearchParamType.Token,
+                Expression = "Resource.meta.security",
+                Path = ["Resource.meta.security"]
+            }
+        ];
     }
 
     protected virtual IEnumerable<VersionIndependentResourceTypesAll> DefinitionResourceTypes()

--- a/Tests/Spark.Engine.R4.Tests/Spark.Engine.R4.Tests.csproj
+++ b/Tests/Spark.Engine.R4.Tests/Spark.Engine.R4.Tests.csproj
@@ -6,6 +6,7 @@
     <AssemblyName>Spark.Engine.R4.Tests</AssemblyName>
     <RootNamespace>Spark.Engine.Tests</RootNamespace>
     <OutputType>Exe</OutputType>
+    <DefineConstants>$(DefineConstants);R4_TESTS</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Tests/Spark.Engine.R4B.Tests/Spark.Engine.R4B.Tests.csproj
+++ b/Tests/Spark.Engine.R4B.Tests/Spark.Engine.R4B.Tests.csproj
@@ -6,6 +6,7 @@
     <AssemblyName>Spark.Engine.R4B.Tests</AssemblyName>
     <RootNamespace>Spark.Engine.Tests</RootNamespace>
     <OutputType>Exe</OutputType>
+    <DefineConstants>$(DefineConstants);R4B_TESTS</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Tests/Spark.Engine.R5.Tests/Spark.Engine.R5.Tests.csproj
+++ b/Tests/Spark.Engine.R5.Tests/Spark.Engine.R5.Tests.csproj
@@ -6,6 +6,7 @@
     <AssemblyName>Spark.Engine.R5.Tests</AssemblyName>
     <RootNamespace>Spark.Engine.Tests</RootNamespace>
     <OutputType>Exe</OutputType>
+    <DefineConstants>$(DefineConstants);R5_TESTS</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Tests/Spark.Engine.STU3.Tests/Spark.Engine.STU3.Tests.csproj
+++ b/Tests/Spark.Engine.STU3.Tests/Spark.Engine.STU3.Tests.csproj
@@ -6,6 +6,7 @@
     <AssemblyName>Spark.Engine.STU3.Tests</AssemblyName>
     <RootNamespace>Spark.Engine.Tests</RootNamespace>
     <OutputType>Exe</OutputType>
+    <DefineConstants>$(DefineConstants);STU3_TESTS</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Tests/Spark.Engine.Tests.Shared/Core/FhirModelTests.cs
+++ b/Tests/Spark.Engine.Tests.Shared/Core/FhirModelTests.cs
@@ -14,13 +14,48 @@ namespace Spark.Engine.Tests.Core;
 
 public class FhirModelTests
 {
+    private FhirModel _model = new();
+
     [Fact]
     public void TestCompartments()
     {
-        FhirModel model = new();
-        var actual = model.FindCompartmentInfo(ResourceType.Patient.GetLiteral());
+        var actual = _model.FindCompartmentInfo(ResourceType.Patient.GetLiteral());
 
         Assert.NotNull(actual);
         Assert.True(actual.ReverseIncludes.Any());
     }
+
+#if STU3_TESTS || R4_TESTS || R4B_TESTS
+    [Fact]
+    public void FindSearchParameters_UsesGeneratedGenericParameterDefinitions()
+    {
+        var genericParameters = _model.FindSearchParameters("Patient")
+            .Where(parameter => new[] { "_id", "_lastUpdated", "_tag", "_profile", "_security" }.Contains(parameter.Name))
+            .ToDictionary(parameter => parameter.Name, parameter => parameter.Type);
+
+        Assert.Equal(5, genericParameters.Count);
+        Assert.Equal(SearchParamType.Token, genericParameters["_id"]);
+        Assert.Equal(SearchParamType.Date, genericParameters["_lastUpdated"]);
+        Assert.Equal(SearchParamType.Token, genericParameters["_tag"]);
+        Assert.Equal(SearchParamType.Uri, genericParameters["_profile"]);
+        Assert.Equal(SearchParamType.Token, genericParameters["_security"]);
+    }
+#endif
+
+#if R5_TESTS
+    [Fact]
+    public void FindSearchParameters_UsesGeneratedR5GenericParameterDefinitions()
+    {
+        var genericParameters = _model.FindSearchParameters("Patient")
+            .Where(parameter => new[] { "_id", "_lastUpdated", "_tag", "_profile", "_security" }.Contains(parameter.Name))
+            .ToDictionary(parameter => parameter.Name, parameter => parameter.Type);
+
+        Assert.Equal(5, genericParameters.Count);
+        Assert.Equal(SearchParamType.Token, genericParameters["_id"]);
+        Assert.Equal(SearchParamType.Date, genericParameters["_lastUpdated"]);
+        Assert.Equal(SearchParamType.Token, genericParameters["_tag"]);
+        Assert.Equal(SearchParamType.Reference, genericParameters["_profile"]);
+        Assert.Equal(SearchParamType.Token, genericParameters["_security"]);
+    }
+#endif
 }

--- a/Tests/Spark.Engine.Tests.Shared/Core/FhirModelTests.cs
+++ b/Tests/Spark.Engine.Tests.Shared/Core/FhirModelTests.cs
@@ -4,31 +4,23 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Spark.Engine.Core;
 using System.Linq;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Utility;
+using Xunit;
 
 namespace Spark.Engine.Tests.Core;
 
-[TestClass]
 public class FhirModelTests
 {
-    private static FhirModel sut;
-
-    [ClassInitialize]
-    public static void ClassInitialize(TestContext testContext)
-    {
-        sut = new FhirModel();
-    }
-
-    [TestMethod]
+    [Fact]
     public void TestCompartments()
     {
-        var actual = sut.FindCompartmentInfo(ResourceType.Patient.GetLiteral());
+        FhirModel model = new();
+        var actual = model.FindCompartmentInfo(ResourceType.Patient.GetLiteral());
 
-        Assert.IsNotNull(actual);
-        Assert.IsTrue(actual.ReverseIncludes.Any());
+        Assert.NotNull(actual);
+        Assert.True(actual.ReverseIncludes.Any());
     }
 }


### PR DESCRIPTION
R5's generic search param defintions of '_profile' has a SearchParamType of 'Reference', previous FHIR versions had this as 'Uri'.