### PR TITLE
MongoDB: Include plain query in TokenQuery only if migration is not run

### DIFF
--- a/Libraries/Spark.Store.MongoDB/DatabaseMigrationRefreshService.cs
+++ b/Libraries/Spark.Store.MongoDB/DatabaseMigrationRefreshService.cs
@@ -42,10 +42,14 @@ internal sealed class DatabaseMigrationRefreshService : BackgroundService
         _refreshInterval = refreshInterval;
     }
 
+    public override async Task StartAsync(CancellationToken cancellationToken)
+    {
+        await RefreshAsync(cancellationToken).ConfigureAwait(false);
+        await base.StartAsync(cancellationToken).ConfigureAwait(false);
+    }
+
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        await RefreshAsync(stoppingToken).ConfigureAwait(false);
-
         using PeriodicTimer timer = new(_refreshInterval);
         try
         {

--- a/Libraries/Spark.Store.MongoDB/DatabaseMigrationService.cs
+++ b/Libraries/Spark.Store.MongoDB/DatabaseMigrationService.cs
@@ -8,6 +8,7 @@ using MongoDB.Bson;
 using MongoDB.Driver;
 using Spark.Engine.Store;
 using Spark.Engine.Store.Interfaces;
+using Spark.Store.MongoDB.Search.Common;
 using System;
 using System.Collections.Generic;
 using System.Threading;
@@ -21,8 +22,11 @@ public sealed class DatabaseMigrationService : IDatabaseMigrationService
     private const string CompletedAtField = "completedAt";
 
     private readonly IMongoCollection<BsonDocument> _collection;
+    private readonly IMongoCollection<BsonDocument> _resources;
+    private readonly IMongoCollection<BsonDocument> _searchIndex;
     private readonly SemaphoreSlim _stateLock = new(1, 1);
     private IReadOnlyDictionary<int, string> _appliedMigrations = new Dictionary<int, string>();
+    private bool _freshDatabaseCheckCompleted;
     private int _currentVersion;
 
     public DatabaseMigrationService(string connectionString)
@@ -34,6 +38,8 @@ public sealed class DatabaseMigrationService : IDatabaseMigrationService
     {
         ArgumentNullException.ThrowIfNull(database);
         _collection = database.GetCollection<BsonDocument>(Collection.SchemaMigrations);
+        _resources = database.GetCollection<BsonDocument>(Collection.RESOURCE);
+        _searchIndex = database.GetCollection<BsonDocument>(MongoCollections.SEARCH_INDEX_COLLECTION);
     }
 
     public int CurrentVersion => Volatile.Read(ref _currentVersion);
@@ -50,6 +56,21 @@ public sealed class DatabaseMigrationService : IDatabaseMigrationService
                 .Sort(Builders<BsonDocument>.Sort.Ascending(Field.PRIMARYKEY))
                 .ToListAsync(cancellationToken)
                 .ConfigureAwait(false);
+
+            if (documents.Count == 0 && !_freshDatabaseCheckCompleted)
+            {
+                bool isFreshDatabase = await IsFreshDatabaseAsync(cancellationToken).ConfigureAwait(false);
+                if (isFreshDatabase)
+                {
+                    BsonDocument migration = await UpsertMigrationAsync(
+                            DatabaseMigrations.StructuredStringTokenIndex,
+                            cancellationToken)
+                        .ConfigureAwait(false);
+                    documents.Add(migration);
+                }
+
+                _freshDatabaseCheckCompleted = true;
+            }
 
             var appliedMigrations = new Dictionary<int, string>(documents.Count);
             var expectedVersion = 1;
@@ -74,6 +95,23 @@ public sealed class DatabaseMigrationService : IDatabaseMigrationService
         {
             _stateLock.Release();
         }
+    }
+
+    private async Task<bool> IsFreshDatabaseAsync(CancellationToken cancellationToken)
+    {
+        CountOptions options = new() { Limit = 1 };
+        long resourceCount = await _resources
+            .CountDocumentsAsync(FilterDefinition<BsonDocument>.Empty, options, cancellationToken)
+            .ConfigureAwait(false);
+        if (resourceCount != 0)
+        {
+            return false;
+        }
+
+        long searchIndexCount = await _searchIndex
+            .CountDocumentsAsync(FilterDefinition<BsonDocument>.Empty, options, cancellationToken)
+            .ConfigureAwait(false);
+        return searchIndexCount == 0;
     }
 
     public async Task RecordCompletedAsync(

--- a/Libraries/Spark.Store.MongoDB/Search/CriteriaMongoExtensions.cs
+++ b/Libraries/Spark.Store.MongoDB/Search/CriteriaMongoExtensions.cs
@@ -57,7 +57,10 @@ internal static class CriteriaMongoExtensions
         return param.SearchParameters?.FirstOrDefault(sp => sp.Resource == resourceType || sp.Resource == "Resource");
     }
 
-    internal static FilterDefinition<BsonDocument> ToFilter(this Criterium param, string resourceType)
+    internal static FilterDefinition<BsonDocument> ToFilter(
+        this Criterium param,
+        string resourceType,
+        bool includePlainStringTokenQuery = true)
     {
         //Maybe it's a generic parameter.
         if (FixedQueries.TryGetValue(param.ParamName, out Func<Criterium, FilterDefinition<BsonDocument>> query))
@@ -69,14 +72,24 @@ internal static class CriteriaMongoExtensions
         {
 
             // todo: DSTU2 - modifier not in SearchParameter
-            return CreateFilter(critSp, param.Operator, param.Modifier, param.Operand);
+            return CreateFilter(
+                critSp,
+                param.Operator,
+                param.Modifier,
+                param.Operand,
+                includePlainStringTokenQuery);
             //return null;
         }
 
         throw new UnknownSearchParameterException(string.Format("Resource {0} has no parameter with the name {1}.", resourceType, param.ParamName));
     }
 
