### PR TITLE
Engine: Only DeepCopy Resource when we know it is a DomainResource

### DIFF
--- a/Libraries/Spark.Engine/Service/FhirServiceExtensions/IndexService.cs
+++ b/Libraries/Spark.Engine/Service/FhirServiceExtensions/IndexService.cs
@@ -114,50 +114,50 @@ public class IndexService : IIndexService
     /// <summary>
     /// The id of a contained resource is only unique in the context of its 'parent'. 
     /// We want to allow the indexStore implementation to treat the IndexValue that comes from the contained resources just like a regular resource.
-    /// Therefore we make the id's globally unique, and adjust the references that point to it from its 'parent' accordingly.
+    /// Therefore, we make the id's globally unique, and adjust the references that point to it from its 'parent' accordingly.
     /// This method trusts on the knowledge that contained resources cannot contain any further nested resources. So one level deep only.
     /// </summary>
     /// <param name="resource"></param>
     /// <returns>A copy of resource, with id's of contained resources and references in resource adjusted to unique values.</returns>
     private Resource MakeContainedReferencesUnique(Resource resource)
     {
-        //We may change id's of contained resources, and don't want that to influence other code. So we make a copy for our own needs.
-        Resource result = (dynamic)resource.DeepCopy();
-        if (resource is DomainResource)
+        if (resource is not DomainResource source || source.Contained.Count == 0)
         {
-            DomainResource domainResource = (DomainResource)result;
-            if (domainResource.Contained != null && domainResource.Contained.Any())
-            {
-                var referenceMap = new Dictionary<string, string>();
-
-                // Create a unique id for each contained resource.
-                foreach (var containedResource in domainResource.Contained)
-                {
-                    string oldRef = string.IsNullOrWhiteSpace(containedResource.Id)
-                        ? $"#{Guid.NewGuid():D}"
-                        : $"#{containedResource.Id}";
-                    string newId = $"{Guid.NewGuid():D}";
-                    containedResource.Id = newId;
-                    string newRef = $"{containedResource.TypeName}/{newId}";
-                    referenceMap.Add(oldRef, newRef);
-                }
-
-                // Replace references to these contained resources with the newly created id's.
-                ResourceVisitor.VisitByType(
-                    domainResource,
-                    (element, _) => {
-                        ResourceReference currentRefence = (element as ResourceReference);
-                        if (string.IsNullOrEmpty(currentRefence?.Reference))
-                            return;
-
-                        referenceMap.TryGetValue(currentRefence.Reference, out string replacementId);
-                        if (replacementId != null)
-                            currentRefence.Reference = replacementId;
-                    },
-                    typeof(ResourceReference));
-            }
+            return resource;
         }
-        return result;
+
+        // NOTE: We may mutate id's of contained resources, and don't want that to influence other code therefore, we
+        //       make a copy.
+        DomainResource domainResourceCopy = source.DeepCopy();
+
+        Dictionary<string, string> referenceMap = new();
+        // Create a unique id for each contained resource.
+        foreach (Resource containedResource in domainResourceCopy.Contained)
+        {
+            string oldRef = string.IsNullOrWhiteSpace(containedResource.Id)
+                ? $"#{Guid.NewGuid():D}"
+                : $"#{containedResource.Id}";
+            string newId = $"{Guid.NewGuid():D}";
+            containedResource.Id = newId;
+            string newRef = $"{containedResource.TypeName}/{newId}";
+            referenceMap.Add(oldRef, newRef);
+        }
+
+        // Replace references to these contained resources with the newly created id's.
+        ResourceVisitor.VisitByType(
+            domainResourceCopy,
+            (element, _) => {
+                ResourceReference currentRefence = (element as ResourceReference);
+                if (string.IsNullOrEmpty(currentRefence?.Reference))
+                    return;
+
+                referenceMap.TryGetValue(currentRefence.Reference, out string replacementId);
+                if (replacementId != null)
+                    currentRefence.Reference = replacementId;
+            },
+            typeof(ResourceReference));
+
+        return domainResourceCopy;
     }
 
     private void AddContainedResources(DomainResource resource, IndexValue parent)

--- a/Tests/Spark.Engine.Tests.Shared/Service/IndexServiceTests2.cs
+++ b/Tests/Spark.Engine.Tests.Shared/Service/IndexServiceTests2.cs
@@ -8,9 +8,14 @@ using Hl7.Fhir.Model;
 using Hl7.Fhir.Specification;
 using Moq;
 using Spark.Engine.Core;
+using Spark.Engine.Model;
 using Spark.Engine.Search;
