### PR TITLE
Engine: Rely on SearchParameter's Expression instead of Xpath

### DIFF
--- a/Libraries/Spark.Engine/Extensions/IServiceCollectionExtensions.cs
+++ b/Libraries/Spark.Engine/Extensions/IServiceCollectionExtensions.cs
@@ -160,7 +160,17 @@ public static class IServiceCollectionExtensions
         services.TryAddTransient<IFhirResponseFactory, FhirResponseFactory.FhirResponseFactory>();
         services.TryAddTransient<IIndexRebuildService, IndexRebuildService>();
         services.TryAddTransient<ISearchService, SearchService>();
-        services.TryAddTransient<ISnapshotPaginationProvider, SnapshotPaginationProvider>();
+
+        // FIXME: When the Obsolete constructor in SnapshotPaginationProvider is removed we can get rid off the implementationFactory.
+        services.TryAddTransient<ISnapshotPaginationProvider>(serviceProvider => new SnapshotPaginationProvider(
+            fhirIndex: serviceProvider.GetRequiredService<IFhirIndex>(),
+            fhirStore: serviceProvider.GetRequiredService<IFhirStore>(), serviceProvider.GetRequiredService<ITransfer>(),
+            localhost: serviceProvider.GetRequiredService<ILocalhost>(),
+            snapshotPaginationCalculator: serviceProvider.GetRequiredService<ISnapshotPaginationCalculator>(),
+            fhirModel: serviceProvider.GetRequiredService<IFhirModel>(),
+            resourceResolver: serviceProvider.GetRequiredService<ResourceResolver>()
+        ));
+
         services.TryAddTransient<ISnapshotPaginationCalculator, SnapshotPaginationCalculator>();
         if (settings.Experimental.IndexingMode == IndexingMode.Background)
         {

--- a/Libraries/Spark.Engine/Extensions/ResourceExtensions.cs
+++ b/Libraries/Spark.Engine/Extensions/ResourceExtensions.cs
@@ -47,6 +47,7 @@ internal static class ResourceExtensions
         return list;
     }
 
+    // FIXME: Remove this when the Obsolete constructor in SnapshotPaginationProvider is removed.
     private static IEnumerable<string> GetReferences(
         this IEnumerable<Resource> resources,
         string path)
@@ -54,6 +55,7 @@ internal static class ResourceExtensions
         return resources.SelectMany(resource => resource.GetReferences(path));
     }
 
+    // FIXME: Remove this when the Obsolete constructor in SnapshotPaginationProvider is removed.
     internal static IEnumerable<string> GetReferences(
         this IEnumerable<Resource> resources,
         IEnumerable<string> paths)