-    private static FilterDefinition<BsonDocument> CreateFilter(SearchParameter parameter, Operator op, String modifier, Expression operand)
+    private static FilterDefinition<BsonDocument> CreateFilter(
+        SearchParameter parameter,
+        Operator op,
+        String modifier,
+        Expression operand,
+        bool includePlainStringTokenQuery)
     {
         if (op == Operator.CHAIN)
         {
@@ -98,7 +111,7 @@ internal static class CriteriaMongoExtensions
             switch (parameter.Type)
             {
                 case SearchParamType.Composite:
-                    return CompositeQuery(parameter, op, modifier, valueOperand);
+                    return CompositeQuery(parameter, op, modifier, valueOperand, includePlainStringTokenQuery);
                 case SearchParamType.Date:
                     return DateQuery(parameterName, op, modifier, valueOperand);
                 case SearchParamType.Number:
@@ -117,7 +130,7 @@ internal static class CriteriaMongoExtensions
                     }
                     else if (modifier == Modifier.IDENTIFIER)
                     {
-                        return TokenQuery(parameterName, op, Modifier.EXACT, valueOperand);
+                        return TokenQuery(parameterName, op, Modifier.EXACT, valueOperand, includePlainStringTokenQuery);
                     }
                     else
                     {
@@ -126,7 +139,7 @@ internal static class CriteriaMongoExtensions
                 case SearchParamType.String:
                     return StringQuery(parameterName, op, modifier, valueOperand);
                 case SearchParamType.Token:
-                    return TokenQuery(parameterName, op, modifier, valueOperand);
+                    return TokenQuery(parameterName, op, modifier, valueOperand, includePlainStringTokenQuery);
                 case SearchParamType.Uri:
                     return UriQuery(parameterName, op, modifier, valueOperand);
                 default:
@@ -327,7 +340,12 @@ internal static class CriteriaMongoExtensions
         return query;
     }
 
-    private static FilterDefinition<BsonDocument> TokenQuery(String parameterName, Operator optor, String modifier, ValueExpression operand)
+    private static FilterDefinition<BsonDocument> TokenQuery(
+        String parameterName,
+        Operator optor,
+        String modifier,
+        ValueExpression operand,
+        bool includePlainStringTokenQuery)
     {
         //$elemMatch only works on array values. But the MongoIndexMapper only creates an array if there are multiple values for a given parameter.
         //So we also construct a query for when there is only one set of values in the searchIndex, hence there is no array.
@@ -349,14 +367,15 @@ internal static class CriteriaMongoExtensions
                     var arrayQueries = new List<FilterDefinition<BsonDocument>>();
                     var noArrayQueries = new List<FilterDefinition<BsonDocument>>{
                         Builders<BsonDocument>.Filter.Not(Builders<BsonDocument>.Filter.Type(parameterName, BsonType.Array))};
-                    var plainStringQueries = new List<FilterDefinition<BsonDocument>>{
-                        Builders<BsonDocument>.Filter.Type(parameterName, BsonType.String)};
+                    List<FilterDefinition<BsonDocument>> plainStringQueries = includePlainStringTokenQuery
+                        ? [Builders<BsonDocument>.Filter.Type(parameterName, BsonType.String)]
+                        : null;
 
                     if (!string.IsNullOrEmpty(typedEqOperand.Value))
                     {
                         noArrayQueries.Add(Builders<BsonDocument>.Filter.Eq(codefield, typedEqOperand.Value));
                         arrayQueries.Add(Builders<BsonDocument>.Filter.Eq("code", typedEqOperand.Value));
-                        plainStringQueries.Add(Builders<BsonDocument>.Filter.Eq(parameterName, typedEqOperand.Value));
+                        plainStringQueries?.Add(Builders<BsonDocument>.Filter.Eq(parameterName, typedEqOperand.Value));
                     }
 
                     //Handle the system part, if present.
@@ -366,28 +385,44 @@ internal static class CriteriaMongoExtensions
                         {
                             arrayQueries.Add(Builders<BsonDocument>.Filter.Exists("system", false));
                             noArrayQueries.Add(Builders<BsonDocument>.Filter.Exists(systemfield, false));
-                            plainStringQueries.Add(Builders<BsonDocument>.Filter.Exists("system", false));
+                            plainStringQueries?.Add(Builders<BsonDocument>.Filter.Exists("system", false));
                         }
                         else
                         {
                             arrayQueries.Add(Builders<BsonDocument>.Filter.Eq("system", typedEqOperand.Namespace));
                             noArrayQueries.Add(Builders<BsonDocument>.Filter.Eq(systemfield, typedEqOperand.Namespace));
-                            plainStringQueries.Add(Builders<BsonDocument>.Filter.Eq("system", typedEqOperand.Namespace));
+                            plainStringQueries?.Add(Builders<BsonDocument>.Filter.Eq("system", typedEqOperand.Namespace));
                         }
                     }
 
                     //Combine code and system
                     var arrayEqQuery = Builders<BsonDocument>.Filter.ElemMatch(parameterName, Builders<BsonDocument>.Filter.And(arrayQueries));
                     var noArrayEqQuery = Builders<BsonDocument>.Filter.And(noArrayQueries);
+                    if (!includePlainStringTokenQuery)
+                    {
+                        return modifier == Modifier.NOT
+                            ? Builders<BsonDocument>.Filter.And(
+                                Builders<BsonDocument>.Filter.Not(arrayEqQuery),
+                                Builders<BsonDocument>.Filter.Not(noArrayEqQuery))
+                            : Builders<BsonDocument>.Filter.Or(arrayEqQuery, noArrayEqQuery);
+                    }
+
                     var plainStringQuery = Builders<BsonDocument>.Filter.And(plainStringQueries);
-                    return modifier == Modifier.NOT ?
-                        Builders<BsonDocument>.Filter.And(Builders<BsonDocument>.Filter.Not(arrayEqQuery),
-                            Builders<BsonDocument>.Filter.Not(noArrayEqQuery), Builders<BsonDocument>.Filter.Not(plainStringQuery))
+                    return modifier == Modifier.NOT
+                        ? Builders<BsonDocument>.Filter.And(
+                            Builders<BsonDocument>.Filter.Not(arrayEqQuery),
+                            Builders<BsonDocument>.Filter.Not(noArrayEqQuery),
+                            Builders<BsonDocument>.Filter.Not(plainStringQuery))
                         : Builders<BsonDocument>.Filter.Or(arrayEqQuery, noArrayEqQuery, plainStringQuery);
                 }
             case Operator.IN:
                 IEnumerable<ValueExpression> opMultiple = ((ChoiceValue)operand).Choices;
-                var queries = opMultiple.Select(choice => TokenQuery(parameterName, Operator.EQ, modifier, choice));
+                var queries = opMultiple.Select(choice => TokenQuery(
+                    parameterName,
+                    Operator.EQ,
+                    modifier,
+                    choice,
+                    includePlainStringTokenQuery));
                 return modifier == Modifier.NOT ? Builders<BsonDocument>.Filter.And(queries) : Builders<BsonDocument>.Filter.Or(queries);
             case Operator.ISNULL:
                 return Builders<BsonDocument>.Filter.And(Builders<BsonDocument>.Filter.Eq(parameterName, BsonNull.Value), Builders<BsonDocument>.Filter.Eq(textfield, BsonNull.Value)); //We don't use Builders<BsonDocument>.Filter.NotExists, because that would exclude resources that have this field with an explicit null in it.
@@ -478,7 +513,12 @@ internal static class CriteriaMongoExtensions
         }
     }
 
