### PR TITLE
MongoDB: Allow re-indexing the latest version of a Resource

### DIFF
--- a/Libraries/Spark.Store.MongoDB/Extensions/IServiceCollectionExtensions.cs
+++ b/Libraries/Spark.Store.MongoDB/Extensions/IServiceCollectionExtensions.cs
@@ -7,6 +7,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Spark.Engine;
 using Spark.Engine.Core;
 using Spark.Engine.Interfaces;
@@ -35,8 +36,8 @@ public static class IServiceCollectionExtensions
         services.TryAddTransient<ISnapshotStore2>(_ => new MongoSnapshotStore(settings.ConnectionString));
         services.TryAddTransient<IFhirStoreAdministration>(_ => new MongoStoreAdministration(settings.ConnectionString));
         services.TryAddTransient<MongoIndexMapper>();
-        services.TryAddTransient<IIndexStore>(provider => new MongoIndexStore(settings.ConnectionString, provider.GetRequiredService<MongoIndexMapper>()));
-        services.TryAddTransient(provider => new MongoIndexStore(settings.ConnectionString, provider.GetRequiredService<MongoIndexMapper>()));
+        services.TryAddTransient<IIndexStore>(provider => new MongoIndexStore(settings.ConnectionString, provider.GetRequiredService<MongoIndexMapper>(), provider.GetRequiredService<ILogger<MongoIndexStore>>()));
+        services.TryAddTransient(provider => new MongoIndexStore(settings.ConnectionString, provider.GetRequiredService<MongoIndexMapper>(), provider.GetRequiredService<ILogger<MongoIndexStore>>()));
         services.TryAddTransient(provider => DefinitionsFactory.Generate(provider.GetRequiredService<IFhirModel>()));
         services.TryAddTransient<MongoSearcher>();
         services.TryAddTransient<IFhirIndex, MongoFhirIndex>();

--- a/Libraries/Spark.Store.MongoDB/Search/Common/MongoIndexStore.cs
+++ b/Libraries/Spark.Store.MongoDB/Search/Common/MongoIndexStore.cs
@@ -51,7 +51,7 @@ public class MongoIndexStore : IIndexStore
                 Builders<BsonDocument>.Filter.Eq(InternalField.ID, keyvalue),
                 Builders<BsonDocument>.Filter.Or(
                     Builders<BsonDocument>.Filter.Exists(InternalField.VERSION, false),
-                    Builders<BsonDocument>.Filter.Lt(InternalField.VERSION, newVersion)
+                    Builders<BsonDocument>.Filter.Lte(InternalField.VERSION, newVersion)
                 )
             );
             try

--- a/Libraries/Spark.Store.MongoDB/Search/Common/MongoIndexStore.cs
+++ b/Libraries/Spark.Store.MongoDB/Search/Common/MongoIndexStore.cs
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+using Microsoft.Extensions.Logging;
 using MongoDB.Bson;
 using MongoDB.Driver;
 using Spark.Engine.Core;
@@ -13,6 +14,7 @@ using System.Threading.Tasks;
 using Spark.Engine.Model;
 using Spark.Store.MongoDB.Search.Indexer;
 using Spark.Engine.Store.Interfaces;
+using System;
 
 namespace Spark.Store.MongoDB.Search.Common;
 
