### PR TITLE
Engine+MongoDB: Necessary infrastructure to support database migrations better

### DIFF
--- a/Libraries/Spark.Engine/Store/DatabaseMigration.cs
+++ b/Libraries/Spark.Engine/Store/DatabaseMigration.cs
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2026, Incendi <info@incendi.no>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+namespace Spark.Engine.Store;
+
+public sealed record DatabaseMigration
+{
+    public required int Version { get; init; }
+
+    public required string Name { get; init; }
+}

--- a/Libraries/Spark.Engine/Store/DatabaseMigrationException.cs
+++ b/Libraries/Spark.Engine/Store/DatabaseMigrationException.cs
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026, Incendi <info@incendi.no>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+using System;
+
+namespace Spark.Engine.Store;
+
+public sealed class DatabaseMigrationException : Exception
+{
+    public DatabaseMigrationException(string message) : base(message)
+    {
+    }
+
+    public DatabaseMigrationException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/Libraries/Spark.Engine/Store/Interfaces/IDatabaseMigrationService.cs
+++ b/Libraries/Spark.Engine/Store/Interfaces/IDatabaseMigrationService.cs
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026, Incendi <info@incendi.no>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Spark.Engine.Store.Interfaces;
+
+public interface IDatabaseMigrationService
+{
+    int CurrentVersion { get; }
+
+    bool IsApplied(int version);
+
+    Task RefreshAsync(CancellationToken cancellationToken = default);
+
+    Task RecordCompletedAsync(
+        DatabaseMigration migration,
+        CancellationToken cancellationToken = default);
+}

--- a/Libraries/Spark.Store.MongoDB/Constants.cs
+++ b/Libraries/Spark.Store.MongoDB/Constants.cs
@@ -13,6 +13,7 @@ public static class Collection
     public const string COUNTERS = "counters";
     public const string SNAPSHOT = "snapshots";
     public const string INDEX_QUEUE = "indexqueue";
+    public const string SchemaMigrations = "schema_migrations";
 }
 
 public static class IndexQueueField