-    private static FilterDefinition<BsonDocument> CompositeQuery(SearchParameter parameterDef, Operator optor, String modifier, ValueExpression operand)
+    private static FilterDefinition<BsonDocument> CompositeQuery(
+        SearchParameter parameterDef,
+        Operator optor,
+        String modifier,
+        ValueExpression operand,
+        bool includePlainStringTokenQuery)
     {
         if (optor == Operator.IN)
         {
@@ -486,7 +526,12 @@ internal static class CriteriaMongoExtensions
             var queries = new List<FilterDefinition<BsonDocument>>();
             foreach (var choice in choices.Choices)
             {
-                queries.Add(CompositeQuery(parameterDef, Operator.EQ, modifier, choice));
+                queries.Add(CompositeQuery(
+                    parameterDef,
+                    Operator.EQ,
+                    modifier,
+                    choice,
+                    includePlainStringTokenQuery));
             }
             return Builders<BsonDocument>.Filter.Or(queries);
         }
@@ -511,7 +556,7 @@ internal static class CriteriaMongoExtensions
                     Operand = components[i],
                     Modifier = modifier
                 };
-                queries.Add(subCrit.ToFilter(parameterDef.Resource));
+                queries.Add(subCrit.ToFilter(parameterDef.Resource, includePlainStringTokenQuery));
             }
             return Builders<BsonDocument>.Filter.And(queries);
         }

--- a/Libraries/Spark.Store.MongoDB/Search/MongoSearcher.cs
+++ b/Libraries/Spark.Store.MongoDB/Search/MongoSearcher.cs
@@ -13,6 +13,8 @@ using MongoDB.Driver;
 using Spark.Engine.Core;
 using Spark.Engine.Search;
 using Spark.Engine.Search.Types;
+using Spark.Engine.Store;
+using Spark.Engine.Store.Interfaces;
 using Spark.Store.MongoDB.Search.Common;
 using System;
 using System.Collections.Generic;
@@ -27,8 +29,27 @@ public class MongoSearcher
     private readonly IMongoCollection<BsonDocument> _collection;
     private readonly ILocalhost _localhost;
     private readonly IFhirModel _fhirModel;
+    private readonly IDatabaseMigrationService _databaseMigrationService;
     private readonly IReferenceNormalizationService _referenceNormalizationService;
 
+    public MongoSearcher(
+        MongoIndexStore mongoIndexStore,
+        ILocalhost localhost,
+        IFhirModel fhirModel,
+        IReferenceNormalizationService referenceNormalizationService,
+        IDatabaseMigrationService databaseMigrationService)
+    {
+        _collection = mongoIndexStore.Collection;
+        _localhost = localhost;
+        _fhirModel = fhirModel;
+        _databaseMigrationService = databaseMigrationService ??
+                                    throw new ArgumentNullException(nameof(databaseMigrationService));
+        _referenceNormalizationService = referenceNormalizationService;
+    }
+
+    [Obsolete(
+        "Use MongoSearcher(MongoIndexStore, ILocalhost, IFhirModel, IReferenceNormalizationService, IDatabaseMigrationService) instead."
+    )]
     public MongoSearcher(MongoIndexStore mongoIndexStore, ILocalhost localhost, IFhirModel fhirModel, 
         IReferenceNormalizationService referenceNormalizationService = null)
     {
@@ -116,6 +137,10 @@ public class MongoSearcher
         return results;
     }
 
