### PR TITLE
MongoDB: Do not index an entry that contains only the root IndexValue

### DIFF
--- a/Libraries/Spark.Store.MongoDB/Search/Indexer/MongoIndexMapper.cs
+++ b/Libraries/Spark.Store.MongoDB/Search/Indexer/MongoIndexMapper.cs
@@ -40,22 +40,26 @@ public class MongoIndexMapper
     private static void EntryToDocument(IndexValue indexValue, int level, List<BsonDocument> result)
     {
         // Add the real values (not contained) to a document and add that to the result.
-        List<IndexValue> notNestedValues =
+        List<IndexValue> indexValues =
         [
             .. indexValue.Values.Where(expression => expression is IndexValue { Name: not "contained" })
                 .Select(expression => (IndexValue)expression)
         ];
+
+        if (indexValues.Count == 0)
+            return;
+
         BsonDocument document = new(new BsonElement(InternalField.LEVEL, level));
-        document.AddRange(notNestedValues.Select(IndexValueToElement));
+        document.AddRange(indexValues.Select(IndexValueToElement));
         result.Add(document);
 
         // Then do that recursively for all contained indexed resources.
-        List<IndexValue> containedValues =
+        List<IndexValue> containedIndexValues =
         [
             .. indexValue.Values.Where(expression => expression is IndexValue { Name: "contained" })
                 .Select(expression => (IndexValue)expression)
         ];
-        foreach (IndexValue contained in containedValues)
+        foreach (IndexValue contained in containedIndexValues)
         {
             EntryToDocument(contained, level + 1, result);
         }

--- a/Tests/Spark.Store.MongoDB.Tests/Indexer/MongoIndexMapperTest.cs
+++ b/Tests/Spark.Store.MongoDB.Tests/Indexer/MongoIndexMapperTest.cs
@@ -18,6 +18,7 @@ using Spark.Engine.Core;
 using Spark.Engine.Search;
 using Spark.Engine.Service.FhirServiceExtensions;
 using Spark.Engine.Store.Interfaces;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using Xunit;
@@ -38,23 +39,53 @@ public class MongoIndexMapperTest
     }
 
     [Fact]
-    public void TestMapRootIndexValue()
+    public void RootIndexValueWillBeSkipped()
     {
-        // "root" element should be skipped.
+        IndexValue rootIndexValue = new("root");
+        List<BsonDocument> indexedEntries = _indexMapper.MapEntry(rootIndexValue);
+        Assert.Empty(indexedEntries);
+    }
+
+    [Fact]
+    public void MissingRootIndexValueWillThrowArgumentException()
+    {
+        IndexValue indexValue = new("not-root");
+        Assert.Throws<ArgumentException>(() => _indexMapper.MapEntry(indexValue));
+    }
+
+    [Fact]
+    public void MapEntryAddsIndexValueInternalLevelEqualToZeroForNonNestedValues()
+    {
         IndexValue indexValue = new("root");
         indexValue.Values.Add(new IndexValue("internal_resource", new StringValue("Patient")));
 
         List<BsonDocument> indexedEntries = _indexMapper.MapEntry(indexValue);
+
         Assert.Single(indexedEntries);
         BsonDocument indexedEntry = indexedEntries[0];
         Assert.True(indexedEntry.IsBsonDocument);
         Assert.Equal(2, indexedEntry.ElementCount);
-        BsonElement firstIndexedElement = indexedEntry.GetElement(0);
-        Assert.Equal("internal_level", firstIndexedElement.Name);
-        BsonElement secondIndexedElement = indexedEntry.GetElement(1);
-        Assert.Equal("internal_resource", secondIndexedElement.Name);
-        Assert.True(secondIndexedElement.Value.IsString);
-        Assert.Equal("Patient", secondIndexedElement.Value.AsString);
+        BsonElement internalLevelElement = indexedEntry.GetElement(0);
+        Assert.Equal("internal_level", internalLevelElement.Name);
+        Assert.Equal(0, internalLevelElement.Value);
+    }
+
+    [Fact]
+    public void MapEntryCanMapIndexValueWithStringValue()
+    {
+        IndexValue indexValue = new("root");
+        indexValue.Values.Add(new IndexValue("internal_resource", new StringValue("Patient")));
+
+        List<BsonDocument> indexedEntries = _indexMapper.MapEntry(indexValue);
+
+        Assert.Single(indexedEntries);
+        BsonDocument indexedEntry = indexedEntries[0];
+        Assert.True(indexedEntry.IsBsonDocument);
+        Assert.Equal(2, indexedEntry.ElementCount);
+        BsonElement indexedInternalResource = indexedEntry.GetElement(1);
+        Assert.Equal("internal_resource", indexedInternalResource.Name);
+        Assert.True(indexedInternalResource.Value.IsString);
+        Assert.Equal("Patient", indexedInternalResource.Value.AsString);
     }
 
     [Fact]

--- a/Tests/Spark.Store.MongoDB.Tests/Indexer/MongoIndexMapperTest.cs
+++ b/Tests/Spark.Store.MongoDB.Tests/Indexer/MongoIndexMapperTest.cs
@@ -21,6 +21,7 @@ using Spark.Engine.Store.Interfaces;
 using System.Collections.Generic;
 using System.IO;
 using Xunit;
+using System.Threading.Tasks;
 using Task = System.Threading.Tasks.Task;
 
 namespace Spark.Store.MongoDB.Tests.Indexer;
@@ -76,7 +77,7 @@ public class MongoIndexMapperTest
         Assert.Equal(2, document["identifier"].AsBsonArray.Count);
     }
 
-    private static async System.Threading.Tasks.Task<BsonDocument> MapExamplePatientAsync(string fileName)
+    private static async Task<BsonDocument> MapExamplePatientAsync(string fileName)
     {
         string json = await File.ReadAllTextAsync(Path.Combine("Examples", fileName), TestContext.Current.CancellationToken);
         Patient patient = new FhirJsonDeserializer().Deserialize<Patient>(json);


### PR DESCRIPTION
This also adds targeted MongoIndexMapper Tests for root IndexValue + splits up the existing test TestMapRootIndexValue() into:
- MapEntryAddsIndexValueInternalLevelEqualToZeroForNonNestedValues()
- MapEntryCanMapIndexValueWithStringValue()