--- a/Libraries/Spark.Store.MongoDB/DatabaseMigrationRefreshService.cs
+++ b/Libraries/Spark.Store.MongoDB/DatabaseMigrationRefreshService.cs
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026, Incendi <info@incendi.no>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Spark.Engine.Store.Interfaces;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Spark.Store.MongoDB;
+
+internal sealed class DatabaseMigrationRefreshService : BackgroundService
+{
+    private static readonly TimeSpan DefaultRefreshInterval = TimeSpan.FromSeconds(30);
+
+    private readonly IDatabaseMigrationService _migrationService;
+    private readonly ILogger<DatabaseMigrationRefreshService> _logger;
+    private readonly TimeSpan _refreshInterval;
+
+    public DatabaseMigrationRefreshService(
+        IDatabaseMigrationService migrationService,
+        ILogger<DatabaseMigrationRefreshService> logger)
+        : this(migrationService, logger, DefaultRefreshInterval)
+    {
+    }
+
+    internal DatabaseMigrationRefreshService(
+        IDatabaseMigrationService migrationService,
+        ILogger<DatabaseMigrationRefreshService> logger,
+        TimeSpan refreshInterval)
+    {
+        ArgumentNullException.ThrowIfNull(migrationService);
+        ArgumentNullException.ThrowIfNull(logger);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(refreshInterval, TimeSpan.Zero);
+
+        _migrationService = migrationService;
+        _logger = logger;
+        _refreshInterval = refreshInterval;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await RefreshAsync(stoppingToken).ConfigureAwait(false);
+
+        using PeriodicTimer timer = new(_refreshInterval);
+        try
+        {
+            while (await timer.WaitForNextTickAsync(stoppingToken).ConfigureAwait(false))
+            {
+                await RefreshAsync(stoppingToken).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+        }
+    }
+
+    private async Task RefreshAsync(CancellationToken stoppingToken)
+    {
+        try
+        {
+            await _migrationService.RefreshAsync(stoppingToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            _logger.LogError(
+                exception,
+                "Failed to refresh database migration state. Retaining version {CurrentVersion}.",
+                _migrationService.CurrentVersion
+            );
+        }
+    }
+}

--- a/Libraries/Spark.Store.MongoDB/DatabaseMigrationService.cs
+++ b/Libraries/Spark.Store.MongoDB/DatabaseMigrationService.cs
@@ -1,0 +1,230 @@
+/*
+ * Copyright (c) 2026, Incendi <info@incendi.no>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+using MongoDB.Bson;
+using MongoDB.Driver;
+using Spark.Engine.Store;
+using Spark.Engine.Store.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Spark.Store.MongoDB;
+
+public sealed class DatabaseMigrationService : IDatabaseMigrationService
+{
+    private const string NameField = "name";
+    private const string CompletedAtField = "completedAt";
+
+    private readonly IMongoCollection<BsonDocument> _collection;
+    private readonly SemaphoreSlim _stateLock = new(1, 1);
+    private IReadOnlyDictionary<int, string> _appliedMigrations = new Dictionary<int, string>();
+    private int _currentVersion;
+
+    public DatabaseMigrationService(string connectionString)
+        : this(MongoDatabaseFactory.GetMongoDatabase(connectionString))
+    {
+    }
+
+    internal DatabaseMigrationService(IMongoDatabase database)
+    {
+        ArgumentNullException.ThrowIfNull(database);
+        _collection = database.GetCollection<BsonDocument>(Collection.SchemaMigrations);
+    }
+
+    public int CurrentVersion => Volatile.Read(ref _currentVersion);
+
+    public bool IsApplied(int version) => version > 0 && version <= CurrentVersion;
+
+    public async Task RefreshAsync(CancellationToken cancellationToken = default)
+    {
+        await _stateLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            List<BsonDocument> documents = await _collection
+                .Find(FilterDefinition<BsonDocument>.Empty)
+                .Sort(Builders<BsonDocument>.Sort.Ascending(Field.PRIMARYKEY))
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            var appliedMigrations = new Dictionary<int, string>(documents.Count);
+            var expectedVersion = 1;
+
+            foreach (BsonDocument document in documents)
+            {
+                (int version, string name) = ReadMigration(document);
+                if (version != expectedVersion)
+                {
+                    throw new DatabaseMigrationException(
+                        $"Expected database migration version {expectedVersion}, but found version {version}."
+                    );
+                }
+
+                appliedMigrations.Add(version, name);
+                expectedVersion++;
+            }
+
+            PublishState(appliedMigrations, expectedVersion - 1);
+        }
+        finally
+        {
+            _stateLock.Release();
+        }
+    }
+
+    public async Task RecordCompletedAsync(
+        DatabaseMigration migration,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentNullException.ThrowIfNull(migration);
+
+        ValidateMigration(migration);
+
+        await _stateLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (migration.Version <= _currentVersion)
+            {
+                if (_appliedMigrations.TryGetValue(migration.Version, out string cachedName) &&
+                    string.Equals(cachedName, migration.Name, StringComparison.Ordinal))
+                {
+                    return;
+                }
+
+                throw new DatabaseMigrationException(
+                    $"Database migration version {migration.Version} is already recorded with a different name."
+                );
+            }
+
+            int expectedVersion = _currentVersion + 1;
+            if (migration.Version != expectedVersion)
+            {
+                throw new DatabaseMigrationException(
+                    $"Expected database migration version {expectedVersion}, but received version {migration.Version}."
+                );
+            }
+
+            BsonDocument persistedMigration;
+            try
+            {
+                persistedMigration = await UpsertMigrationAsync(migration, cancellationToken).ConfigureAwait(false);
+            }
+            catch (MongoWriteException exception) when (exception.WriteError?.Code == 11000)
+            {
+                throw CreateConflictException(migration, exception);
+            }
+            catch (MongoCommandException exception) when (exception.Code == 11000)
+            {
+                throw CreateConflictException(migration, exception);
+            }
+
+            (_, string persistedName) = ReadMigration(persistedMigration);
+            if (!string.Equals(persistedName, migration.Name, StringComparison.Ordinal))
+            {
+                throw new DatabaseMigrationException(
+                    $"Database migration version {migration.Version} is already recorded as '{persistedName}', " +
+                    $"not '{migration.Name}'."
+                );
+            }
+
+            var appliedMigrations = new Dictionary<int, string>(_appliedMigrations)
+            {
+                [migration.Version] = migration.Name
+            };
+            PublishState(appliedMigrations, migration.Version);
+        }
+        finally
+        {
+            _stateLock.Release();
+        }
+    }
+
+    private async Task<BsonDocument> UpsertMigrationAsync(
+        DatabaseMigration migration,
+        CancellationToken cancellationToken
+    )
+    {
+        // If version 1 already exists with a different name the attempted upsert will collide, RecordCompletedAsync
+        // will then convert that duplicate-key error into a DatabaseMigrationException.
+        FilterDefinition<BsonDocument> filter = Builders<BsonDocument>.Filter
+            .And(
+                Builders<BsonDocument>.Filter.Eq(Field.PRIMARYKEY, migration.Version),
+                Builders<BsonDocument>.Filter.Eq(NameField, migration.Name)
+            );
+
+        PipelineDefinition<BsonDocument, BsonDocument> pipeline = new[]
+        {
+            new BsonDocument(
+                "$set",
+                new BsonDocument(
+                    CompletedAtField,
+                    new BsonDocument("$ifNull", new BsonArray { $"${CompletedAtField}", "$$NOW" })
+                )
+            )
+        };
+
+        FindOneAndUpdateOptions<BsonDocument> options = new()
+        {
+            IsUpsert = true, ReturnDocument = ReturnDocument.After
+        };
+
+        return await _collection
+            .FindOneAndUpdateAsync(filter, pipeline, options, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private static (int Version, string Name) ReadMigration(BsonDocument document)
+    {
+        if (!document.TryGetValue(Field.PRIMARYKEY, out BsonValue versionValue) || !versionValue.IsInt32
+            || versionValue.AsInt32 <= 0)
+        {
+            throw new DatabaseMigrationException("A persisted database migration has an invalid version.");
+        }
+
+        if (!document.TryGetValue(NameField, out BsonValue nameValue) || !nameValue.IsString
+            || string.IsNullOrWhiteSpace(nameValue.AsString))
+        {
+            throw new DatabaseMigrationException(
+                $"Persisted database migration version {versionValue.AsInt32} has an invalid name."
+            );
+        }
+
+        if (!document.TryGetValue(CompletedAtField, out BsonValue completedAtValue) || !completedAtValue.IsBsonDateTime)
+        {
+            throw new DatabaseMigrationException(
+                $"Persisted database migration version {versionValue.AsInt32} has an invalid completion timestamp."
+            );
+        }
+
+        return (versionValue.AsInt32, nameValue.AsString);
+    }
+
+    private static void ValidateMigration(DatabaseMigration migration)
+    {
+        if (migration.Version <= 0)
+            throw new DatabaseMigrationException("A database migration version must be greater than zero.");
+        if (string.IsNullOrWhiteSpace(migration.Name))
+            throw new DatabaseMigrationException("A database migration name must not be empty.");
+    }
+
+    private void PublishState(IReadOnlyDictionary<int, string> appliedMigrations, int currentVersion)
+    {
+        _appliedMigrations = appliedMigrations;
+        Volatile.Write(ref _currentVersion, currentVersion);
+    }
+
+    private static DatabaseMigrationException CreateConflictException(
+        DatabaseMigration migration,
+        Exception innerException)
+    {
+        return new DatabaseMigrationException(
+            $"Database migration version {migration.Version} is already recorded with a different name.",
+            innerException
+        );
+    }
+}

--- a/Tests/Spark.Store.MongoDB.Tests/DatabaseMigrationRefreshServiceTests.cs
+++ b/Tests/Spark.Store.MongoDB.Tests/DatabaseMigrationRefreshServiceTests.cs
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2026, Incendi <info@incendi.no>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+using Microsoft.Extensions.Logging;
+using Spark.Engine.Store;
+using Spark.Engine.Store.Interfaces;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Spark.Store.MongoDB.Tests;
+
+public partial class DatabaseMigrationRefreshServiceTests
+{
+    [Fact]
+    public async Task StartAsync_RefreshesImmediately()
+    {
+        TaskCompletionSource refreshed = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        StubMigrationService migrationService = new((_, _) =>
+        {
+            refreshed.TrySetResult();
+            return Task.CompletedTask;
+        });
+        DatabaseMigrationRefreshService worker = CreateWorker(migrationService, TimeSpan.FromHours(1));
+
+        await worker.StartAsync(TestContext.Current.CancellationToken);
+        try
+        {
+            await refreshed.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+            Assert.Equal(1, migrationService.RefreshCount);
+        }
+        finally
+        {
+            await worker.StopAsync(CancellationToken.None);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_RefreshesPeriodically()
+    {
+        TaskCompletionSource refreshedTwice = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        StubMigrationService migrationService = new((count, _) =>
+        {
+            if (count >= 2)
+                refreshedTwice.TrySetResult();
+
+            return Task.CompletedTask;
+        });
+        DatabaseMigrationRefreshService worker = CreateWorker(migrationService, TimeSpan.FromMilliseconds(10));
+
+        await worker.StartAsync(TestContext.Current.CancellationToken);
+        try
+        {
+            await refreshedTwice.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+            Assert.True(migrationService.RefreshCount >= 2);
+        }
+        finally
+        {
+            await worker.StopAsync(CancellationToken.None);
+        }
+    }
+
+    [Fact]
+    public async Task StopAsync_CancelsActiveRefresh()
+    {
+        TaskCompletionSource refreshStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource refreshCancelled = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        StubMigrationService migrationService = new(async (_, cancellationToken) =>
+        {
+            refreshStarted.TrySetResult();
+            try
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                refreshCancelled.TrySetResult();
+                throw;
+            }
+        });
+        DatabaseMigrationRefreshService worker = CreateWorker(migrationService, TimeSpan.FromHours(1));
+
+        await worker.StartAsync(TestContext.Current.CancellationToken);
+        await refreshStarted.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        await worker.StopAsync(TestContext.Current.CancellationToken);
+
+        await refreshCancelled.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenRefreshFails_LogsAndContinuesRefreshing()
+    {
+        TaskCompletionSource secondRefresh = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        StubMigrationService migrationService = new((count, _) =>
+            {
+                if (count == 1)
+                    throw new InvalidOperationException("Refresh failed.");
+
+                secondRefresh.TrySetResult();
+                return Task.CompletedTask;
+            }
+        );
+        migrationService.CurrentVersion = 2;
+        TestLogger<DatabaseMigrationRefreshService> logger = new();
+        DatabaseMigrationRefreshService worker = new(
+            migrationService,
+            logger,
+            TimeSpan.FromMilliseconds(10));
+
+        await worker.StartAsync(TestContext.Current.CancellationToken);
+        try
+        {
+            await secondRefresh.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+            Assert.Equal(2, migrationService.CurrentVersion);
+            Assert.Contains(
+                logger.Entries,
+                entry =>
+                    entry.Level == LogLevel.Error &&
+                    entry.Exception is InvalidOperationException &&
+                    entry.Message.Contains("Retaining version 2", StringComparison.Ordinal)
+            );
+        }
+        finally
+        {
+            await worker.StopAsync(CancellationToken.None);
+        }
+    }
+
+    private static DatabaseMigrationRefreshService CreateWorker(
+        IDatabaseMigrationService migrationService,
+        TimeSpan refreshInterval)
+    {
+        return new DatabaseMigrationRefreshService(
+            migrationService,
+            new TestLogger<DatabaseMigrationRefreshService>(),
+            refreshInterval
+        );
+    }
+
+    private sealed class StubMigrationService : IDatabaseMigrationService
+    {
+        private readonly Func<int, CancellationToken, Task> _refresh;
+        private int _refreshCount;
+
+        public StubMigrationService(Func<int, CancellationToken, Task> refresh)
+        {
+            _refresh = refresh;
+        }
+
+        public int CurrentVersion { get; set; }
+
+        public int RefreshCount => Volatile.Read(ref _refreshCount);
+
+        public bool IsApplied(int version) => version > 0 && version <= CurrentVersion;
+
+        public Task RefreshAsync(CancellationToken cancellationToken = default)
+        {
+            int count = Interlocked.Increment(ref _refreshCount);
+            return _refresh(count, cancellationToken);
+        }
+
+        public Task RecordCompletedAsync(
+            DatabaseMigration migration,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/Tests/Spark.Store.MongoDB.Tests/DatabaseMigrationServiceTests.cs
+++ b/Tests/Spark.Store.MongoDB.Tests/DatabaseMigrationServiceTests.cs
@@ -1,0 +1,248 @@
+/*
+ * Copyright (c) 2026, Incendi <info@incendi.no>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+using MongoDB.Bson;
+using MongoDB.Driver;
+using Spark.Engine.Store;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Testcontainers.MongoDb;
+using Xunit;
+
+namespace Spark.Store.MongoDB.Tests;
+
+[Trait("Category", "Integration")]
+public class DatabaseMigrationServiceTests : IAsyncLifetime
+{
+    private MongoDbContainer _container;
+
+    public async ValueTask InitializeAsync() => _container = await StartMongoOrSkipAsync();
+
+    public ValueTask DisposeAsync() => _container.DisposeAsync();
+
+    [Fact]
+    public async Task RefreshAsync_WithNoPersistedMigrations_UsesVersionZero()
+    {
+        var service = CreateService();
+
+        await service.RefreshAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(0, service.CurrentVersion);
+        Assert.False(service.IsApplied(1));
+    }
+
+    [Fact]
+    public async Task RecordCompletedAsync_PersistsMigrationAndRefreshesAnotherService()
+    {
+        string connectionString = CreateConnectionString();
+        var service = new DatabaseMigrationService(connectionString);
+        DateTime startedAt = DateTime.UtcNow.AddSeconds(-1);
+
+        await service.RecordCompletedAsync(Migration(1, "first"), TestContext.Current.CancellationToken);
+
+        BsonDocument document = await GetCollection(connectionString)
+            .Find(Builders<BsonDocument>.Filter.Empty)
+            .SingleAsync(TestContext.Current.CancellationToken);
+        var refreshedService = new DatabaseMigrationService(connectionString);
+        await refreshedService.RefreshAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(1, document[Field.PRIMARYKEY].AsInt32);
+        Assert.Equal("first", document["name"].AsString);
+        Assert.True(document["completedAt"].IsBsonDateTime);
+        Assert.InRange(document["completedAt"].ToUniversalTime(), startedAt, DateTime.UtcNow.AddSeconds(1));
+        Assert.Equal(1, refreshedService.CurrentVersion);
+        Assert.True(refreshedService.IsApplied(1));
+    }
+
+    [Fact]
+    public async Task RecordCompletedAsync_RepeatingSameMigration_IsIdempotent()
+    {
+        string connectionString = CreateConnectionString();
+        var firstService = new DatabaseMigrationService(connectionString);
+        await firstService.RecordCompletedAsync(Migration(1, "first"), TestContext.Current.CancellationToken);
+        BsonDateTime completedAt = (await GetCollection(connectionString)
+            .Find(Builders<BsonDocument>.Filter.Empty)
+            .SingleAsync(TestContext.Current.CancellationToken))["completedAt"].AsBsonDateTime;
+
+        var secondService = new DatabaseMigrationService(connectionString);
+        await secondService.RecordCompletedAsync(Migration(1, "first"), TestContext.Current.CancellationToken);
+
+        BsonDocument persisted = await GetCollection(connectionString)
+            .Find(Builders<BsonDocument>.Filter.Empty)
+            .SingleAsync(TestContext.Current.CancellationToken);
+        Assert.Equal(completedAt, persisted["completedAt"].AsBsonDateTime);
+        Assert.Equal(1, secondService.CurrentVersion);
+        Assert.Equal(1, await GetCollection(connectionString)
+            .CountDocumentsAsync(Builders<BsonDocument>.Filter.Empty,
+                cancellationToken: TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task RecordCompletedAsync_WithConflictingName_RejectsMigration()
+    {
+        string connectionString = CreateConnectionString();
+        var firstService = new DatabaseMigrationService(connectionString);
+        await firstService.RecordCompletedAsync(Migration(1, "first"), TestContext.Current.CancellationToken);
+        var secondService = new DatabaseMigrationService(connectionString);
+
+        await Assert.ThrowsAsync<DatabaseMigrationException>(() =>
+            secondService.RecordCompletedAsync(Migration(1, "conflict"), TestContext.Current.CancellationToken));
+
+        Assert.Equal(0, secondService.CurrentVersion);
+    }
+
+    [Fact]
+    public async Task RecordCompletedAsync_WithSkippedVersion_RejectsMigration()
+    {
+        string connectionString = CreateConnectionString();
+        var service = new DatabaseMigrationService(connectionString);
+
+        await Assert.ThrowsAsync<DatabaseMigrationException>(() =>
+            service.RecordCompletedAsync(Migration(2, "second"), TestContext.Current.CancellationToken));
+
+        Assert.Equal(0, service.CurrentVersion);
+        Assert.Equal(0, await GetCollection(connectionString)
+            .CountDocumentsAsync(Builders<BsonDocument>.Filter.Empty,
+                cancellationToken: TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task RefreshAsync_WithVersionGap_RejectsStateAndKeepsPreviousCache()
+    {
+        string connectionString = CreateConnectionString();
+        var service = new DatabaseMigrationService(connectionString);
+        await service.RecordCompletedAsync(Migration(1, "first"), TestContext.Current.CancellationToken);
+        await GetCollection(connectionString).InsertOneAsync(
+            PersistedMigration(3, "third"),
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        await Assert.ThrowsAsync<DatabaseMigrationException>(() =>
+            service.RefreshAsync(TestContext.Current.CancellationToken));
+
+        Assert.Equal(1, service.CurrentVersion);
+        Assert.True(service.IsApplied(1));
+        Assert.False(service.IsApplied(2));
+    }
+
+    [Fact]
+    public async Task RefreshAsync_WithInvalidPersistedMigration_RejectsState()
+    {
+        string connectionString = CreateConnectionString();
+        await GetCollection(connectionString).InsertOneAsync(
+            new BsonDocument
+            {
+                [Field.PRIMARYKEY] = 1,
+                ["name"] = "first"
+            },
+            cancellationToken: TestContext.Current.CancellationToken);
+        var service = new DatabaseMigrationService(connectionString);
+
+        await Assert.ThrowsAsync<DatabaseMigrationException>(() =>
+            service.RefreshAsync(TestContext.Current.CancellationToken));
+
+        Assert.Equal(0, service.CurrentVersion);
+    }
+
+    [Fact]
+    public async Task RecordCompletedAsync_WhenPersistenceFails_DoesNotAdvanceCache()
+    {
+        await using MongoDbContainer container = await StartMongoOrSkipAsync();
+        string connectionString = BuildConnectionString(container.GetConnectionString(), "migration-failure", 1);
+        var service = new DatabaseMigrationService(connectionString);
+        await service.RefreshAsync(TestContext.Current.CancellationToken);
+        await container.StopAsync(TestContext.Current.CancellationToken);
+
+        await Assert.ThrowsAsync<TimeoutException>(() =>
+            service.RecordCompletedAsync(Migration(1, "first"), TestContext.Current.CancellationToken));
+
+        Assert.Equal(0, service.CurrentVersion);
+        Assert.False(service.IsApplied(1));
+    }
+
+    [Fact]
+    public async Task RecordCompletedAsync_ConcurrentlyRecordingSameMigration_IsIdempotent()
+    {
+        string connectionString = CreateConnectionString();
+        DatabaseMigrationService[] services = Enumerable.Range(0, 8)
+            .Select(_ => new DatabaseMigrationService(connectionString))
+            .ToArray();
+
+        await Task.WhenAll(services.Select(service =>
+            service.RecordCompletedAsync(Migration(1, "first"), TestContext.Current.CancellationToken)));
+
+        Assert.All(services, service => Assert.Equal(1, service.CurrentVersion));
+        Assert.Equal(1, await GetCollection(connectionString)
+            .CountDocumentsAsync(Builders<BsonDocument>.Filter.Empty,
+                cancellationToken: TestContext.Current.CancellationToken));
+    }
+
+    private DatabaseMigrationService CreateService() => new(CreateConnectionString());
+
+    private string CreateConnectionString() =>
+        BuildConnectionString(_container.GetConnectionString(), "migration");
+
+    private static DatabaseMigration Migration(int version, string name) => new()
+    {
+        Version = version,
+        Name = name
+    };
+
+    private static BsonDocument PersistedMigration(int version, string name) => new()
+    {
+        [Field.PRIMARYKEY] = version,
+        ["name"] = name,
+        ["completedAt"] = DateTime.UtcNow
+    };
+
+    private static IMongoCollection<BsonDocument> GetCollection(string connectionString) =>
+        MongoDatabaseFactory.GetMongoDatabase(connectionString)
+            .GetCollection<BsonDocument>(Collection.SchemaMigrations);
+
+    private static async Task<MongoDbContainer> StartMongoOrSkipAsync()
+    {
+        MongoDbContainer container = null;
+        try
+        {
+            container = new MongoDbBuilder("mongo:8.2.7").Build();
+            await container.StartAsync(TestContext.Current.CancellationToken);
+            return container;
+        }
+        catch (Exception exception)
+        {
+            if (container != null)
+            {
+                await container.DisposeAsync();
+            }
+
+            Assert.Skip($"Docker/Testcontainers not available: {exception.Message}");
+            return null;
+        }
+    }
+
+    private static string BuildConnectionString(
+        string rawConnectionString,
+        string databaseName,
+        int? serverSelectionTimeoutSeconds = null)
+    {
+        var builder = new MongoUrlBuilder(rawConnectionString)
+        {
+            DatabaseName = $"{databaseName}-{Guid.NewGuid():N}"
+        };
+        if (!string.IsNullOrEmpty(builder.Username) && string.IsNullOrEmpty(builder.AuthenticationSource))
+        {
+            builder.AuthenticationSource = "admin";
+        }
+
+        if (serverSelectionTimeoutSeconds.HasValue)
+        {
+            builder.ServerSelectionTimeout = TimeSpan.FromSeconds(serverSelectionTimeoutSeconds.Value);
+            builder.ConnectTimeout = TimeSpan.FromSeconds(serverSelectionTimeoutSeconds.Value);
+        }
+
+        return builder.ToMongoUrl().ToString();
+    }
+}

--- a/Tests/Spark.Store.MongoDB.Tests/TestLogger.cs
+++ b/Tests/Spark.Store.MongoDB.Tests/TestLogger.cs
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026, Incendi <info@incendi.no>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Concurrent;
+
+namespace Spark.Store.MongoDB.Tests;
+
+public sealed record LogEntry(LogLevel Level, Exception Exception, string Message);
+
+public sealed class TestLogger<T> : ILogger<T>
+{
+    public ConcurrentQueue<LogEntry> Entries { get; } = new();
+
+    public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(
+        LogLevel logLevel,
+        EventId eventId,
+        TState state,
+        Exception exception,
+        Func<TState, Exception, string> formatter)
+    {
+        Entries.Enqueue(new LogEntry(logLevel, exception, formatter(state, exception)));
+    }
+
+    private sealed class NullScope : IDisposable
+    {
+        public static NullScope Instance { get; } = new();
+
+        public void Dispose()
+        {
+        }
+    }
+}


### PR DESCRIPTION
This adds necessary infrastructure to support database migrations better.

Related to #1385 