@@ -20,8 +22,18 @@ public class MongoIndexStore : IIndexStore
 {
     private IMongoDatabase _database;
     private MongoIndexMapper _indexMapper;
+    private readonly ILogger<MongoIndexStore> _logger;
     public IMongoCollection<BsonDocument> Collection;
 
+    public MongoIndexStore(string mongoUrl, MongoIndexMapper indexMapper, ILogger<MongoIndexStore> logger)
+    {
+        _database = MongoDatabaseFactory.GetMongoDatabase(mongoUrl);
+        _indexMapper = indexMapper;
+        _logger = logger;
+        Collection = _database.GetCollection<BsonDocument>(MongoCollections.SEARCH_INDEX_COLLECTION);
+    }
+
+    [Obsolete("Use ctor MongoIndexStore(string, MongoIndexMapper, ILogger<MongoIndexStore>) instead.")]
     public MongoIndexStore(string mongoUrl, MongoIndexMapper indexMapper)
     {
         _database = MongoDatabaseFactory.GetMongoDatabase(mongoUrl);
@@ -59,10 +71,10 @@ public class MongoIndexStore : IIndexStore
                 await Collection.FindOneAndReplaceAsync(conditionalFilter, document,
                     new FindOneAndReplaceOptions<BsonDocument> { IsUpsert = true }).ConfigureAwait(false);
             }
-            catch (MongoWriteException ex) when (ex.WriteError.Code == 11000)
+            catch (MongoCommandException ex) when (ex.Code == 11000)
             {
-                // FIXME: Log the Exception.
-                // Duplicate key: a newer version is already indexed — stale write, skip.
+                _logger?.LogError(ex, "Duplicate key: a newer version is already indexed — stale write, skip.");
+                throw;
             }
         }
         else

--- a/Tests/Spark.Store.MongoDB.Tests/DatabaseMigrationServiceCollectionExtensionsTests.cs
+++ b/Tests/Spark.Store.MongoDB.Tests/DatabaseMigrationServiceCollectionExtensionsTests.cs
@@ -65,6 +65,7 @@ public class DatabaseMigrationServiceCollectionExtensionsTests
         services.AddSingleton<ILocalhost>(localhost);
         services.AddSingleton(new Mock<IFhirModel>().Object);
         services.AddSingleton<IReferenceNormalizationService>(new ReferenceNormalizationService(localhost));
+        services.AddLogging();
         services.AddMongoFhirStore(CreateSettings());
 
         using ServiceProvider provider = services.BuildServiceProvider();

--- a/Tests/Spark.Store.MongoDB.Tests/Search/ChainedSearchErrorHandlingTests.cs
+++ b/Tests/Spark.Store.MongoDB.Tests/Search/ChainedSearchErrorHandlingTests.cs
@@ -8,6 +8,7 @@ using System;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Rest;
 using Hl7.Fhir.Specification;
+using Microsoft.Extensions.Logging.Abstractions;
 using MongoDB.Driver;
 using Moq;
 using Spark.Engine.Core;
@@ -163,7 +164,7 @@ public class ChainedSearchErrorHandlingTests
         // Wire up the real index/search object graph.
         IFhirModel fhirModel = new FhirModel();
         ILocalhost localhost = new Localhost(new Uri(BaseUri));
-        var indexStore = new MongoIndexStore(connectionString, new MongoIndexMapper());
+        var indexStore = new MongoIndexStore(connectionString, new MongoIndexMapper(), new NullLogger<MongoIndexStore>());
         var indexService = new IndexService(fhirModel, indexStore, new ElementIndexer(fhirModel),
             new ResourceResolver(fhirModel.SupportedResources, new PocoStructureDefinitionSummaryProvider()));
         var searcher = new MongoSearcher(

--- a/Tests/Spark.Store.MongoDB.Tests/Search/MongoIndexStoreIntegrationTests.cs
+++ b/Tests/Spark.Store.MongoDB.Tests/Search/MongoIndexStoreIntegrationTests.cs
@@ -7,6 +7,7 @@
 using MongoDB.Bson;
 using MongoDB.Driver;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Spark.Engine.Model;
 using Spark.Engine.Search.Types;
@@ -76,7 +77,9 @@ public class MongoIndexStoreIntegrationTests : IAsyncLifetime
 
         MongoIndexStore indexStore = new(
             connectionString,
-            new MongoIndexMapper());
+            new MongoIndexMapper(),
+            new NullLogger<MongoIndexStore>()
+        );
 
         return (indexStore, collection);
     }

