### PR TITLE
CI: Remove output direction in integration tests

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -51,8 +51,13 @@ jobs:
           cd Tests/IntegrationTests
           mkdir -p logs html_summaries json_results
           docker compose up -d spark
-          docker compose run --rm --no-deps plan_executor ./execute_all.sh 'http://spark:8080/fhir' '${{ matrix.fhir-version }}' 'html|json|stdout'
+          set +e
+          docker compose run --rm --no-deps plan_executor \
+            bundle exec rake "crucible:execute_all[http://spark:8080/fhir,${{ matrix.fhir-version }},html|json|stdout]" 2>&1 | tee logs/execute_all.log
+          suite_status=${PIPESTATUS[0]}
+          printf '%s\n' "$suite_status" > logs/suite-exit-status.log
           docker compose logs spark > logs/backend.log
+          exit "$suite_status"
       -
         name: Combine test results
         if: ${{ always() }}

--- a/Tests/IntegrationTests/docker-compose.yml
+++ b/Tests/IntegrationTests/docker-compose.yml
@@ -23,7 +23,7 @@
       - "17017:27017"
   plan_executor:
     container_name: plan_executor
-    image: incendi/plan_executor@sha256:f2c4c04815c1e78e68399964cdb100c3825ddb41d0f202981c1c45f81d7d06a3
+    image: incendi/plan_executor@sha256:3039e62d19f715ef8d4c80158dd6b916a23d9804f713276d070c0bcead664ecd
     depends_on:
       - spark
     volumes:


### PR DESCRIPTION
Output integration tests logs directly to stdout/stderr. Use tee to  additionally write to execute_all.log.