### PR TITLE
Engine: Add support for _source search parameter in FhirModel

### DIFF
--- a/Libraries/Spark.Engine.R5/Core/FhirModel.cs
+++ b/Libraries/Spark.Engine.R5/Core/FhirModel.cs
@@ -74,6 +74,14 @@ public class FhirModel : FhirModelBase
                 Type = SearchParamType.Token,
                 Expression = "Resource.meta.security",
                 Path = ["Resource.meta.security"]
+            },
+            new()
+            {
+                Resource = "Resource",
+                Name = "_source",
+                Type = SearchParamType.Uri,
+                Expression = "Resource.meta.source",
+                Path = ["Resource.meta.source"]
             }
         ];
     }

--- a/Libraries/Spark.Engine/Core/FhirModelBase.cs
+++ b/Libraries/Spark.Engine/Core/FhirModelBase.cs
@@ -197,6 +197,14 @@ public abstract class FhirModelBase : IFhirModel
                 Type = SearchParamType.Token,
                 Expression = "Resource.meta.security",
                 Path = ["Resource.meta.security"]
+            },
+            new()
+            {
+                Resource = "Resource",
+                Name = "_source",
+                Type = SearchParamType.Uri,
+                Expression = "Resource.meta.source",
+                Path = ["Resource.meta.source"]
             }
         ];
     }

--- a/Tests/Spark.Engine.Tests.Shared/Core/FhirModelTests.cs
+++ b/Tests/Spark.Engine.Tests.Shared/Core/FhirModelTests.cs
@@ -30,15 +30,16 @@ public class FhirModelTests
     public void FindSearchParameters_UsesGeneratedGenericParameterDefinitions()
     {
         var genericParameters = _model.FindSearchParameters("Patient")
-            .Where(parameter => new[] { "_id", "_lastUpdated", "_tag", "_profile", "_security" }.Contains(parameter.Name))
+            .Where(parameter => new[] { "_id", "_lastUpdated", "_tag", "_profile", "_security", "_source" }.Contains(parameter.Name))
             .ToDictionary(parameter => parameter.Name, parameter => parameter.Type);
 
-        Assert.Equal(5, genericParameters.Count);
+        Assert.Equal(6, genericParameters.Count);
         Assert.Equal(SearchParamType.Token, genericParameters["_id"]);
         Assert.Equal(SearchParamType.Date, genericParameters["_lastUpdated"]);
         Assert.Equal(SearchParamType.Token, genericParameters["_tag"]);
         Assert.Equal(SearchParamType.Uri, genericParameters["_profile"]);
         Assert.Equal(SearchParamType.Token, genericParameters["_security"]);
+        Assert.Equal(SearchParamType.Uri, genericParameters["_source"]);
     }
 #endif
 
@@ -47,15 +48,16 @@ public class FhirModelTests
     public void FindSearchParameters_UsesGeneratedR5GenericParameterDefinitions()
     {
         var genericParameters = _model.FindSearchParameters("Patient")
-            .Where(parameter => new[] { "_id", "_lastUpdated", "_tag", "_profile", "_security" }.Contains(parameter.Name))
+            .Where(parameter => new[] { "_id", "_lastUpdated", "_tag", "_profile", "_security", "_source" }.Contains(parameter.Name))
             .ToDictionary(parameter => parameter.Name, parameter => parameter.Type);
 
-        Assert.Equal(5, genericParameters.Count);
+        Assert.Equal(6, genericParameters.Count);
         Assert.Equal(SearchParamType.Token, genericParameters["_id"]);
         Assert.Equal(SearchParamType.Date, genericParameters["_lastUpdated"]);
         Assert.Equal(SearchParamType.Token, genericParameters["_tag"]);
         Assert.Equal(SearchParamType.Reference, genericParameters["_profile"]);
         Assert.Equal(SearchParamType.Token, genericParameters["_security"]);
+        Assert.Equal(SearchParamType.Uri, genericParameters["_source"]);
     }
 #endif
 }


### PR DESCRIPTION
This change fixes #1338 

Add generic search parameter definition of '_source'.
Tests have been modified to include added parameter.