--- a/Tests/Spark.Store.MongoDB.Tests/Search/MongoIndexStoreIntegrationTests.cs
+++ b/Tests/Spark.Store.MongoDB.Tests/Search/MongoIndexStoreIntegrationTests.cs
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2026, Incendi <info@incendi.no>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+using MongoDB.Bson;
+using MongoDB.Driver;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Spark.Engine.Model;
+using Spark.Engine.Search.Types;
+using Spark.Store.MongoDB.Search.Common;
+using Spark.Store.MongoDB.Search.Indexer;
+using System;
+using System.Threading.Tasks;
+using Testcontainers.MongoDb;
+using Xunit;
+using Task = System.Threading.Tasks.Task;
+
+namespace Spark.Store.MongoDB.Tests.Search;
+
+[Trait("Category", "Integration")]
+public class MongoIndexStoreIntegrationTests : IAsyncLifetime
+{
+    private MongoDbContainer _container;
+
+    public async ValueTask InitializeAsync() => _container = await StartMongoOrSkipAsync();
+
+    public ValueTask DisposeAsync() => _container.DisposeAsync();
+
+    [Fact]
+    public async Task SaveAsync_ThrowsDuplicateKeyWhenStaleVersionFollowsNewerVersion()
+    {
+        (MongoIndexStore indexStore, IMongoCollection<BsonDocument> collection) = await CreateIndexStoreAsync();
+        await indexStore.SaveAsync(CreateIndexValue(version: 2));
+
+        MongoCommandException exception = await Assert.ThrowsAsync<MongoCommandException>(
+            () => indexStore.SaveAsync(CreateIndexValue(version: 1)));
+
+        Assert.Equal(11000, exception.Code);
+
+        BsonDocument storedDocument = await collection
+            .Find(Builders<BsonDocument>.Filter.Eq(InternalField.ID, "Patient/patient-1"))
+            .SingleAsync(TestContext.Current.CancellationToken);
+        Assert.Equal(2, storedDocument[InternalField.VERSION].ToInt64());
+    }
+
+    [Fact]
+    public async Task SaveAsync_SameVersionIsAllowedToBeReIndexed()
+    {
+        (MongoIndexStore indexStore, IMongoCollection<BsonDocument> collection) = await CreateIndexStoreAsync();
+        await indexStore.SaveAsync(CreateIndexValue(version: 2));
+
+        // Re-index the same version, this is allowed.
+        await indexStore.SaveAsync(CreateIndexValue(version: 2));
+
+        BsonDocument storedDocument = await collection
+            .Find(Builders<BsonDocument>.Filter.Eq(InternalField.ID, "Patient/patient-1"))
+            .SingleAsync(TestContext.Current.CancellationToken);
+        Assert.Equal(2, storedDocument[InternalField.VERSION].ToInt64());
+    }
+
+    private async Task<(MongoIndexStore IndexStore, IMongoCollection<BsonDocument> Collection)> CreateIndexStoreAsync()
+    {
+        string connectionString = BuildConnectionString(_container.GetConnectionString());
+        IMongoDatabase database = MongoDatabaseFactory.GetMongoDatabase(connectionString);
+        IMongoCollection<BsonDocument> collection =
+            database.GetCollection<BsonDocument>(MongoCollections.SEARCH_INDEX_COLLECTION);
+
+        await collection.Indexes.CreateOneAsync(
+            new CreateIndexModel<BsonDocument>(
+                Builders<BsonDocument>.IndexKeys.Ascending(InternalField.ID),
+                new CreateIndexOptions { Unique = true, Sparse = true }),
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        MongoIndexStore indexStore = new(
+            connectionString,
+            new MongoIndexMapper());
+
+        return (indexStore, collection);
+    }
+
+    private static IndexValue CreateIndexValue(long version) => new(
+        "root",
+        new IndexValue(InternalField.ID, new StringValue("Patient/patient-1")),
+        new IndexValue(InternalField.VERSION, new NumberValue(version)));
+
+    private static async Task<MongoDbContainer> StartMongoOrSkipAsync()
+    {
+        MongoDbContainer container = null;
+        try
+        {
+            container = new MongoDbBuilder("mongo:8.2.7").Build();
+            await container.StartAsync(TestContext.Current.CancellationToken);
+            return container;
+        }
+        catch (Exception exception)
+        {
+            if (container != null)
+            {
+                await container.DisposeAsync();
+            }
+
+            Assert.Skip($"Docker/Testcontainers not available: {exception.Message}");
+            return null;
+        }
+    }
+
+    private static string BuildConnectionString(string rawConnectionString)
+    {
+        MongoUrlBuilder builder = new(rawConnectionString)
+        {
+            DatabaseName = $"sparktest-{Guid.NewGuid():N}"
+        };
+        if (!string.IsNullOrEmpty(builder.Username) && string.IsNullOrEmpty(builder.AuthenticationSource))
+        {
+            builder.AuthenticationSource = "admin";
+        }
+
+        return builder.ToMongoUrl().ToString();
+    }
+}

--- a/Tests/Spark.Store.MongoDB.Tests/Search/MongoSearcherMigrationTests.cs
+++ b/Tests/Spark.Store.MongoDB.Tests/Search/MongoSearcherMigrationTests.cs
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Spark.Engine.Core;
 using Spark.Engine.Store;
 using Spark.Engine.Store.Interfaces;
@@ -27,11 +28,12 @@ public class MongoSearcherMigrationTests
             .Setup(service => service.IsApplied(DatabaseMigrations.StructuredStringTokenIndex.Version))
             .Returns(() => currentVersion >= DatabaseMigrations.StructuredStringTokenIndex.Version);
         MongoSearcher searcher = new(
-            new MongoIndexStore("mongodb://localhost/spark", new MongoIndexMapper()),
+            new MongoIndexStore("mongodb://localhost/spark", new MongoIndexMapper(), new NullLogger<MongoIndexStore>()),
             new Localhost(new Uri("http://localhost/fhir")),
             new Mock<IFhirModel>().Object,
             referenceNormalizationService: null,
-            databaseMigrationService: migrationService.Object);
+            databaseMigrationService: migrationService.Object
+        );
 
         Assert.True(searcher.IncludePlainStringTokenQuery);
 