+    internal bool IncludePlainStringTokenQuery =>
+        _databaseMigrationService == null
+        || !_databaseMigrationService.IsApplied(DatabaseMigrations.StructuredStringTokenIndex.Version);
+
     private List<BsonValue> CollectKeys(string resourceType, IEnumerable<Criterium> criteria, int level = 0)
     {
         return CollectKeys(resourceType, criteria, null, level);
@@ -197,9 +222,14 @@ public class MongoSearcher
 
     }
 
-    private static FilterDefinition<BsonDocument> CreateMongoQuery(string resourceType, SearchResults results, int level, Dictionary<Criterium, Criterium> closedCriteria)
+    private FilterDefinition<BsonDocument> CreateMongoQuery(
+        string resourceType,
+        SearchResults results,
+        int level,
+        Dictionary<Criterium, Criterium> closedCriteria)
     {
         FilterDefinition<BsonDocument> resultQuery = CriteriaMongoExtensions.ResourceFilter(resourceType, level);
+        bool includePlainStringTokenQuery = IncludePlainStringTokenQuery;
         if (closedCriteria.Count > 0)
         {
             var criteriaQueries = new List<FilterDefinition<BsonDocument>>();
@@ -209,7 +239,7 @@ public class MongoSearcher
                 {
                     try
                     {
-                        criteriaQueries.Add(crit.Value.ToFilter(resourceType));
+                        criteriaQueries.Add(crit.Value.ToFilter(resourceType, includePlainStringTokenQuery));
                     }
                     catch (ArgumentException ex)
                     {

--- a/Tests/Spark.Store.MongoDB.Tests/DatabaseMigrationRefreshServiceTests.cs
+++ b/Tests/Spark.Store.MongoDB.Tests/DatabaseMigrationRefreshServiceTests.cs
@@ -45,6 +45,31 @@ public partial class DatabaseMigrationRefreshServiceTests
     }
 
     [Fact]
+    public async Task StartAsync_WaitsForInitialRefresh()
+    {
+        TaskCompletionSource refreshStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource completeRefresh = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        Mock<IDatabaseMigrationService> migrationService = new();
+        migrationService
+            .Setup(service => service.RefreshAsync(It.IsAny<CancellationToken>()))
+            .Returns(async () =>
+            {
+                refreshStarted.TrySetResult();
+                await completeRefresh.Task;
+            });
+        DatabaseMigrationRefreshService worker = CreateWorker(migrationService.Object, TimeSpan.FromHours(1));
+
+        Task start = worker.StartAsync(TestContext.Current.CancellationToken);
+        await refreshStarted.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        Assert.False(start.IsCompleted);
+
+        completeRefresh.TrySetResult();
+        await start;
+        await worker.StopAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
     public async Task ExecuteAsync_RefreshesPeriodically()
     {
         TaskCompletionSource refreshedTwice = new(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -78,11 +103,17 @@ public partial class DatabaseMigrationRefreshServiceTests
     {
         TaskCompletionSource refreshStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
         TaskCompletionSource refreshCancelled = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        int refreshCount = 0;
         Mock<IDatabaseMigrationService> migrationService = new();
         migrationService
             .Setup(service => service.RefreshAsync(It.IsAny<CancellationToken>()))
             .Returns(async (CancellationToken cancellationToken) =>
             {
+                if (Interlocked.Increment(ref refreshCount) == 1)
+                {
+                    return;
+                }
+
                 refreshStarted.TrySetResult();
                 try
                 {
@@ -94,7 +125,7 @@ public partial class DatabaseMigrationRefreshServiceTests
                     throw;
                 }
             });
-        DatabaseMigrationRefreshService worker = CreateWorker(migrationService.Object, TimeSpan.FromHours(1));
+        DatabaseMigrationRefreshService worker = CreateWorker(migrationService.Object, TimeSpan.FromMilliseconds(10));
 
         await worker.StartAsync(TestContext.Current.CancellationToken);
         await refreshStarted.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);

--- a/Tests/Spark.Store.MongoDB.Tests/DatabaseMigrationRefreshServiceTests.cs
+++ b/Tests/Spark.Store.MongoDB.Tests/DatabaseMigrationRefreshServiceTests.cs
@@ -5,7 +5,7 @@
  */
 
 using Microsoft.Extensions.Logging;
-using Spark.Engine.Store;
+using Moq;
 using Spark.Engine.Store.Interfaces;
 using System;
 using System.Threading;
@@ -20,18 +20,23 @@ public partial class DatabaseMigrationRefreshServiceTests
     public async Task StartAsync_RefreshesImmediately()
     {
         TaskCompletionSource refreshed = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        StubMigrationService migrationService = new((_, _) =>
-        {
-            refreshed.TrySetResult();
-            return Task.CompletedTask;
-        });
-        DatabaseMigrationRefreshService worker = CreateWorker(migrationService, TimeSpan.FromHours(1));
+        Mock<IDatabaseMigrationService> migrationService = new();
+        migrationService
+            .Setup(service => service.RefreshAsync(It.IsAny<CancellationToken>()))
+            .Returns(() =>
+            {
+                refreshed.TrySetResult();
+                return Task.CompletedTask;
+            });
+        DatabaseMigrationRefreshService worker = CreateWorker(migrationService.Object, TimeSpan.FromHours(1));
 
         await worker.StartAsync(TestContext.Current.CancellationToken);
         try
         {
             await refreshed.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
-            Assert.Equal(1, migrationService.RefreshCount);
+            migrationService.Verify(
+                service => service.RefreshAsync(It.IsAny<CancellationToken>()),
+                Times.Once);
         }
         finally
         {
@@ -43,20 +48,24 @@ public partial class DatabaseMigrationRefreshServiceTests
     public async Task ExecuteAsync_RefreshesPeriodically()
     {
         TaskCompletionSource refreshedTwice = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        StubMigrationService migrationService = new((count, _) =>
-        {
-            if (count >= 2)
-                refreshedTwice.TrySetResult();
+        int refreshCount = 0;
+        Mock<IDatabaseMigrationService> migrationService = new();
+        migrationService
+            .Setup(service => service.RefreshAsync(It.IsAny<CancellationToken>()))
+            .Returns(() =>
+            {
+                if (Interlocked.Increment(ref refreshCount) >= 2)
+                    refreshedTwice.TrySetResult();
 
-            return Task.CompletedTask;
-        });
-        DatabaseMigrationRefreshService worker = CreateWorker(migrationService, TimeSpan.FromMilliseconds(10));
+                return Task.CompletedTask;
+            });
+        DatabaseMigrationRefreshService worker = CreateWorker(migrationService.Object, TimeSpan.FromMilliseconds(10));
 
         await worker.StartAsync(TestContext.Current.CancellationToken);
         try
         {
             await refreshedTwice.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
-            Assert.True(migrationService.RefreshCount >= 2);
+            Assert.True(Volatile.Read(ref refreshCount) >= 2);
         }
         finally
         {
@@ -69,20 +78,23 @@ public partial class DatabaseMigrationRefreshServiceTests
     {
         TaskCompletionSource refreshStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
         TaskCompletionSource refreshCancelled = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        StubMigrationService migrationService = new(async (_, cancellationToken) =>
-        {
-            refreshStarted.TrySetResult();
-            try
+        Mock<IDatabaseMigrationService> migrationService = new();
+        migrationService
+            .Setup(service => service.RefreshAsync(It.IsAny<CancellationToken>()))
+            .Returns(async (CancellationToken cancellationToken) =>
             {
-                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
-            }
-            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-            {
-                refreshCancelled.TrySetResult();
-                throw;
-            }
-        });
-        DatabaseMigrationRefreshService worker = CreateWorker(migrationService, TimeSpan.FromHours(1));
+                refreshStarted.TrySetResult();
+                try
+                {
+                    await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    refreshCancelled.TrySetResult();
+                    throw;
+                }
+            });
+        DatabaseMigrationRefreshService worker = CreateWorker(migrationService.Object, TimeSpan.FromHours(1));
 
         await worker.StartAsync(TestContext.Current.CancellationToken);
         await refreshStarted.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
@@ -95,19 +107,23 @@ public partial class DatabaseMigrationRefreshServiceTests
     public async Task ExecuteAsync_WhenRefreshFails_LogsAndContinuesRefreshing()
     {
         TaskCompletionSource secondRefresh = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        StubMigrationService migrationService = new((count, _) =>
+        int refreshCount = 0;
+        Mock<IDatabaseMigrationService> migrationService = new();
+        migrationService.SetupGet(service => service.CurrentVersion).Returns(2);
+        migrationService
+            .Setup(service => service.RefreshAsync(It.IsAny<CancellationToken>()))
+            .Returns(() =>
             {
+                int count = Interlocked.Increment(ref refreshCount);
                 if (count == 1)
                     throw new InvalidOperationException("Refresh failed.");
 
                 secondRefresh.TrySetResult();
                 return Task.CompletedTask;
-            }
-        );
-        migrationService.CurrentVersion = 2;
+            });
         TestLogger<DatabaseMigrationRefreshService> logger = new();
         DatabaseMigrationRefreshService worker = new(
-            migrationService,
+            migrationService.Object,
             logger,
             TimeSpan.FromMilliseconds(10));
 
@@ -116,7 +132,7 @@ public partial class DatabaseMigrationRefreshServiceTests
         {
             await secondRefresh.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
-            Assert.Equal(2, migrationService.CurrentVersion);
+            Assert.Equal(2, migrationService.Object.CurrentVersion);
             Assert.Contains(
                 logger.Entries,
                 entry =>
@@ -142,33 +158,4 @@ public partial class DatabaseMigrationRefreshServiceTests
         );
     }
 
-    private sealed class StubMigrationService : IDatabaseMigrationService
-    {
-        private readonly Func<int, CancellationToken, Task> _refresh;
-        private int _refreshCount;
-
-        public StubMigrationService(Func<int, CancellationToken, Task> refresh)
-        {
-            _refresh = refresh;
-        }
-
-        public int CurrentVersion { get; set; }
-
-        public int RefreshCount => Volatile.Read(ref _refreshCount);
-
-        public bool IsApplied(int version) => version > 0 && version <= CurrentVersion;
-
-        public Task RefreshAsync(CancellationToken cancellationToken = default)
-        {
-            int count = Interlocked.Increment(ref _refreshCount);
-            return _refresh(count, cancellationToken);
-        }
-
-        public Task RecordCompletedAsync(
-            DatabaseMigration migration,
-            CancellationToken cancellationToken = default)
-        {
-            throw new NotSupportedException();
-        }
-    }
 }

--- a/Tests/Spark.Store.MongoDB.Tests/DatabaseMigrationServiceCollectionExtensionsTests.cs
+++ b/Tests/Spark.Store.MongoDB.Tests/DatabaseMigrationServiceCollectionExtensionsTests.cs
@@ -6,9 +6,15 @@
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Moq;
 using Spark.Engine;
+using Spark.Engine.Core;
+using Spark.Engine.Search;
+using Spark.Engine.Store;
 using Spark.Engine.Store.Interfaces;
 using Spark.Store.MongoDB.Extensions;
+using Spark.Store.MongoDB.Search;
+using System;
 using Xunit;
 
 namespace Spark.Store.MongoDB.Tests;
@@ -44,6 +50,27 @@ public class DatabaseMigrationServiceCollectionExtensionsTests
                 service.ServiceType == typeof(IHostedService) &&
                 service.ImplementationType == typeof(DatabaseMigrationRefreshService));
         Assert.Equal(ServiceLifetime.Singleton, descriptor.Lifetime);
+    }
+
+    [Fact]
+    public void AddMongoFhirStore_MongoSearcherUsesRegisteredMigrationService()
+    {
+        ServiceCollection services = new();
+        Mock<IDatabaseMigrationService> migrationService = new();
+        migrationService
+            .Setup(service => service.IsApplied(DatabaseMigrations.StructuredStringTokenIndex.Version))
+            .Returns(true);
+        Localhost localhost = new(new Uri("http://localhost/fhir"));
+        services.AddSingleton<IDatabaseMigrationService>(migrationService.Object);
+        services.AddSingleton<ILocalhost>(localhost);
+        services.AddSingleton(new Mock<IFhirModel>().Object);
+        services.AddSingleton<IReferenceNormalizationService>(new ReferenceNormalizationService(localhost));
+        services.AddMongoFhirStore(CreateSettings());
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+
+        MongoSearcher searcher = provider.GetRequiredService<MongoSearcher>();
+        Assert.False(searcher.IncludePlainStringTokenQuery);
     }
 
     private static StoreSettings CreateSettings() => new()

--- a/Tests/Spark.Store.MongoDB.Tests/DatabaseMigrationServiceTests.cs
+++ b/Tests/Spark.Store.MongoDB.Tests/DatabaseMigrationServiceTests.cs
@@ -7,6 +7,7 @@
 using MongoDB.Bson;
 using MongoDB.Driver;
 using Spark.Engine.Store;
+using Spark.Store.MongoDB.Search.Common;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
@@ -25,14 +26,76 @@ public class DatabaseMigrationServiceTests : IAsyncLifetime
     public ValueTask DisposeAsync() => _container.DisposeAsync();
 
     [Fact]
-    public async Task RefreshAsync_WithNoPersistedMigrations_UsesVersionZero()
+    public async Task RefreshAsync_WithFreshDatabase_RecordsCurrentMigration()
     {
         var service = CreateService();
 
         await service.RefreshAsync(TestContext.Current.CancellationToken);
 
+        Assert.Equal(1, service.CurrentVersion);
+        Assert.True(service.IsApplied(1));
+    }
+
+    [Fact]
+    public async Task RefreshAsync_WithUnversionedResources_UsesVersionZero()
+    {
+        string connectionString = CreateConnectionString();
+        await GetDatabase(connectionString)
+            .GetCollection<BsonDocument>(Collection.RESOURCE)
+            .InsertOneAsync(new BsonDocument("resource", true),
+                cancellationToken: TestContext.Current.CancellationToken);
+        var service = new DatabaseMigrationService(connectionString);
+
+        await service.RefreshAsync(TestContext.Current.CancellationToken);
+
         Assert.Equal(0, service.CurrentVersion);
         Assert.False(service.IsApplied(1));
+        Assert.Equal(0, await GetCollection(connectionString)
+            .CountDocumentsAsync(Builders<BsonDocument>.Filter.Empty,
+                cancellationToken: TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task RefreshAsync_WithUnversionedSearchIndex_UsesVersionZero()
+    {
+        string connectionString = CreateConnectionString();
+        await GetDatabase(connectionString)
+            .GetCollection<BsonDocument>(MongoCollections.SEARCH_INDEX_COLLECTION)
+            .InsertOneAsync(new BsonDocument("index", true),
+                cancellationToken: TestContext.Current.CancellationToken);
+        var service = new DatabaseMigrationService(connectionString);
+
+        await service.RefreshAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(0, service.CurrentVersion);
+        Assert.False(service.IsApplied(1));
+        Assert.Equal(0, await GetCollection(connectionString)
+            .CountDocumentsAsync(Builders<BsonDocument>.Filter.Empty,
+                cancellationToken: TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task RefreshAsync_DoesNotReclassifyLegacyDatabaseAsFresh()
+    {
+        string connectionString = CreateConnectionString();
+        IMongoCollection<BsonDocument> resources = GetDatabase(connectionString)
+            .GetCollection<BsonDocument>(Collection.RESOURCE);
+        await resources.InsertOneAsync(
+            new BsonDocument("resource", true),
+            cancellationToken: TestContext.Current.CancellationToken);
+        var service = new DatabaseMigrationService(connectionString);
+
+        await service.RefreshAsync(TestContext.Current.CancellationToken);
+        await resources.DeleteManyAsync(
+            FilterDefinition<BsonDocument>.Empty,
+            TestContext.Current.CancellationToken);
+        await service.RefreshAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(0, service.CurrentVersion);
+        Assert.False(service.IsApplied(1));
+        Assert.Equal(0, await GetCollection(connectionString)
+            .CountDocumentsAsync(Builders<BsonDocument>.Filter.Empty,
+                cancellationToken: TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -153,7 +216,6 @@ public class DatabaseMigrationServiceTests : IAsyncLifetime
         await using MongoDbContainer container = await StartMongoOrSkipAsync();
         string connectionString = BuildConnectionString(container.GetConnectionString(), "migration-failure", 1);
         var service = new DatabaseMigrationService(connectionString);
-        await service.RefreshAsync(TestContext.Current.CancellationToken);
         await container.StopAsync(TestContext.Current.CancellationToken);
 
         await Assert.ThrowsAsync<TimeoutException>(() =>
@@ -199,8 +261,11 @@ public class DatabaseMigrationServiceTests : IAsyncLifetime
     };
 
     private static IMongoCollection<BsonDocument> GetCollection(string connectionString) =>
-        MongoDatabaseFactory.GetMongoDatabase(connectionString)
+        GetDatabase(connectionString)
             .GetCollection<BsonDocument>(Collection.SchemaMigrations);
+
+    private static IMongoDatabase GetDatabase(string connectionString) =>
+        MongoDatabaseFactory.GetMongoDatabase(connectionString);
 
     private static async Task<MongoDbContainer> StartMongoOrSkipAsync()
     {

--- a/Tests/Spark.Store.MongoDB.Tests/Search/ChainedSearchErrorHandlingTests.cs
+++ b/Tests/Spark.Store.MongoDB.Tests/Search/ChainedSearchErrorHandlingTests.cs
@@ -9,9 +9,11 @@ using Hl7.Fhir.Model;
 using Hl7.Fhir.Rest;
 using Hl7.Fhir.Specification;
 using MongoDB.Driver;
+using Moq;
 using Spark.Engine.Core;
 using Spark.Engine.Search;
 using Spark.Engine.Service.FhirServiceExtensions;
+using Spark.Engine.Store.Interfaces;
 using Spark.Store.MongoDB.Search;
 using Spark.Store.MongoDB.Search.Common;
 using Spark.Store.MongoDB.Search.Indexer;
@@ -164,7 +166,12 @@ public class ChainedSearchErrorHandlingTests
         var indexStore = new MongoIndexStore(connectionString, new MongoIndexMapper());
         var indexService = new IndexService(fhirModel, indexStore, new ElementIndexer(fhirModel),
             new ResourceResolver(fhirModel.SupportedResources, new PocoStructureDefinitionSummaryProvider()));
-        var searcher = new MongoSearcher(indexStore, localhost, fhirModel, new ReferenceNormalizationService(localhost));
+        var searcher = new MongoSearcher(
+            indexStore,
+            localhost,
+            fhirModel,
+            new ReferenceNormalizationService(localhost),
+            new Mock<IDatabaseMigrationService>().Object);
 
         // Two patients born after the cut-off and two before, each with one Observation.
         var birthdates = new[] { "2000-01-01", "2001-01-01", "1950-01-01", "1951-01-01" };

--- a/Tests/Spark.Store.MongoDB.Tests/Search/CriteriumQueryBuilderTests.cs
+++ b/Tests/Spark.Store.MongoDB.Tests/Search/CriteriumQueryBuilderTests.cs
@@ -38,6 +38,46 @@ public class CriteriumQueryBuilderTests
     }
 
     [Theory]
+    [InlineData(
+        ResourceType.Condition,
+        "code",
+        "code=ha125",
+        "{ \"$or\" : [{ \"code\" : { \"$elemMatch\" : { \"code\" : \"ha125\" } } }, { \"code\" : { \"$not\" : { \"$type\" : 4 } }, \"code.code\" : \"ha125\" }] }")]
+    [InlineData(
+        ResourceType.Patient,
+        "gender",
+        "gender:not=male",
+        "{ \"gender\" : { \"$not\" : { \"$elemMatch\" : { \"code\" : \"male\" } } }, \"$nor\" : [{ \"gender\" : { \"$not\" : { \"$type\" : 4 } }, \"gender.code\" : \"male\" }] }")]
+    public void MigratedTokenQuery_OmitsPlainStringBranch(
+        ResourceType resourceType,
+        string searchParameter,
+        string query,
+        string expected)
+    {
+        string jsonFilter = BuildAndReturnQueryFilterAsJsonString(
+            resourceType,
+            searchParameter,
+            query,
+            includePlainStringTokenQuery: false);
+
+        Assert.Equal(expected, jsonFilter);
+    }
+
+    [Fact]
+    public void MigratedMultiValueTokenQuery_OmitsPlainStringBranchFromEveryChoice()
+    {
+        string jsonFilter = BuildAndReturnQueryFilterAsJsonString(
+            ResourceType.Patient,
+            "gender",
+            "gender=male,female",
+            includePlainStringTokenQuery: false);
+
+        Assert.DoesNotContain("\"$type\" : 2", jsonFilter);
+        Assert.Contains("\"gender.code\" : \"male\"", jsonFilter);
+        Assert.Contains("\"gender.code\" : \"female\"", jsonFilter);
+    }
+
+    [Theory]
     [InlineData(ResourceType.RiskAssessment, "probability", "probability=0.8", "{ \"probability\" : \"0.8\" }")]
     [InlineData(ResourceType.RiskAssessment, "probability", "probability=eq0.8", "{ \"probability\" : \"0.8\" }")]
     [InlineData(ResourceType.RiskAssessment, "probability", "probability=gt0.8", "{ \"probability\" : { \"$gt\" : \"0.8\" } }")]
@@ -105,7 +145,11 @@ public class CriteriumQueryBuilderTests
         Assert.Equal(expected, jsonFilter);
     }
 
-    private string BuildAndReturnQueryFilterAsJsonString(ResourceType resourceType, string searchParameter, string query)
+    private string BuildAndReturnQueryFilterAsJsonString(
+        ResourceType resourceType,
+        string searchParameter,
+        string query,
+        bool includePlainStringTokenQuery = true)
     {
         var fhirModel = new FhirModel();
         var bsonSerializerRegistry = new BsonSerializerRegistry();
@@ -117,7 +161,7 @@ public class CriteriumQueryBuilderTests
         var criterium = Criterium.Parse(fhirModel.SearchParameters, resourceTypeAsString, keyVal.Item1, keyVal.Item2);
         criterium.SearchParameters.AddRange(fhirModel.FindSearchParameters(resourceTypeAsString).Where(sp => sp.Name == searchParameter));
 
-        var filter = criterium.ToFilter(resourceType.GetLiteral());
+        var filter = criterium.ToFilter(resourceType.GetLiteral(), includePlainStringTokenQuery);
         var jsonFilter = filter.Render(new RenderArgs<BsonDocument>(bsonSerializerRegistry.GetSerializer<BsonDocument>(), bsonSerializerRegistry)).ToJson();
 
         return jsonFilter;

--- a/Tests/Spark.Store.MongoDB.Tests/Search/MongoSearcherMigrationTests.cs
+++ b/Tests/Spark.Store.MongoDB.Tests/Search/MongoSearcherMigrationTests.cs
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026, Incendi <info@incendi.no>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+using Spark.Engine.Core;
+using Spark.Engine.Store;
+using Spark.Engine.Store.Interfaces;
+using Spark.Store.MongoDB.Search;
+using Spark.Store.MongoDB.Search.Common;
+using Spark.Store.MongoDB.Search.Indexer;
+using Moq;
+using System;
+using Xunit;
+
+namespace Spark.Store.MongoDB.Tests.Search;
+
+public class MongoSearcherMigrationTests
+{
+    [Fact]
+    public void IncludePlainStringTokenQuery_ReflectsCurrentMigrationState()
+    {
+        int currentVersion = 0;
+        Mock<IDatabaseMigrationService> migrationService = new();
+        migrationService
+            .Setup(service => service.IsApplied(DatabaseMigrations.StructuredStringTokenIndex.Version))
+            .Returns(() => currentVersion >= DatabaseMigrations.StructuredStringTokenIndex.Version);
+        MongoSearcher searcher = new(
+            new MongoIndexStore("mongodb://localhost/spark", new MongoIndexMapper()),
+            new Localhost(new Uri("http://localhost/fhir")),
+            new Mock<IFhirModel>().Object,
+            referenceNormalizationService: null,
+            databaseMigrationService: migrationService.Object);
+
+        Assert.True(searcher.IncludePlainStringTokenQuery);
+
+        currentVersion = 1;
+
+        Assert.False(searcher.IncludePlainStringTokenQuery);
+    }
+
+    [Fact]
+    public void LegacyConstructor_IncludesPlainStringTokenQuery()
+    {
+#pragma warning disable CS0618
+        MongoSearcher searcher = new(
+            new MongoIndexStore("mongodb://localhost/spark", new MongoIndexMapper()),
+            new Localhost(new Uri("http://localhost/fhir")),
+            new Mock<IFhirModel>().Object,
+            null);
+#pragma warning restore CS0618
+
+        Assert.True(searcher.IncludePlainStringTokenQuery);
+    }
+}

--- a/Tests/Spark.Store.MongoDB.Tests/Search/QuantitySearchIntegrationTests.cs
+++ b/Tests/Spark.Store.MongoDB.Tests/Search/QuantitySearchIntegrationTests.cs
@@ -8,9 +8,11 @@ using Hl7.Fhir.Model;
 using Hl7.Fhir.Rest;
 using Hl7.Fhir.Specification;
 using MongoDB.Driver;
+using Moq;
 using Spark.Engine.Core;
 using Spark.Engine.Search;
 using Spark.Engine.Service.FhirServiceExtensions;
+using Spark.Engine.Store.Interfaces;
 using Spark.Store.MongoDB.Search;
 using Spark.Store.MongoDB.Search.Common;
 using Spark.Store.MongoDB.Search.Indexer;
@@ -142,7 +144,12 @@ public class QuantitySearchIntegrationTests : IAsyncLifetime
         MongoIndexStore indexStore = new(connectionString, new MongoIndexMapper());
         IndexService indexService = new(fhirModel, indexStore, new ElementIndexer(fhirModel),
             new ResourceResolver(fhirModel.SupportedResources, new PocoStructureDefinitionSummaryProvider()));
-        MongoSearcher searcher = new(indexStore, localhost, fhirModel, new ReferenceNormalizationService(localhost));
+        MongoSearcher searcher = new(
+            indexStore,
+            localhost,
+            fhirModel,
+            new ReferenceNormalizationService(localhost),
+            new Mock<IDatabaseMigrationService>().Object);
 
         foreach (Resource resource in resources)
         {

--- a/Tests/Spark.Store.MongoDB.Tests/Spark.Store.MongoDB.Tests.csproj
+++ b/Tests/Spark.Store.MongoDB.Tests/Spark.Store.MongoDB.Tests.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Only include the `plainStringQuery` in a token query if the `StructuredStringTokenIndex` database migration has not been run.

Closes #1385 