--- a/Libraries/Spark.Engine/Search/ResourceResolver.cs
+++ b/Libraries/Spark.Engine/Search/ResourceResolver.cs
@@ -16,8 +16,8 @@ namespace Spark.Engine.Search;
 
 public class ResourceResolver
 {
-    private const string RESOURCE_TYPE_CAPTURE = "resourceType";
-    private const string RESOURCE_ID_CAPTURE = "resourceId";
+    private const string ResourceTypeCapture = "resourceType";
+    private const string ResourceIdCapture = "resourceId";
 
     private readonly Regex _referenceRegex;
     private readonly IStructureDefinitionSummaryProvider _structureDefinitionSummaryProvider;
@@ -25,7 +25,7 @@ public class ResourceResolver
     public ResourceResolver(IReadOnlyList<string> supportedResources, IStructureDefinitionSummaryProvider structureDefinitionSummaryProvider)
     {
         var resourceTypesPattern = string.Join("|", supportedResources);
-        var referenceCaptureRegexPattern = $@"(?<{RESOURCE_TYPE_CAPTURE}>{resourceTypesPattern})\/(?<{RESOURCE_ID_CAPTURE}>[A-Za-z0-9\-\.]{{1,64}})(\/_history\/[A-Za-z0-9\-\.]{{1,64}})?";
+        var referenceCaptureRegexPattern = $@"(?<{ResourceTypeCapture}>{resourceTypesPattern})\/(?<{ResourceIdCapture}>[A-Za-z0-9\-\.]{{1,64}})(\/_history\/[A-Za-z0-9\-\.]{{1,64}})?";
         _referenceRegex = new Regex(referenceCaptureRegexPattern, RegexOptions.Singleline | RegexOptions.Compiled | RegexOptions.ExplicitCapture);
 
         _structureDefinitionSummaryProvider = structureDefinitionSummaryProvider;
@@ -44,8 +44,8 @@ public class ResourceResolver
             return null;
         }
 
-        string resourceTypeInString = match.Groups[RESOURCE_TYPE_CAPTURE].Value;
-        string resourceId = match.Groups[RESOURCE_ID_CAPTURE].Value;
+        string resourceTypeInString = match.Groups[ResourceTypeCapture].Value;
+        string resourceId = match.Groups[ResourceIdCapture].Value;
         ISourceNode node = FhirJsonNode.Create(
             JObject.FromObject(
                 new

--- a/Libraries/Spark.Engine/Service/FhirServiceExtensions/IndexService.cs
+++ b/Libraries/Spark.Engine/Service/FhirServiceExtensions/IndexService.cs
@@ -37,7 +37,10 @@ public class IndexService : IIndexService
         _indexStore = indexStore ?? throw new ArgumentNullException(nameof(indexStore));
         _elementIndexer = elementIndexer ?? throw new ArgumentNullException(nameof(elementIndexer));
         _elementResolver = elementResolver ?? throw new ArgumentNullException(nameof(elementResolver));
+
+        ElementNavFhirExtensions.PrepareFhirSymbolTableFunctions();
     }
+
     public async Task ProcessAsync(Entry entry)
     {
         if (entry.HasResource())
@@ -70,8 +73,6 @@ public class IndexService : IIndexService
 
         var rootIndexValue = new IndexValue(rootPartName);
         AddMetaParts(resource, key, rootIndexValue);
-
-        ElementNavFhirExtensions.PrepareFhirSymbolTableFunctions();
 
         foreach (var searchParameter in searchParameters)
         {

--- a/Libraries/Spark.Engine/Service/FhirServiceExtensions/SnapshotPaginationProvider.cs
+++ b/Libraries/Spark.Engine/Service/FhirServiceExtensions/SnapshotPaginationProvider.cs
@@ -7,20 +7,40 @@
 
 using Spark.Engine.Core;
 using Spark.Engine.Interfaces;
+using Spark.Engine.Search;
 using Spark.Engine.Store.Interfaces;
+using System;
 
 namespace Spark.Engine.Service.FhirServiceExtensions;
 
 public class SnapshotPaginationProvider : ISnapshotPaginationProvider
 {
-    private IFhirIndex _fhirIndex;
-    private IFhirStore _fhirStore;
+    private readonly IFhirIndex _fhirIndex;
+    private readonly IFhirStore _fhirStore;
     private readonly ITransfer _transfer;
     private readonly ILocalhost _localhost;
     private readonly ISnapshotPaginationCalculator _snapshotPaginationCalculator;
     private readonly IFhirModel _fhirModel;
-     
-    public SnapshotPaginationProvider(IFhirIndex fhirIndex, IFhirStore fhirStore, ITransfer transfer, ILocalhost localhost, ISnapshotPaginationCalculator snapshotPaginationCalculator, IFhirModel fhirModel)
+    private readonly ResourceResolver _resourceResolver;
+
+    public SnapshotPaginationProvider(IFhirIndex fhirIndex, IFhirStore fhirStore, ITransfer transfer,
+        ILocalhost localhost, ISnapshotPaginationCalculator snapshotPaginationCalculator, IFhirModel fhirModel,
+        ResourceResolver resourceResolver)
+    {
+        _fhirIndex = fhirIndex ?? throw new ArgumentNullException(nameof(fhirIndex));
+        _fhirStore = fhirStore ?? throw new ArgumentNullException(nameof(fhirStore));
+        _transfer = transfer ?? throw new ArgumentNullException(nameof(transfer));
+        _localhost = localhost ?? throw new ArgumentNullException(nameof(localhost));
+        _snapshotPaginationCalculator = snapshotPaginationCalculator ??
+                                        throw new ArgumentNullException(nameof(snapshotPaginationCalculator));
+        _fhirModel = fhirModel ?? throw new ArgumentNullException(nameof(fhirModel));
+        _resourceResolver = resourceResolver ?? throw new ArgumentNullException(nameof(resourceResolver));
+    }
+
+    [Obsolete(
+        message: $"Use {nameof(SnapshotPaginationProvider)}(IFhirIndex, IFhirStore, ITransfer, ILocalhost, ISnapshotPaginationCalculator, IFhirModel, ResourceResolver) instead.")]
+    public SnapshotPaginationProvider(IFhirIndex fhirIndex, IFhirStore fhirStore, ITransfer transfer,
+        ILocalhost localhost, ISnapshotPaginationCalculator snapshotPaginationCalculator, IFhirModel fhirModel)
     {
         _fhirIndex = fhirIndex;
         _fhirStore = fhirStore;
@@ -32,6 +52,15 @@ public class SnapshotPaginationProvider : ISnapshotPaginationProvider
 
     public ISnapshotPagination StartPagination(Snapshot snapshot)
     {
-        return new SnapshotPaginationService(_fhirIndex, _fhirStore, _transfer, _localhost, _snapshotPaginationCalculator, snapshot, _fhirModel);
+        return new SnapshotPaginationService(
+            _fhirIndex,
+            _fhirStore,
+            _transfer,
+            _localhost,
+            _snapshotPaginationCalculator,
+            snapshot,
+            _fhirModel,
+            _resourceResolver
+        );
     }
 }

--- a/Libraries/Spark.Engine/Service/FhirServiceExtensions/SnapshotPaginationService.cs
+++ b/Libraries/Spark.Engine/Service/FhirServiceExtensions/SnapshotPaginationService.cs
@@ -5,15 +5,18 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+using Hl7.Fhir.FhirPath;
 using Hl7.Fhir.Model;
 using Spark.Engine.Core;
 using Spark.Engine.Extensions;
 using Spark.Engine.Interfaces;
+using Spark.Engine.Search;
 using Spark.Engine.Store.Interfaces;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using SearchParameter = Spark.Engine.Model.SearchParameter;
 
 namespace Spark.Engine.Service.FhirServiceExtensions;
 
@@ -26,8 +29,18 @@ internal class SnapshotPaginationService : ISnapshotPagination
     private readonly ISnapshotPaginationCalculator _snapshotPaginationCalculator;
     private readonly Snapshot _snapshot;
     private readonly IFhirModel _fhirModel;
+    private readonly ResourceResolver _resourceResolver;
 
-    public SnapshotPaginationService(IFhirIndex fhirIndex, IFhirStore fhirStore, ITransfer transfer, ILocalhost localhost, ISnapshotPaginationCalculator snapshotPaginationCalculator, Snapshot snapshot, IFhirModel fhirModel)
+    public SnapshotPaginationService(
+        IFhirIndex fhirIndex,
+        IFhirStore fhirStore,
+        ITransfer transfer,
+        ILocalhost localhost,
+        ISnapshotPaginationCalculator snapshotPaginationCalculator,
+        Snapshot snapshot,
+        IFhirModel fhirModel,
+        ResourceResolver resourceResolver
+    )
     {
         _fhirIndex = fhirIndex ?? throw new ArgumentNullException(nameof(fhirIndex));
         _fhirStore = fhirStore ?? throw new ArgumentNullException(nameof(fhirStore));
@@ -36,6 +49,10 @@ internal class SnapshotPaginationService : ISnapshotPagination
         _snapshotPaginationCalculator = snapshotPaginationCalculator ?? throw new ArgumentNullException(nameof(snapshotPaginationCalculator));
         _snapshot = snapshot ?? throw new ArgumentNullException(nameof(snapshot));
         _fhirModel = fhirModel ?? throw new ArgumentNullException(nameof(fhirModel));
+        // FIXME: Throw ArgumentNullException when we have removed the Obsolete constructor in SnapshotPaginationProvider.
+        _resourceResolver = resourceResolver;
+
+        ElementNavFhirExtensions.PrepareFhirSymbolTableFunctions();
     }
 
     public async Task<Bundle> GetPageAsync(int? index = null, Action<Entry> transformElement = null)
@@ -117,10 +134,15 @@ internal class SnapshotPaginationService : ISnapshotPagination
         if (includes == null || !includes.Any())
             return [];
 
-        var paths = includes.SelectMany(IncludeToPath);
-        var identifiers = entries
-            .GetResources()
-            .GetReferences(paths)
+        var searchParameters = includes
+            .Select(IncludeToSearchParameter)
+            .Where(searchParameter => searchParameter != null)
+            .ToArray();
+        var resources = entries.GetResources();
+        var references = _resourceResolver == null
+            ? resources.GetReferences(searchParameters.SelectMany(searchParameter => searchParameter.Path))
+            : resources.SelectMany(resource => GetIncludeReferences(resource, searchParameters));
+        var identifiers = references
             .Distinct()
             .Select(IKey (reference) => Key.ParseOperationPath(reference))
             .ToList();
@@ -178,7 +200,7 @@ internal class SnapshotPaginationService : ISnapshotPagination
         return baseUrl.AddParam(FhirParameter.Offset, offset.ToString());
     }
 
-    private IEnumerable<string> IncludeToPath(string include)
+    private SearchParameter IncludeToSearchParameter(string include)
     {
         var include_ = include.Split(':');
         var resource = include_.FirstOrDefault();
@@ -187,8 +209,34 @@ internal class SnapshotPaginationService : ISnapshotPagination
             .FirstOrDefault(parameter =>
                 parameter.Resource == resource && parameter.Name == parameterName
             );
-        return searchParameter == null
-            ? Enumerable.Empty<string>()
-            : searchParameter.Path;
+        return searchParameter;
+    }
+
+    // FIXME: Move this ResourceExtensions or some other better place.
+    private IEnumerable<string> GetIncludeReferences(Resource resource, IEnumerable<SearchParameter> searchParameters)
+    {
+        foreach (var searchParameter in searchParameters.Where(parameter => parameter.Resource == resource.TypeName))
+        {
+            if (string.IsNullOrWhiteSpace(searchParameter.Expression))
+                continue;
+
+            IEnumerable<Base> values;
+            try
+            {
+                values = resource.SelectNew(
+                    searchParameter.Expression,
+                    new FhirEvaluationContext { ElementResolver = _resourceResolver.Resolve });
+            }
+            catch (Exception)
+            {
+                continue;
+            }
+
+            foreach (var reference in values.OfType<ResourceReference>())
+            {
+                if (!string.IsNullOrWhiteSpace(reference.Reference))
+                    yield return reference.Reference;
+            }
+        }
     }
 }

--- a/Tests/Spark.Engine.Tests.Shared/Service/SnapshotPaginationServiceTests.cs
+++ b/Tests/Spark.Engine.Tests.Shared/Service/SnapshotPaginationServiceTests.cs
@@ -4,10 +4,13 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+using Hl7.Fhir.FhirPath;
 using Hl7.Fhir.Model;
+using Hl7.Fhir.Specification;
 using Moq;
 using Spark.Engine.Core;
 using Spark.Engine.Interfaces;
+using Spark.Engine.Search;
 using Spark.Engine.Service;
 using Spark.Engine.Service.FhirServiceExtensions;
 using Spark.Engine.Store.Interfaces;
@@ -25,6 +28,12 @@ public class SnapshotPaginationServiceTests
 
     private static ISnapshotPagination CreateService(Snapshot snapshot, Entry[] entries = null)
     {
+        FhirModel fhirModel = new();
+        ElementNavFhirExtensions.PrepareFhirSymbolTableFunctions();
+        ResourceResolver resourceResolver = new(
+            fhirModel.SupportedResources,
+            new PocoStructureDefinitionSummaryProvider());
+
         var mockFhirIndex = new Mock<IFhirIndex>();
         var mockFhirStore = new Mock<IFhirStore>();
         var mockTransfer = new Mock<ITransfer>();
@@ -46,7 +55,8 @@ public class SnapshotPaginationServiceTests
             mockLocalhost.Object,
             calculator,
             snapshot,
-            new FhirModel());
+            fhirModel,
+            resourceResolver);
     }
 
     private static ISnapshotPagination CreateService(Snapshot snapshot, IFhirStore fhirStore)
@@ -60,6 +70,12 @@ public class SnapshotPaginationServiceTests
             .Setup(l => l.Absolute(It.IsAny<Uri>()))
             .Returns<Uri>(u => u.IsAbsoluteUri ? u : new Uri(new Uri(BaseUrl), u));
 
+        FhirModel fhirModel = new();
+        ElementNavFhirExtensions.PrepareFhirSymbolTableFunctions();
+        ResourceResolver resourceResolver = new(
+            fhirModel.SupportedResources,
+            new PocoStructureDefinitionSummaryProvider());
+
         return new SnapshotPaginationService(
             mockFhirIndex.Object,
             fhirStore,
@@ -67,7 +83,8 @@ public class SnapshotPaginationServiceTests
             mockLocalhost.Object,
             calculator,
             snapshot,
-            new FhirModel());
+            fhirModel,
+            resourceResolver);
     }
 
     [Fact]


### PR DESCRIPTION
In R5 SearchParameter's Xpath attributte is no longer populated, we therefore have to move away from using Xpaths in our code and use FHIRPath expressions instead. This requires us to have a dependency on ResourceResolver in IndexService, SnapshotPaginationProvider, and SnapshotPaginationService.