@@ -45,10 +47,11 @@ public class MongoSearcherMigrationTests
     {
 #pragma warning disable CS0618
         MongoSearcher searcher = new(
-            new MongoIndexStore("mongodb://localhost/spark", new MongoIndexMapper()),
+            new MongoIndexStore("mongodb://localhost/spark", new MongoIndexMapper(), new NullLogger<MongoIndexStore>()),
             new Localhost(new Uri("http://localhost/fhir")),
             new Mock<IFhirModel>().Object,
-            null);
+            null
+        );
 #pragma warning restore CS0618
 
         Assert.True(searcher.IncludePlainStringTokenQuery);

--- a/Tests/Spark.Store.MongoDB.Tests/Search/QuantitySearchIntegrationTests.cs
+++ b/Tests/Spark.Store.MongoDB.Tests/Search/QuantitySearchIntegrationTests.cs
@@ -7,6 +7,7 @@
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Rest;
 using Hl7.Fhir.Specification;
+using Microsoft.Extensions.Logging.Abstractions;
 using MongoDB.Driver;
 using Moq;
 using Spark.Engine.Core;
@@ -141,7 +142,7 @@ public class QuantitySearchIntegrationTests : IAsyncLifetime
 
         IFhirModel fhirModel = new FhirModel();
         ILocalhost localhost = new Localhost(new Uri(BaseUri));
-        MongoIndexStore indexStore = new(connectionString, new MongoIndexMapper());
+        MongoIndexStore indexStore = new(connectionString, new MongoIndexMapper(), new NullLogger<MongoIndexStore>());
         IndexService indexService = new(fhirModel, indexStore, new ElementIndexer(fhirModel),
             new ResourceResolver(fhirModel.SupportedResources, new PocoStructureDefinitionSummaryProvider()));
         MongoSearcher searcher = new(


### PR DESCRIPTION
Also, log and re-throw when a duplicate key exception is thrown.

Closes #1400 
