### PR TITLE
Engine+Web: Log errors from IndexRebuildService instead + Remove logging from HubContextProgressNotifier

### DIFF
--- a/Applications/Spark.Web.Shared/Hubs/HubContextProgressNotifier.cs
+++ b/Applications/Spark.Web.Shared/Hubs/HubContextProgressNotifier.cs
@@ -5,8 +5,8 @@
  */
 
 using Microsoft.AspNetCore.SignalR;
-using Microsoft.Extensions.Logging;
 using Spark.Engine.Service.FhirServiceExtensions;
+using System;
 using System.Threading.Tasks;
 
 namespace Spark.Web.Hubs;
@@ -19,27 +19,21 @@ namespace Spark.Web.Hubs;
 internal class HubContextProgressNotifier : IIndexBuildProgressReporter
 {
     private readonly IHubContext<MaintenanceHub> _hubContext;
-    private readonly ILogger<MaintenanceHub> _logger;
 
     private int _progress;
 
-    public HubContextProgressNotifier(
-        IHubContext<MaintenanceHub> hubContext,
-        ILogger<MaintenanceHub> logger)
+    public HubContextProgressNotifier(IHubContext<MaintenanceHub> hubContext)
     {
-        _hubContext = hubContext;
-        _logger = logger;
+        _hubContext = hubContext ?? throw new ArgumentNullException(nameof(hubContext));
     }
 
     public Task ReportProgressAsync(int progress, string message)
     {
-        _logger.LogInformation("[{Progress}%] {Message}", progress, message);
         return SendProgressUpdate(progress, message);
     }
 
     public Task ReportErrorAsync(string message)
     {
-        _logger.LogError("[{Progress}%] {Message}", _progress, message);
         return SendProgressUpdate(_progress, message);
     }
 

--- a/Applications/Spark.Web.Shared/Hubs/MaintenanceHub.cs
+++ b/Applications/Spark.Web.Shared/Hubs/MaintenanceHub.cs
@@ -89,7 +89,7 @@ public class MaintenanceHub : Hub<IMaintenanceHub>
         try
         {
             await _hubContext.Clients.All.SendAsync("UpdateProgress", "Rebuilding index...");
-            await _indexRebuildService.RebuildIndexAsync(new HubContextProgressNotifier(_hubContext, _logger));
+            await _indexRebuildService.RebuildIndexAsync(new HubContextProgressNotifier(_hubContext));
             await _hubContext.Clients.All.SendAsync("UpdateProgress", "Index rebuilt!");
         }
         catch (Exception e)

--- a/Libraries/Spark.Engine/Service/FhirServiceExtensions/IndexRebuildService.cs
+++ b/Libraries/Spark.Engine/Service/FhirServiceExtensions/IndexRebuildService.cs
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+using Microsoft.Extensions.Logging;
 using Spark.Engine.Core;
 using Spark.Engine.Maintenance;
 using Spark.Engine.Store.Interfaces;
@@ -18,7 +19,23 @@ public class IndexRebuildService : IIndexRebuildService
     private readonly IIndexService _indexService;
     private readonly IFhirStorePagedReader _entryReader;
     private readonly SparkSettings _sparkSettings;
+    private readonly ILogger<IndexRebuildService> _logger;
 
+    public IndexRebuildService(
+        IIndexStore indexStore,
+        IIndexService indexService,
+        IFhirStorePagedReader entryReader,
+        SparkSettings sparkSettings,
+        ILogger<IndexRebuildService> logger)
+    {
+        _indexStore = indexStore ?? throw new ArgumentNullException(nameof(indexStore));
+        _indexService = indexService ?? throw new ArgumentNullException(nameof(indexService));
+        _entryReader = entryReader ?? throw new ArgumentNullException(nameof(entryReader));
+        _sparkSettings = sparkSettings ?? throw new ArgumentNullException(nameof(sparkSettings));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    [Obsolete("Use ctor with signature 'IndexRebuildService(IIndexStore, IIndexService, IFhirStorePagedReader, SparkSettings, ILogger<IIndexRebuildService>)' instead.")]
     public IndexRebuildService(
         IIndexStore indexStore,
         IIndexService indexService,
@@ -64,9 +81,9 @@ public class IndexRebuildService : IIndexRebuildService
                     {
                         await _indexService.ProcessAsync(entry).ConfigureAwait(false);
                     }
-                    catch (Exception)
+                    catch (Exception exception)
                     {
-                        // TODO: log exception!
+                        _logger.LogError(exception, "Failed to reindex entry {EntryKey}", entry.Key);
                         await progress.ErrorAsync($"Failed to reindex entry {entry.Key}");
                     }
                 }


### PR DESCRIPTION
#### Engine: Log errors from IndexRebuildService 

These errors was previously logged in HubContextProgressNotifier, but at that level we were missing exception details, therefore we move it here instead.

#### Web: Remove logging from HubContextProgressNotifier

Logging at this abstraction level (too low) makes our logging approach convoluted.

This will also remove information logging which we do not reinstate at the moment. If someone later sees the need for logging this information we can re-add the informational logging statement.

The error logging is moved to IndexRebuildService