+using Spark.Engine.Search.Model;
+using Spark.Engine.Search.Types;
 using Spark.Engine.Service.FhirServiceExtensions;
 using Spark.Engine.Store.Interfaces;
+using System;
+using System.Reflection;
 using Xunit;
 using Task = System.Threading.Tasks.Task;
 
@@ -19,6 +24,82 @@ namespace Spark.Engine.Tests.Service;
 // FIXME: Migrate the old tests in IndexServiceTests to XUnit and Consolidate those tests with these tests.
 public class IndexServiceTests2
 {
+    [Fact]
+    public async Task IndexResourceWithContainedReferenceUsesGeneratedIdInParentAndContainedIndexValues()
+    {
+        FhirModel fhirModel = new();
+        Mock<IIndexStore> indexStoreMock = new();
+        ElementIndexer elementIndexer = new(fhirModel);
+        ResourceResolver resourceResolver = new(fhirModel.SupportedResources, new PocoStructureDefinitionSummaryProvider());
+        IndexService indexService = new(fhirModel, indexStoreMock.Object, elementIndexer, resourceResolver);
+
+        Organization containedOrganization = new() { Id = "contained" };
+        Organization organization = new()
+        {
+            Id = "parent",
+            PartOf = new ResourceReference("#contained")
+        };
+        organization.Contained.Add(containedOrganization);
+
+        IndexValue indexValue = await indexService.IndexResourceAsync(
+            organization,
+            Key.Create("Organization", "parent"));
+
+        IndexValue containedIndex = Assert.Single(
+            indexValue.IndexValues(), value => value.Name == "contained");
+        IndexValue containedJustId = Assert.Single(
+            containedIndex.IndexValues(), value => value.Name == IndexFieldNames.JUSTID);
+        string indexedContainedId = Assert.IsType<StringValue>(
+            Assert.Single(containedJustId.Values)).Value;
+
+        IndexValue partOfIndex = Assert.Single(
+            indexValue.IndexValues(), value => value.Name == "partof");
+        string indexedPartOf = Assert.IsType<StringValue>(
+            Assert.Single(partOfIndex.Values)).Value;
+
+        Assert.NotEqual("contained", indexedContainedId);
+        Assert.True(Guid.TryParse(indexedContainedId, out _));
+        Assert.Equal($"Organization/{indexedContainedId}", indexedPartOf);
+        Assert.Equal("contained", containedOrganization.Id);
+        Assert.Equal("#contained", organization.PartOf.Reference);
+    }
+
+    [Fact]
+    public void MakeContainedReferencesUniqueCopiesAndRewritesOnlyTheIndexedResource()
+    {
+        FhirModel fhirModel = new();
+        Mock<IIndexStore> indexStoreMock = new();
+        ElementIndexer elementIndexer = new(fhirModel);
+        ResourceResolver resourceResolver = new(fhirModel.SupportedResources, new PocoStructureDefinitionSummaryProvider());
+        IndexService indexService = new(fhirModel, indexStoreMock.Object, elementIndexer, resourceResolver);
+
+        Organization containedOrganization = new() { Id = "contained" };
+        Organization organization = new()
+        {
+            Id = "parent",
+            PartOf = new ResourceReference("#contained")
+        };
+        organization.Contained.Add(containedOrganization);
+
+        MethodInfo method = typeof(IndexService).GetMethod(
+            "MakeContainedReferencesUnique",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+
+        Organization indexedOrganization = Assert.IsType<Organization>(
+            method.Invoke(indexService, new object[] { organization }));
+        Organization indexedContainedOrganization = Assert.Single(indexedOrganization.Contained) as Organization;
+
+        Assert.NotSame(organization, indexedOrganization);
+        Assert.NotSame(containedOrganization, indexedContainedOrganization);
+
+        Assert.Equal("contained", containedOrganization.Id);
+        Assert.Equal("#contained", organization.PartOf.Reference);
+
+        Assert.NotEqual("contained", indexedContainedOrganization.Id);
+        Assert.True(Guid.TryParse(indexedContainedOrganization.Id, out _));
+        Assert.Equal($"Organization/{indexedContainedOrganization.Id}", indexedOrganization.PartOf.Reference);
+    }
+
     [Fact]
     public async Task IndexResourceWithContainedResourcesLackingAnIdShouldNotCrash()
     {


### PR DESCRIPTION
This avoids making a DeepCopy of the Resource unless we have already determined it is a DomainResource.

The method is also refactored to avoid if-nesting.

Tests have been added to prove there are no behavioral change.